### PR TITLE
Integrates bonus lists into auction data

### DIFF
--- a/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/auction/Auction.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/auction/Auction.kt
@@ -45,6 +45,8 @@ data class AuctionItem(
     val itemId: Int,
     @OneToMany(cascade = [CascadeType.ALL], fetch = FetchType.EAGER)
     val modifiers: MutableList<AuctionItemModifier>? = mutableListOf(),
+    @Column(name = "bonus_lists")
+    val bonusLists: String = "",
     val context: Int?,
     val petBreedId: Int?,
     val petLevel: Int?,

--- a/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/auction/AuctionHousePrice.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/auction/AuctionHousePrice.kt
@@ -33,6 +33,9 @@ class AuctionHousePrice(
     @Id
     @Column(name = "modifier_key")
     var modifierKey: String = "",
+    @Id
+    @Column(name = "bonus_key")
+    var bonusKey: String = "",
     @Column(name = "price")
     var price: Long? = null,
     @Column(name = "quantity")

--- a/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/auction/AuctionHousePriceId.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/auction/AuctionHousePriceId.kt
@@ -10,4 +10,5 @@ data class AuctionHousePriceId(
     var itemId: Int = 0,
     var petSpeciesId: Int = 0,
     var modifierKey: String = "",
+    var bonusKey: String = "",
 ) : Serializable

--- a/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/auction/AuctionStatsId.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/auction/AuctionStatsId.kt
@@ -25,7 +25,9 @@ data class AuctionStatsId(
     val petSpeciesId: Int? = null,
     @Column(name = "modifier_key")
     val modifierKey: String = "",
+    @Column(name = "bonus_key")
+    val bonusKey: String = "",
 ) : Serializable {
     override fun toString(): String =
-        "${connectedRealm.id}-$gameBuildVersion-$itemId-$date-${petSpeciesId ?: ""}-$modifierKey"
+        "${connectedRealm.id}-$gameBuildVersion-$itemId-$date-${petSpeciesId ?: ""}-$modifierKey-$bonusKey"
 }

--- a/src/main/kotlin/net/jonasmf/auctionengine/dto/auction/AuctionItemDTO.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/dto/auction/AuctionItemDTO.kt
@@ -1,13 +1,12 @@
 package net.jonasmf.auctionengine.dto.auction
 
 import net.jonasmf.auctionengine.dbo.rds.auction.AuctionItem
+import net.jonasmf.auctionengine.utility.AuctionVariantKeyUtility
 
 data class AuctionItemDTO(
     val id: Int,
     val modifiers: List<ModifierDTO>? = null,
-    // Equipment specific fields
-    // @OneToMany
-    // val bonus_lists: List<Int>? = mutableListOf<Int>(),
+    val bonus_lists: List<Int>? = null,
     val context: Int? = null, // Raid, Dungeon, Delve, PvP, etc.
     // Pet specific fields
     val pet_breed_id: Int? = null,
@@ -20,6 +19,7 @@ data class AuctionItemDTO(
             id = null,
             itemId = id,
             modifiers = modifiers?.map { it.toDBO() }?.toMutableList(),
+            bonusLists = AuctionVariantKeyUtility.canonicalBonusKey(bonus_lists),
             context = context,
             petBreedId = pet_breed_id,
             petLevel = pet_level,

--- a/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionHousePriceRepository.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionHousePriceRepository.kt
@@ -19,6 +19,13 @@ interface AuctionHousePriceRepository : JpaRepository<AuctionHousePrice, Auction
         modifierKey: String,
     ): List<AuctionHousePrice>
 
+    fun findAllByConnectedRealmIdAndItemIdAndModifierKeyAndBonusKeyOrderByAuctionTimestampAsc(
+        connectedRealmId: Int,
+        itemId: Int,
+        modifierKey: String,
+        bonusKey: String,
+    ): List<AuctionHousePrice>
+
     fun findAllByAuctionTimestampBetweenOrderByAuctionTimestampAsc(
         from: LocalDateTime,
         to: LocalDateTime,

--- a/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionItemRepository.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionItemRepository.kt
@@ -27,6 +27,7 @@ interface AuctionItemRepository : JpaRepository<AuctionItem, Long> {
         AND ai.petQualityId = :petQualityId 
         AND ai.petSpeciesId = :petSpeciesId 
         AND ai.context = :context
+        AND ai.bonusLists = :bonusLists
     """,
     )
     fun findByCompositeKey(
@@ -36,6 +37,7 @@ interface AuctionItemRepository : JpaRepository<AuctionItem, Long> {
         @Param("petQualityId") petQualityId: Int?,
         @Param("petSpeciesId") petSpeciesId: Int?,
         @Param("context") context: Int?,
+        @Param("bonusLists") bonusLists: String,
     ): AuctionItem?
 
     @Query(
@@ -47,6 +49,7 @@ interface AuctionItemRepository : JpaRepository<AuctionItem, Long> {
         AND (ai.petQualityId = :petQualityId OR (ai.petQualityId IS NULL AND :petQualityId IS NULL))
         AND (ai.petSpeciesId = :petSpeciesId OR (ai.petSpeciesId IS NULL AND :petSpeciesId IS NULL))
         AND (ai.context = :context OR (ai.context IS NULL AND :context IS NULL))
+        AND ai.bonusLists = :bonusLists
     """,
     )
     fun findByCompositeKeyWithNullHandlingList(
@@ -56,5 +59,6 @@ interface AuctionItemRepository : JpaRepository<AuctionItem, Long> {
         @Param("petQualityId") petQualityId: Int?,
         @Param("petSpeciesId") petSpeciesId: Int?,
         @Param("context") context: Int?,
+        @Param("bonusLists") bonusLists: String,
     ): List<AuctionItem>
 }

--- a/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/HourlyPriceStatisticsRepository.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/HourlyPriceStatisticsRepository.kt
@@ -13,6 +13,7 @@ data class HourlyStatsUpsertRow(
     val date: LocalDate,
     val petSpeciesId: Int?,
     val modifierKey: String,
+    val bonusKey: String,
     val price: Long?,
     val quantity: Long?,
 )
@@ -34,7 +35,7 @@ class HourlyPriceStatisticsRepository(
         val priceColumn = "price%02d".format(hour)
         val quantityColumn = "quantity%02d".format(hour)
         val tableName = "hourly_auction_stats"
-        val numberOfColumns = 8
+        val numberOfColumns = 9
         var total = 0
         val valueTuple = List(numberOfColumns) { "?" }.joinToString(",", "(", ")")
 
@@ -49,6 +50,7 @@ class HourlyPriceStatisticsRepository(
                     date,
                     pet_species_id,
                     modifier_key,
+                    bonus_key,
                     $priceColumn,
                     $quantityColumn
                 ) VALUES $placeholders
@@ -65,6 +67,7 @@ class HourlyPriceStatisticsRepository(
                 params.add(Date.valueOf(row.date))
                 params.add(row.petSpeciesId ?: -1)
                 params.add(row.modifierKey)
+                params.add(row.bonusKey)
                 params.add(row.price)
                 params.add(row.quantity)
             }

--- a/src/main/kotlin/net/jonasmf/auctionengine/service/BlizzardAuctionService.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/service/BlizzardAuctionService.kt
@@ -531,9 +531,23 @@ class BlizzardAuctionService(
     }
 
     private fun createItemKey(item: net.jonasmf.auctionengine.dto.auction.AuctionItemDTO): String =
-        "${item.id}_${item.pet_breed_id ?: "null"}_${item.pet_level ?: "null"}_${item.pet_quality_id ?: "null"}_${item.pet_species_id ?: "null"}_${item.context ?: "null"}_${item.modifiers?.hashCode() ?: "null"}_${AuctionVariantKeyUtility.canonicalBonusKey(
-            item.bonus_lists,
-        )}"
+        buildString {
+            append(item.id)
+            append('_')
+            append(item.pet_breed_id ?: "null")
+            append('_')
+            append(item.pet_level ?: "null")
+            append('_')
+            append(item.pet_quality_id ?: "null")
+            append('_')
+            append(item.pet_species_id ?: "null")
+            append('_')
+            append(item.context ?: "null")
+            append('_')
+            append(item.modifiers?.hashCode() ?: "null")
+            append('_')
+            append(AuctionVariantKeyUtility.canonicalBonusKey(item.bonus_lists))
+        }
 
     private fun saveItemsInBatches(
         items: List<AuctionItemDBO>,

--- a/src/main/kotlin/net/jonasmf/auctionengine/service/BlizzardAuctionService.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/service/BlizzardAuctionService.kt
@@ -15,6 +15,7 @@ import net.jonasmf.auctionengine.integration.blizzard.DownloadedAuctionPayload
 import net.jonasmf.auctionengine.repository.rds.AuctionItemModifierRepository
 import net.jonasmf.auctionengine.repository.rds.AuctionItemRepository
 import net.jonasmf.auctionengine.repository.rds.AuctionRepository
+import net.jonasmf.auctionengine.utility.AuctionVariantKeyUtility
 import net.jonasmf.auctionengine.utility.JvmRuntimeDiagnostics
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -437,6 +438,7 @@ class BlizzardAuctionService(
                         auctionDTO.item.pet_quality_id,
                         auctionDTO.item.pet_species_id,
                         auctionDTO.item.context,
+                        AuctionVariantKeyUtility.canonicalBonusKey(auctionDTO.item.bonus_lists),
                     )
 
                 val existingItem =
@@ -444,7 +446,7 @@ class BlizzardAuctionService(
                         if (existingItems.size > 1) {
                             duplicateItemCount++
                             logger.debug(
-                                "Found ${existingItems.size} duplicate items for itemId=${auctionDTO.item.id}, petBreedId=${auctionDTO.item.pet_breed_id}, petLevel=${auctionDTO.item.pet_level}, petQualityId=${auctionDTO.item.pet_quality_id}, petSpeciesId=${auctionDTO.item.pet_species_id}, context=${auctionDTO.item.context}. Using first match.",
+                                "Found ${existingItems.size} duplicate items for itemId=${auctionDTO.item.id}, petBreedId=${auctionDTO.item.pet_breed_id}, petLevel=${auctionDTO.item.pet_level}, petQualityId=${auctionDTO.item.pet_quality_id}, petSpeciesId=${auctionDTO.item.pet_species_id}, context=${auctionDTO.item.context}, bonusLists=${auctionDTO.item.bonus_lists}. Using first match.",
                             )
                         }
                         existingItems.first()
@@ -529,7 +531,9 @@ class BlizzardAuctionService(
     }
 
     private fun createItemKey(item: net.jonasmf.auctionengine.dto.auction.AuctionItemDTO): String =
-        "${item.id}_${item.pet_breed_id ?: "null"}_${item.pet_level ?: "null"}_${item.pet_quality_id ?: "null"}_${item.pet_species_id ?: "null"}_${item.context ?: "null"}_${item.modifiers?.hashCode() ?: "null"}"
+        "${item.id}_${item.pet_breed_id ?: "null"}_${item.pet_level ?: "null"}_${item.pet_quality_id ?: "null"}_${item.pet_species_id ?: "null"}_${item.context ?: "null"}_${item.modifiers?.hashCode() ?: "null"}_${AuctionVariantKeyUtility.canonicalBonusKey(
+            item.bonus_lists,
+        )}"
 
     private fun saveItemsInBatches(
         items: List<AuctionItemDBO>,

--- a/src/main/kotlin/net/jonasmf/auctionengine/service/HourlyPriceStatisticsService.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/service/HourlyPriceStatisticsService.kt
@@ -6,9 +6,9 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import net.jonasmf.auctionengine.constant.GameBuildVersion
 import net.jonasmf.auctionengine.dbo.rds.realm.ConnectedRealm
 import net.jonasmf.auctionengine.dto.auction.AuctionDTO
-import net.jonasmf.auctionengine.dto.auction.ModifierDTO
 import net.jonasmf.auctionengine.repository.rds.HourlyPriceStatisticsRepository
 import net.jonasmf.auctionengine.repository.rds.HourlyStatsUpsertRow
+import net.jonasmf.auctionengine.utility.AuctionVariantKeyUtility
 import net.jonasmf.auctionengine.utility.JvmRuntimeDiagnostics
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -174,10 +174,4 @@ class HourlyPriceStatisticsService(
             }
         }
     }
-
-    private fun canonicalModifierKey(modifiers: List<ModifierDTO>?): String =
-        modifiers
-            .orEmpty()
-            .sortedBy { it.value }
-            .joinToString(",") { it.value.toString() }
 }

--- a/src/main/kotlin/net/jonasmf/auctionengine/service/HourlyPriceStatisticsService.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/service/HourlyPriceStatisticsService.kt
@@ -78,12 +78,13 @@ class HourlyPriceStatisticsService(
         iterateAuctions { auction ->
             val itemId = auction.item.id
             val petSpeciesId = auction.item.pet_species_id
-            val modifierKey = canonicalModifierKey(auction.item.modifiers)
+            val modifierKey = AuctionVariantKeyUtility.canonicalModifierKey(auction.item.modifiers)
+            val bonusKey = AuctionVariantKeyUtility.canonicalBonusKey(auction.item.bonus_lists)
             val key = "${connectedRealm.id}|${
                 GameBuildVersion.RETAIL.ordinal
             }|$itemId|$date|${
                 petSpeciesId ?: ""
-            }|$modifierKey"
+            }|$modifierKey|$bonusKey"
             val price = auction.buyout ?: auction.unit_price ?: 0L
             val quantity = auction.quantity.takeIf { it > 0 } ?: 1L
 
@@ -97,6 +98,7 @@ class HourlyPriceStatisticsService(
                         date = date,
                         petSpeciesId = petSpeciesId,
                         modifierKey = modifierKey,
+                        bonusKey = bonusKey,
                         price = price,
                         quantity = quantity,
                     )

--- a/src/main/kotlin/net/jonasmf/auctionengine/utility/AuctionProcessorUtility.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/utility/AuctionProcessorUtility.kt
@@ -79,6 +79,7 @@ class AuctionProcessorUtility(
                 itemId = auctionDTO.item.id,
                 date = LocalDate.now(),
                 petSpeciesId = auctionDTO.item.pet_species_id,
+                bonusKey = AuctionVariantKeyUtility.canonicalBonusKey(auctionDTO.item.bonus_lists),
             )
         val hourlyStat =
             HourlyAuctionStats(
@@ -152,6 +153,7 @@ class AuctionProcessorUtility(
                 itemId = auctionDTO.item.id,
                 date = LocalDate.now(),
                 petSpeciesId = auctionDTO.item.pet_species_id,
+                bonusKey = AuctionVariantKeyUtility.canonicalBonusKey(auctionDTO.item.bonus_lists),
             )
         val dailyStat =
             DailyAuctionStats(

--- a/src/main/kotlin/net/jonasmf/auctionengine/utility/AuctionVariantKeyUtility.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/utility/AuctionVariantKeyUtility.kt
@@ -1,0 +1,17 @@
+package net.jonasmf.auctionengine.utility
+
+import net.jonasmf.auctionengine.dto.auction.ModifierDTO
+
+object AuctionVariantKeyUtility {
+    fun canonicalBonusKey(bonusLists: List<Int>?): String =
+        bonusLists
+            .orEmpty()
+            .sorted()
+            .joinToString(",")
+
+    fun canonicalModifierKey(modifiers: List<ModifierDTO>?): String =
+        modifiers
+            .orEmpty()
+            .sortedBy { it.value }
+            .joinToString(",") { it.value.toString() }
+}

--- a/src/main/resources/db/migration/V2__add_bonus_key_to_auction_variants.sql
+++ b/src/main/resources/db/migration/V2__add_bonus_key_to_auction_variants.sql
@@ -1,0 +1,317 @@
+ALTER TABLE auction_item
+    ADD COLUMN IF NOT EXISTS bonus_lists VARCHAR(255) NOT NULL DEFAULT '';
+
+UPDATE auction_item
+SET bonus_lists = ''
+WHERE bonus_lists IS NULL;
+
+ALTER TABLE hourly_auction_stats
+    ADD COLUMN IF NOT EXISTS bonus_key VARCHAR(255) NOT NULL DEFAULT '';
+
+UPDATE hourly_auction_stats
+SET bonus_key = ''
+WHERE bonus_key IS NULL;
+
+ALTER TABLE daily_auction_stats
+    ADD COLUMN IF NOT EXISTS bonus_key VARCHAR(255) NOT NULL DEFAULT '';
+
+UPDATE daily_auction_stats
+SET bonus_key = ''
+WHERE bonus_key IS NULL;
+
+ALTER TABLE hourly_auction_stats
+    DROP PRIMARY KEY,
+    ADD PRIMARY KEY (connected_realm_id, ah_type_id, item_id, date, pet_species_id, modifier_key, bonus_key);
+
+ALTER TABLE daily_auction_stats
+    DROP PRIMARY KEY,
+    ADD PRIMARY KEY (connected_realm_id, ah_type_id, item_id, date, pet_species_id, modifier_key, bonus_key);
+
+CREATE OR REPLACE VIEW v_auction_house_prices AS
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(0, 0, 0)) AS auction_timestamp,
+       price00 AS price,
+       quantity00 AS quantity
+FROM hourly_auction_stats
+WHERE price00 IS NOT NULL OR quantity00 IS NOT NULL
+UNION ALL
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(1, 0, 0)) AS auction_timestamp,
+       price01 AS price,
+       quantity01 AS quantity
+FROM hourly_auction_stats
+WHERE price01 IS NOT NULL OR quantity01 IS NOT NULL
+UNION ALL
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(2, 0, 0)) AS auction_timestamp,
+       price02 AS price,
+       quantity02 AS quantity
+FROM hourly_auction_stats
+WHERE price02 IS NOT NULL OR quantity02 IS NOT NULL
+UNION ALL
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(3, 0, 0)) AS auction_timestamp,
+       price03 AS price,
+       quantity03 AS quantity
+FROM hourly_auction_stats
+WHERE price03 IS NOT NULL OR quantity03 IS NOT NULL
+UNION ALL
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(4, 0, 0)) AS auction_timestamp,
+       price04 AS price,
+       quantity04 AS quantity
+FROM hourly_auction_stats
+WHERE price04 IS NOT NULL OR quantity04 IS NOT NULL
+UNION ALL
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(5, 0, 0)) AS auction_timestamp,
+       price05 AS price,
+       quantity05 AS quantity
+FROM hourly_auction_stats
+WHERE price05 IS NOT NULL OR quantity05 IS NOT NULL
+UNION ALL
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(6, 0, 0)) AS auction_timestamp,
+       price06 AS price,
+       quantity06 AS quantity
+FROM hourly_auction_stats
+WHERE price06 IS NOT NULL OR quantity06 IS NOT NULL
+UNION ALL
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(7, 0, 0)) AS auction_timestamp,
+       price07 AS price,
+       quantity07 AS quantity
+FROM hourly_auction_stats
+WHERE price07 IS NOT NULL OR quantity07 IS NOT NULL
+UNION ALL
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(8, 0, 0)) AS auction_timestamp,
+       price08 AS price,
+       quantity08 AS quantity
+FROM hourly_auction_stats
+WHERE price08 IS NOT NULL OR quantity08 IS NOT NULL
+UNION ALL
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(9, 0, 0)) AS auction_timestamp,
+       price09 AS price,
+       quantity09 AS quantity
+FROM hourly_auction_stats
+WHERE price09 IS NOT NULL OR quantity09 IS NOT NULL
+UNION ALL
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(10, 0, 0)) AS auction_timestamp,
+       price10 AS price,
+       quantity10 AS quantity
+FROM hourly_auction_stats
+WHERE price10 IS NOT NULL OR quantity10 IS NOT NULL
+UNION ALL
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(11, 0, 0)) AS auction_timestamp,
+       price11 AS price,
+       quantity11 AS quantity
+FROM hourly_auction_stats
+WHERE price11 IS NOT NULL OR quantity11 IS NOT NULL
+UNION ALL
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(12, 0, 0)) AS auction_timestamp,
+       price12 AS price,
+       quantity12 AS quantity
+FROM hourly_auction_stats
+WHERE price12 IS NOT NULL OR quantity12 IS NOT NULL
+UNION ALL
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(13, 0, 0)) AS auction_timestamp,
+       price13 AS price,
+       quantity13 AS quantity
+FROM hourly_auction_stats
+WHERE price13 IS NOT NULL OR quantity13 IS NOT NULL
+UNION ALL
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(14, 0, 0)) AS auction_timestamp,
+       price14 AS price,
+       quantity14 AS quantity
+FROM hourly_auction_stats
+WHERE price14 IS NOT NULL OR quantity14 IS NOT NULL
+UNION ALL
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(15, 0, 0)) AS auction_timestamp,
+       price15 AS price,
+       quantity15 AS quantity
+FROM hourly_auction_stats
+WHERE price15 IS NOT NULL OR quantity15 IS NOT NULL
+UNION ALL
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(16, 0, 0)) AS auction_timestamp,
+       price16 AS price,
+       quantity16 AS quantity
+FROM hourly_auction_stats
+WHERE price16 IS NOT NULL OR quantity16 IS NOT NULL
+UNION ALL
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(17, 0, 0)) AS auction_timestamp,
+       price17 AS price,
+       quantity17 AS quantity
+FROM hourly_auction_stats
+WHERE price17 IS NOT NULL OR quantity17 IS NOT NULL
+UNION ALL
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(18, 0, 0)) AS auction_timestamp,
+       price18 AS price,
+       quantity18 AS quantity
+FROM hourly_auction_stats
+WHERE price18 IS NOT NULL OR quantity18 IS NOT NULL
+UNION ALL
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(19, 0, 0)) AS auction_timestamp,
+       price19 AS price,
+       quantity19 AS quantity
+FROM hourly_auction_stats
+WHERE price19 IS NOT NULL OR quantity19 IS NOT NULL
+UNION ALL
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(20, 0, 0)) AS auction_timestamp,
+       price20 AS price,
+       quantity20 AS quantity
+FROM hourly_auction_stats
+WHERE price20 IS NOT NULL OR quantity20 IS NOT NULL
+UNION ALL
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(21, 0, 0)) AS auction_timestamp,
+       price21 AS price,
+       quantity21 AS quantity
+FROM hourly_auction_stats
+WHERE price21 IS NOT NULL OR quantity21 IS NOT NULL
+UNION ALL
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(22, 0, 0)) AS auction_timestamp,
+       price22 AS price,
+       quantity22 AS quantity
+FROM hourly_auction_stats
+WHERE price22 IS NOT NULL OR quantity22 IS NOT NULL
+UNION ALL
+SELECT connected_realm_id,
+       ah_type_id,
+       item_id,
+       pet_species_id,
+       modifier_key,
+       bonus_key,
+       TIMESTAMP(date, MAKETIME(23, 0, 0)) AS auction_timestamp,
+       price23 AS price,
+       quantity23 AS quantity
+FROM hourly_auction_stats
+WHERE price23 IS NOT NULL OR quantity23 IS NOT NULL;

--- a/src/test/kotlin/net/jonasmf/auctionengine/dto/auction/AuctionDTODeserializationTest.kt
+++ b/src/test/kotlin/net/jonasmf/auctionengine/dto/auction/AuctionDTODeserializationTest.kt
@@ -1,0 +1,30 @@
+package net.jonasmf.auctionengine.dto.auction
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import net.jonasmf.auctionengine.testsupport.loadFixture
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class AuctionDTODeserializationTest {
+    private val mapper = jacksonObjectMapper()
+
+    @Test
+    fun `should deserialize auction payloads with bonus lists`() {
+        val payload = loadFixture(this, "/blizzard/auction/auction-data-response.json")
+        val response: AuctionData = mapper.readValue(payload)
+
+        assertEquals(listOf(12499, 12252, 12251), response.auctions[1].item.bonus_lists)
+    }
+
+    @Test
+    fun `should canonicalize bonus lists when converting to dbo`() {
+        val dbo =
+            AuctionItemDTO(
+                id = 19019,
+                bonus_lists = listOf(12499, 12252, 12251),
+            ).toDBO()
+
+        assertEquals("12251,12252,12499", dbo.bonusLists)
+    }
+}

--- a/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionHousePriceRepositoryTest.kt
+++ b/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionHousePriceRepositoryTest.kt
@@ -52,6 +52,20 @@ class AuctionHousePriceRepositoryTest : IntegrationTestBase() {
             )
 
         assertEquals(1, viewCount)
+
+        val bonusKeyColumnCount =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM information_schema.columns
+                WHERE table_schema = DATABASE()
+                  AND table_name = 'v_auction_house_prices'
+                  AND column_name = 'bonus_key'
+                """.trimIndent(),
+                Int::class.java,
+            )
+
+        assertEquals(1, bonusKeyColumnCount)
     }
 
     @Test
@@ -69,6 +83,7 @@ class AuctionHousePriceRepositoryTest : IntegrationTestBase() {
                         date = date,
                         petSpeciesId = null,
                         modifierKey = "",
+                        bonusKey = "",
                         price = 123_456L,
                         quantity = 10L,
                     ),
@@ -85,6 +100,7 @@ class AuctionHousePriceRepositoryTest : IntegrationTestBase() {
                         date = date,
                         petSpeciesId = null,
                         modifierKey = "",
+                        bonusKey = "",
                         price = 120_000L,
                         quantity = 15L,
                     ),
@@ -102,6 +118,7 @@ class AuctionHousePriceRepositoryTest : IntegrationTestBase() {
         assertEquals(10L, first.quantity)
         assertEquals(-1, first.petSpeciesId)
         assertEquals("", first.modifierKey)
+        assertEquals("", first.bonusKey)
 
         val second = prices[1]
         assertEquals(LocalDateTime.of(2026, 4, 6, 7, 0), second.auctionTimestamp)
@@ -124,6 +141,7 @@ class AuctionHousePriceRepositoryTest : IntegrationTestBase() {
                         date = date,
                         petSpeciesId = 42,
                         modifierKey = "",
+                        bonusKey = "",
                         price = 99L,
                         quantity = 2L,
                     ),
@@ -173,6 +191,56 @@ class AuctionHousePriceRepositoryTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `should keep different bonus lists as separate hourly variants`() {
+        val connectedRealm = seedConnectedRealm(3584)
+        val lastModified = ZonedDateTime.of(2026, 4, 8, 11, 0, 0, 0, ZonedDateTime.now().zone)
+
+        hourlyPriceStatisticsService.processHourlyPriceStatistics(
+            connectedRealm = connectedRealm,
+            auctions =
+                listOf(
+                    auction(
+                        11,
+                        19031,
+                        500L,
+                        2L,
+                        modifiers = listOf(ModifierDTO("9", 100)),
+                        bonusLists = listOf(12251, 12252),
+                    ),
+                    auction(
+                        12,
+                        19031,
+                        450L,
+                        3L,
+                        modifiers = listOf(ModifierDTO("9", 100)),
+                        bonusLists = listOf(12251, 12253),
+                    ),
+                ),
+            lastModified = lastModified,
+        )
+
+        val first =
+            repository.findAllByConnectedRealmIdAndItemIdAndModifierKeyAndBonusKeyOrderByAuctionTimestampAsc(
+                3584,
+                19031,
+                "100",
+                "12251,12252",
+            )
+        val second =
+            repository.findAllByConnectedRealmIdAndItemIdAndModifierKeyAndBonusKeyOrderByAuctionTimestampAsc(
+                3584,
+                19031,
+                "100",
+                "12251,12253",
+            )
+
+        assertEquals(1, first.size)
+        assertEquals(1, second.size)
+        assertEquals(500L, first.single().price)
+        assertEquals(450L, second.single().price)
+    }
+
+    @Test
     fun `should canonicalize modifier order into one hourly variant`() {
         val connectedRealm = seedConnectedRealm(4084)
         val lastModified = ZonedDateTime.of(2026, 4, 9, 14, 0, 0, 0, ZonedDateTime.now().zone)
@@ -198,6 +266,36 @@ class AuctionHousePriceRepositoryTest : IntegrationTestBase() {
         assertEquals(LocalDateTime.of(2026, 4, 9, 14, 0), prices.single().auctionTimestamp)
         assertEquals(650L, prices.single().price)
         assertEquals(9L, prices.single().quantity)
+    }
+
+    @Test
+    fun `should canonicalize bonus list order into one hourly variant`() {
+        val connectedRealm = seedConnectedRealm(4584)
+        val lastModified = ZonedDateTime.of(2026, 4, 9, 16, 0, 0, 0, ZonedDateTime.now().zone)
+
+        hourlyPriceStatisticsService.processHourlyPriceStatistics(
+            connectedRealm = connectedRealm,
+            auctions =
+                listOf(
+                    auction(13, 19032, 700L, 4L, bonusLists = listOf(12499, 12252, 12251)),
+                    auction(14, 19032, 650L, 5L, bonusLists = listOf(12251, 12499, 12252)),
+                ),
+            lastModified = lastModified,
+        )
+
+        val prices =
+            repository.findAllByConnectedRealmIdAndItemIdAndModifierKeyAndBonusKeyOrderByAuctionTimestampAsc(
+                4584,
+                19032,
+                "",
+                "12251,12252,12499",
+            )
+
+        assertEquals(1, prices.size)
+        assertEquals(LocalDateTime.of(2026, 4, 9, 16, 0), prices.single().auctionTimestamp)
+        assertEquals(650L, prices.single().price)
+        assertEquals(9L, prices.single().quantity)
+        assertEquals("12251,12252,12499", prices.single().bonusKey)
     }
 
     @Test
@@ -265,12 +363,14 @@ class AuctionHousePriceRepositoryTest : IntegrationTestBase() {
         price: Long,
         quantity: Long,
         modifiers: List<ModifierDTO>? = null,
+        bonusLists: List<Int>? = null,
     ) = AuctionDTO(
         id = id,
         item =
             AuctionItemDTO(
                 id = itemId,
                 modifiers = modifiers,
+                bonus_lists = bonusLists,
             ),
         quantity = quantity,
         unit_price = null,

--- a/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionItemRepositoryTest.kt
+++ b/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionItemRepositoryTest.kt
@@ -1,0 +1,67 @@
+package net.jonasmf.auctionengine.repository.rds
+
+import net.jonasmf.auctionengine.config.IntegrationTestBase
+import net.jonasmf.auctionengine.dbo.rds.auction.AuctionItem
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class AuctionItemRepositoryTest : IntegrationTestBase() {
+    @Autowired
+    lateinit var repository: AuctionItemRepository
+
+    @Test
+    fun `should treat different bonus lists as different item variants`() {
+        repository.save(
+            AuctionItem(
+                itemId = 19019,
+                bonusLists = "12251,12252,12499",
+                context = 52,
+                petBreedId = null,
+                petLevel = null,
+                petQualityId = null,
+                petSpeciesId = null,
+            ),
+        )
+        repository.save(
+            AuctionItem(
+                itemId = 19019,
+                bonusLists = "12251,12253,12499",
+                context = 52,
+                petBreedId = null,
+                petLevel = null,
+                petQualityId = null,
+                petSpeciesId = null,
+            ),
+        )
+
+        val first =
+            repository.findByCompositeKeyWithNullHandlingList(
+                itemId = 19019,
+                petBreedId = null,
+                petLevel = null,
+                petQualityId = null,
+                petSpeciesId = null,
+                context = 52,
+                bonusLists = "12251,12252,12499",
+            )
+        val second =
+            repository.findByCompositeKeyWithNullHandlingList(
+                itemId = 19019,
+                petBreedId = null,
+                petLevel = null,
+                petQualityId = null,
+                petSpeciesId = null,
+                context = 52,
+                bonusLists = "12251,12253,12499",
+            )
+
+        assertEquals(1, first.size)
+        assertEquals(1, second.size)
+        assertNotNull(first.single().id)
+        assertNotNull(second.single().id)
+        assertEquals("12251,12252,12499", first.single().bonusLists)
+        assertEquals("12251,12253,12499", second.single().bonusLists)
+    }
+}

--- a/src/test/kotlin/net/jonasmf/auctionengine/utility/AuctionProcessorUtilityTest.kt
+++ b/src/test/kotlin/net/jonasmf/auctionengine/utility/AuctionProcessorUtilityTest.kt
@@ -47,6 +47,7 @@ class AuctionProcessorUtilityTest {
                 item =
                     AuctionItemDTO(
                         id = 100,
+                        bonus_lists = listOf(20, 10),
                         modifiers = null,
                         context = null,
                         pet_breed_id = null,
@@ -64,8 +65,22 @@ class AuctionProcessorUtilityTest {
 
         assertEquals(1, hourlyRepoCapture.calls.size)
         assertEquals(1, hourlyRepoCapture.calls.single().size)
+        assertEquals(
+            "10,20",
+            hourlyRepoCapture.calls
+                .single()
+                .single()
+                .id.bonusKey,
+        )
         assertEquals(1, dailyRepoCapture.calls.size)
         assertEquals(1, dailyRepoCapture.calls.single().size)
+        assertEquals(
+            "10,20",
+            dailyRepoCapture.calls
+                .single()
+                .single()
+                .id.bonusKey,
+        )
     }
 
     @Test

--- a/src/test/resources/blizzard/auction/auction-data-response.json
+++ b/src/test/resources/blizzard/auction/auction-data-response.json
@@ -22,6 +22,11 @@
       "item": {
         "id": 211297,
         "context": 52,
+        "bonus_lists": [
+          12499,
+          12252,
+          12251
+        ],
         "modifiers": [
           {
             "type": "PLAYER_LEVEL",

--- a/tools/README.md
+++ b/tools/README.md
@@ -12,6 +12,18 @@ Downloads the provided WoW auction JSON archives, stores the original `.json.gz`
 By default, outputs are written under `target/auction-json-map/`, which is already ignored by Git.
 By default, every element in each JSON array is inspected so the structure map is as complete as possible.
 Primitive fields with `20` or fewer unique values are flagged as enum candidates.
+Authenticated endpoints are supported via `--bearer-token`.
+
+## `analyze-auction-field.mjs`
+
+Downloads one or more WoW auction payloads, extracts a field from each auction entry, and writes value-distribution summaries. It is designed for fields such as `item.bonus_lists` where you want both per-value counts and per-array combination counts.
+
+Outputs are written under `target/auction-field-analysis/` by default:
+
+- `field-analysis.json`: structured per-source summary
+- `field-analysis.txt`: readable per-source summary
+- `summary.json`: aggregate results across all URLs
+- `summary.txt`: readable aggregate summary
 
 ## Usage
 
@@ -25,6 +37,7 @@ Custom URLs, output folder, a capped array sample size, and a custom enum thresh
 node .\tools\map-auction-json.mjs `
   --url "https://wah-data-eu.s3.eu-west-1.amazonaws.com/engine/auctions/europe/commodity/1773733732000.json.gz" `
   --url "https://wah-data-eu.s3.eu-west-1.amazonaws.com/engine/auctions/europe/1403/1773733732000.json.gz" `
+  --bearer-token "<token>" `
   --out-dir .\target\auction-json-map `
   --sample-size 250 `
   --enum-threshold 12
@@ -42,5 +55,20 @@ node .\tools\map-auction-json.mjs --sample-size all
 node --test .\tools\map-auction-json.test.mjs
 ```
 
+Field analysis for `item.bonus_lists` on authenticated Blizzard API endpoints:
+
+```powershell
+node .\tools\analyze-auction-field.mjs `
+  --url "https://eu.api.blizzard.com/data/wow/connected-realm/1597/auctions?namespace=dynamic-eu&locale=en_US" `
+  --url "https://eu.api.blizzard.com/data/wow/connected-realm/1598/auctions?namespace=dynamic-eu&locale=en_US" `
+  --bearer-token "<token>" `
+  --field-path "item.bonus_lists"
+```
+
+Tests:
+
+```powershell
+node --test .\tools\analyze-auction-field.test.mjs
+```
 
 

--- a/tools/analyze-auction-field.mjs
+++ b/tools/analyze-auction-field.mjs
@@ -1,0 +1,431 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { downloadBuffer, decompressIfNeeded } from './map-auction-json.mjs';
+
+export const DEFAULT_OUT_DIR = path.resolve(process.cwd(), 'target', 'auction-field-analysis');
+export const DEFAULT_FIELD_PATH = 'item.bonus_lists';
+export const DEFAULT_TOP_N = 50;
+
+export function parseCliArgs(argv) {
+  const options = {
+    bearerToken: undefined,
+    fieldPath: DEFAULT_FIELD_PATH,
+    outDir: DEFAULT_OUT_DIR,
+    topN: DEFAULT_TOP_N,
+    urls: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+
+    if (argument === '--url') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('Missing value for --url');
+      }
+      options.urls.push(value);
+      index += 1;
+      continue;
+    }
+
+    if (argument === '--bearer-token') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('Missing value for --bearer-token');
+      }
+      options.bearerToken = value;
+      index += 1;
+      continue;
+    }
+
+    if (argument === '--field-path') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('Missing value for --field-path');
+      }
+      options.fieldPath = value;
+      index += 1;
+      continue;
+    }
+
+    if (argument === '--out-dir') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('Missing value for --out-dir');
+      }
+      options.outDir = path.resolve(value);
+      index += 1;
+      continue;
+    }
+
+    if (argument === '--top') {
+      const rawValue = argv[index + 1];
+      const value = Number.parseInt(rawValue, 10);
+      if (!Number.isInteger(value) || value < 1) {
+        throw new Error('--top must be a positive integer');
+      }
+      options.topN = value;
+      index += 1;
+      continue;
+    }
+
+    if (argument === '--help' || argument === '-h') {
+      options.help = true;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${argument}`);
+  }
+
+  if (options.urls.length === 0) {
+    throw new Error('At least one --url is required');
+  }
+
+  return options;
+}
+
+function printHelp() {
+  console.log(`Analyze a field across WoW auction API payloads.
+
+Usage:
+  node tools/analyze-auction-field.mjs [options]
+
+Options:
+  --url <url>              Add a URL to inspect. Can be used multiple times.
+  --bearer-token <token>   Send an Authorization: Bearer header with each request.
+  --field-path <path>      Dot path relative to each auction object. Default: ${DEFAULT_FIELD_PATH}
+  --out-dir <path>         Output directory. Default: ${DEFAULT_OUT_DIR}
+  --top <count>            Number of top values/combinations to emit. Default: ${DEFAULT_TOP_N}
+  --help, -h               Show this help message.
+`);
+}
+
+function safeLabelFromUrl(urlText) {
+  const url = new URL(urlText);
+  const segments = url.pathname.split('/').filter(Boolean);
+  return segments.join('-').replace(/[^a-zA-Z0-9._-]+/g, '_');
+}
+
+export function getValueAtPath(source, fieldPath) {
+  const segments = fieldPath.split('.').filter(Boolean);
+  let current = source;
+
+  for (const segment of segments) {
+    if (current === null || current === undefined || typeof current !== 'object' || !(segment in current)) {
+      return undefined;
+    }
+    current = current[segment];
+  }
+
+  return current;
+}
+
+function createCounter() {
+  return new Map();
+}
+
+function incrementCounter(counter, key, amount = 1) {
+  counter.set(key, (counter.get(key) ?? 0) + amount);
+}
+
+function toSortedRows(counter, topN, mapper) {
+  return [...counter.entries()]
+    .sort((left, right) => {
+      if (right[1] !== left[1]) {
+        return right[1] - left[1];
+      }
+      return String(left[0]).localeCompare(String(right[0]));
+    })
+    .slice(0, topN)
+    .map(([key, count]) => mapper(key, count));
+}
+
+function toSortedNumericRows(counter, mapper) {
+  return [...counter.entries()]
+    .sort((left, right) => Number(left[0]) - Number(right[0]))
+    .map(([key, count]) => mapper(key, count));
+}
+
+export function analyzeAuctionField(data, fieldPath, options = {}) {
+  const topN = options.topN ?? DEFAULT_TOP_N;
+  const auctions = Array.isArray(data.auctions) ? data.auctions : [];
+
+  const valueCounter = createCounter();
+  const combinationCounter = createCounter();
+  const arrayLengthCounter = createCounter();
+
+  let auctionsWithField = 0;
+  let auctionsWithoutField = 0;
+  let nullFieldCount = 0;
+  let scalarFieldCount = 0;
+  let arrayFieldCount = 0;
+  let emptyArrayCount = 0;
+  let totalExtractedValues = 0;
+
+  for (const auction of auctions) {
+    const rawValue = getValueAtPath(auction, fieldPath);
+
+    if (rawValue === undefined) {
+      auctionsWithoutField += 1;
+      continue;
+    }
+
+    auctionsWithField += 1;
+
+    if (rawValue === null) {
+      nullFieldCount += 1;
+      continue;
+    }
+
+    if (Array.isArray(rawValue)) {
+      arrayFieldCount += 1;
+      incrementCounter(arrayLengthCounter, rawValue.length);
+
+      if (rawValue.length === 0) {
+        emptyArrayCount += 1;
+        continue;
+      }
+
+      const normalizedValues = rawValue.map((value) => {
+        incrementCounter(valueCounter, JSON.stringify(value));
+        totalExtractedValues += 1;
+        return value;
+      });
+
+      const comboKey = JSON.stringify([...normalizedValues].sort((left, right) => String(left).localeCompare(String(right))));
+      incrementCounter(combinationCounter, comboKey);
+      continue;
+    }
+
+    scalarFieldCount += 1;
+    totalExtractedValues += 1;
+    incrementCounter(valueCounter, JSON.stringify(rawValue));
+    incrementCounter(combinationCounter, JSON.stringify([rawValue]));
+  }
+
+  return {
+    fieldPath,
+    auctionsAnalyzed: auctions.length,
+    auctionsWithField,
+    auctionsWithoutField,
+    nullFieldCount,
+    scalarFieldCount,
+    arrayFieldCount,
+    emptyArrayCount,
+    totalExtractedValues,
+    distinctValueCount: valueCounter.size,
+    distinctCombinationCount: combinationCounter.size,
+    valueCounts: toSortedRows(valueCounter, Number.POSITIVE_INFINITY, (key, count) => ({
+      value: JSON.parse(key),
+      count,
+    })),
+    combinationCounts: toSortedRows(combinationCounter, Number.POSITIVE_INFINITY, (key, count) => ({
+      values: JSON.parse(key),
+      count,
+    })),
+    topValues: toSortedRows(valueCounter, topN, (key, count) => ({
+      value: JSON.parse(key),
+      count,
+    })),
+    topCombinations: toSortedRows(combinationCounter, topN, (key, count) => ({
+      values: JSON.parse(key),
+      count,
+    })),
+    arrayLengthDistribution: toSortedNumericRows(arrayLengthCounter, (key, count) => ({
+      length: Number(key),
+      count,
+    })),
+  };
+}
+
+export function mergeAnalyses(analyses, options = {}) {
+  const topN = options.topN ?? DEFAULT_TOP_N;
+  if (analyses.length === 0) {
+    return null;
+  }
+
+  const mergedValueCounter = createCounter();
+  const mergedCombinationCounter = createCounter();
+  const mergedLengthCounter = createCounter();
+
+  const merged = {
+    fieldPath: analyses[0].fieldPath,
+    sources: analyses.length,
+    auctionsAnalyzed: 0,
+    auctionsWithField: 0,
+    auctionsWithoutField: 0,
+    nullFieldCount: 0,
+    scalarFieldCount: 0,
+    arrayFieldCount: 0,
+    emptyArrayCount: 0,
+    totalExtractedValues: 0,
+  };
+
+  for (const analysis of analyses) {
+    merged.auctionsAnalyzed += analysis.auctionsAnalyzed;
+    merged.auctionsWithField += analysis.auctionsWithField;
+    merged.auctionsWithoutField += analysis.auctionsWithoutField;
+    merged.nullFieldCount += analysis.nullFieldCount;
+    merged.scalarFieldCount += analysis.scalarFieldCount;
+    merged.arrayFieldCount += analysis.arrayFieldCount;
+    merged.emptyArrayCount += analysis.emptyArrayCount;
+    merged.totalExtractedValues += analysis.totalExtractedValues;
+
+    for (const row of analysis.valueCounts ?? analysis.topValues) {
+      incrementCounter(mergedValueCounter, JSON.stringify(row.value), row.count);
+    }
+    for (const row of analysis.combinationCounts ?? analysis.topCombinations) {
+      incrementCounter(mergedCombinationCounter, JSON.stringify(row.values), row.count);
+    }
+    for (const row of analysis.arrayLengthDistribution) {
+      incrementCounter(mergedLengthCounter, row.length, row.count);
+    }
+  }
+
+  return {
+    ...merged,
+    distinctValueCount: mergedValueCounter.size,
+    distinctCombinationCount: mergedCombinationCounter.size,
+    valueCounts: toSortedRows(mergedValueCounter, Number.POSITIVE_INFINITY, (key, count) => ({
+      value: JSON.parse(key),
+      count,
+    })),
+    combinationCounts: toSortedRows(mergedCombinationCounter, Number.POSITIVE_INFINITY, (key, count) => ({
+      values: JSON.parse(key),
+      count,
+    })),
+    topValues: toSortedRows(mergedValueCounter, topN, (key, count) => ({
+      value: JSON.parse(key),
+      count,
+    })),
+    topCombinations: toSortedRows(mergedCombinationCounter, topN, (key, count) => ({
+      values: JSON.parse(key),
+      count,
+    })),
+    arrayLengthDistribution: toSortedNumericRows(mergedLengthCounter, (key, count) => ({
+      length: Number(key),
+      count,
+    })),
+  };
+}
+
+export function formatAnalysis(analysis, scopeLabel = 'Summary') {
+  const lines = [
+    `${scopeLabel}`,
+    `fieldPath: ${analysis.fieldPath}`,
+    `auctionsAnalyzed: ${analysis.auctionsAnalyzed}`,
+    `auctionsWithField: ${analysis.auctionsWithField}`,
+    `auctionsWithoutField: ${analysis.auctionsWithoutField}`,
+    `arrayFieldCount: ${analysis.arrayFieldCount}`,
+    `scalarFieldCount: ${analysis.scalarFieldCount}`,
+    `nullFieldCount: ${analysis.nullFieldCount}`,
+    `emptyArrayCount: ${analysis.emptyArrayCount}`,
+    `totalExtractedValues: ${analysis.totalExtractedValues}`,
+    `distinctValueCount: ${analysis.distinctValueCount}`,
+    `distinctCombinationCount: ${analysis.distinctCombinationCount}`,
+    'topValues:',
+  ];
+
+  if (analysis.topValues.length === 0) {
+    lines.push('  (none)');
+  } else {
+    for (const row of analysis.topValues) {
+      lines.push(`  ${JSON.stringify(row.value)} => ${row.count}`);
+    }
+  }
+
+  lines.push('topCombinations:');
+  if (analysis.topCombinations.length === 0) {
+    lines.push('  (none)');
+  } else {
+    for (const row of analysis.topCombinations) {
+      lines.push(`  ${JSON.stringify(row.values)} => ${row.count}`);
+    }
+  }
+
+  lines.push('arrayLengthDistribution:');
+  if (analysis.arrayLengthDistribution.length === 0) {
+    lines.push('  (none)');
+  } else {
+    for (const row of analysis.arrayLengthDistribution) {
+      lines.push(`  ${row.length} => ${row.count}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export async function loadAuctionPayload(url, options = {}) {
+  const compressed = await downloadBuffer(url, options);
+  const decompressed = decompressIfNeeded(compressed, url);
+  return JSON.parse(decompressed.toString('utf8'));
+}
+
+export async function processUrl(url, options) {
+  const payload = await loadAuctionPayload(url, options);
+  const analysis = analyzeAuctionField(payload, options.fieldPath, options);
+  const label = safeLabelFromUrl(url);
+  const outputDir = path.join(options.outDir, label);
+  await mkdir(outputDir, { recursive: true });
+
+  const jsonPath = path.join(outputDir, 'field-analysis.json');
+  const textPath = path.join(outputDir, 'field-analysis.txt');
+
+  await writeFile(jsonPath, `${JSON.stringify(analysis, null, 2)}\n`, 'utf8');
+  await writeFile(textPath, `${formatAnalysis(analysis, `Source: ${url}`)}\n`, 'utf8');
+
+  return {
+    url,
+    label,
+    analysis,
+    jsonPath,
+    textPath,
+  };
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseCliArgs(argv);
+
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  await mkdir(options.outDir, { recursive: true });
+
+  const results = [];
+  for (const url of options.urls) {
+    console.log(`Analyzing ${url}`);
+    const result = await processUrl(url, options);
+    results.push(result);
+    console.log(`  Saved JSON analysis to ${result.jsonPath}`);
+    console.log(`  Saved text analysis to ${result.textPath}`);
+  }
+
+  const aggregate = mergeAnalyses(results.map((result) => result.analysis), options);
+  const summaryPath = path.join(options.outDir, 'summary.json');
+  const summaryTextPath = path.join(options.outDir, 'summary.txt');
+
+  await writeFile(summaryPath, `${JSON.stringify({ generatedAt: new Date().toISOString(), results, aggregate }, null, 2)}\n`, 'utf8');
+  if (aggregate) {
+    await writeFile(summaryTextPath, `${formatAnalysis(aggregate, 'Aggregate')}\n`, 'utf8');
+  }
+
+  console.log(`Wrote aggregate summary to ${summaryPath}`);
+  console.log(`Wrote aggregate text summary to ${summaryTextPath}`);
+}
+
+const launchedDirectly = process.argv[1]
+  ? import.meta.url === pathToFileURL(process.argv[1]).href
+  : false;
+
+if (launchedDirectly) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/tools/analyze-auction-field.mjs
+++ b/tools/analyze-auction-field.mjs
@@ -81,7 +81,7 @@ export function parseCliArgs(argv) {
     throw new Error(`Unknown argument: ${argument}`);
   }
 
-  if (options.urls.length === 0) {
+  if (!options.help && options.urls.length === 0) {
     throw new Error('At least one --url is required');
   }
 

--- a/tools/analyze-auction-field.test.mjs
+++ b/tools/analyze-auction-field.test.mjs
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  analyzeAuctionField,
+  formatAnalysis,
+  getValueAtPath,
+  mergeAnalyses,
+  parseCliArgs,
+} from './analyze-auction-field.mjs';
+
+test('parseCliArgs reads required urls and optional auth token', () => {
+  const parsed = parseCliArgs([
+    '--url', 'https://example.test/one',
+    '--url', 'https://example.test/two',
+    '--bearer-token', 'secret',
+    '--field-path', 'item.bonus_lists',
+    '--top', '10',
+  ]);
+
+  assert.deepEqual(parsed.urls, ['https://example.test/one', 'https://example.test/two']);
+  assert.equal(parsed.bearerToken, 'secret');
+  assert.equal(parsed.fieldPath, 'item.bonus_lists');
+  assert.equal(parsed.topN, 10);
+});
+
+test('getValueAtPath walks nested auction paths', () => {
+  const auction = {
+    item: {
+      bonus_lists: [123, 456],
+    },
+  };
+
+  assert.deepEqual(getValueAtPath(auction, 'item.bonus_lists'), [123, 456]);
+  assert.equal(getValueAtPath(auction, 'item.context'), undefined);
+});
+
+test('analyzeAuctionField summarizes array-backed bonus list values', () => {
+  const payload = {
+    auctions: [
+      { item: { bonus_lists: [10, 20] } },
+      { item: { bonus_lists: [20, 10] } },
+      { item: { bonus_lists: [30] } },
+      { item: { bonus_lists: [] } },
+      { item: { context: 55 } },
+    ],
+  };
+
+  const analysis = analyzeAuctionField(payload, 'item.bonus_lists', { topN: 10 });
+
+  assert.equal(analysis.auctionsAnalyzed, 5);
+  assert.equal(analysis.auctionsWithField, 4);
+  assert.equal(analysis.auctionsWithoutField, 1);
+  assert.equal(analysis.arrayFieldCount, 4);
+  assert.equal(analysis.emptyArrayCount, 1);
+  assert.equal(analysis.totalExtractedValues, 5);
+  assert.equal(analysis.distinctValueCount, 3);
+  assert.deepEqual(analysis.topValues, [
+    { value: 10, count: 2 },
+    { value: 20, count: 2 },
+    { value: 30, count: 1 },
+  ]);
+  assert.deepEqual(analysis.topCombinations, [
+    { values: [10, 20], count: 2 },
+    { values: [30], count: 1 },
+  ]);
+  assert.deepEqual(analysis.arrayLengthDistribution, [
+    { length: 0, count: 1 },
+    { length: 1, count: 1 },
+    { length: 2, count: 2 },
+  ]);
+});
+
+test('mergeAnalyses combines per-source counters', () => {
+  const first = analyzeAuctionField({ auctions: [{ item: { bonus_lists: [1, 2] } }] }, 'item.bonus_lists', { topN: 10 });
+  const second = analyzeAuctionField({ auctions: [{ item: { bonus_lists: [2] } }] }, 'item.bonus_lists', { topN: 10 });
+
+  const merged = mergeAnalyses([first, second], { topN: 10 });
+
+  assert.equal(merged.auctionsAnalyzed, 2);
+  assert.equal(merged.totalExtractedValues, 3);
+  assert.deepEqual(merged.topValues, [
+    { value: 2, count: 2 },
+    { value: 1, count: 1 },
+  ]);
+});
+
+test('formatAnalysis renders a readable summary', () => {
+  const analysis = analyzeAuctionField({ auctions: [{ item: { bonus_lists: [1, 2] } }] }, 'item.bonus_lists', { topN: 10 });
+  const text = formatAnalysis(analysis, 'Aggregate');
+
+  assert.match(text, /Aggregate/);
+  assert.match(text, /topValues:/);
+  assert.match(text, /topCombinations:/);
+});

--- a/tools/analyze-auction-field.test.mjs
+++ b/tools/analyze-auction-field.test.mjs
@@ -24,6 +24,13 @@ test('parseCliArgs reads required urls and optional auth token', () => {
   assert.equal(parsed.topN, 10);
 });
 
+test('parseCliArgs allows help without requiring urls', () => {
+  const parsed = parseCliArgs(['--help']);
+
+  assert.equal(parsed.help, true);
+  assert.deepEqual(parsed.urls, []);
+});
+
 test('getValueAtPath walks nested auction paths', () => {
   const auction = {
     item: {

--- a/tools/map-auction-json.mjs
+++ b/tools/map-auction-json.mjs
@@ -16,6 +16,7 @@ export const DEFAULT_OUT_DIR = path.resolve(process.cwd(), 'target', 'auction-js
 
 export function parseCliArgs(argv) {
   const options = {
+    bearerToken: undefined,
     urls: [],
     outDir: DEFAULT_OUT_DIR,
     enumThreshold: DEFAULT_ENUM_THRESHOLD,
@@ -31,6 +32,16 @@ export function parseCliArgs(argv) {
         throw new Error('Missing value for --url');
       }
       options.urls.push(value);
+      index += 1;
+      continue;
+    }
+
+    if (argument === '--bearer-token') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('Missing value for --bearer-token');
+      }
+      options.bearerToken = value;
       index += 1;
       continue;
     }
@@ -99,6 +110,7 @@ Usage:
 
 Options:
   --url <url>            Add a URL to inspect. Can be used multiple times.
+  --bearer-token <token> Send an Authorization: Bearer header with each request.
   --out-dir <path>       Output directory. Default: ${DEFAULT_OUT_DIR}
   --sample-size <count>  Number of array elements to inspect per array. Use "all" to inspect every element.
                          Default: all elements
@@ -396,8 +408,15 @@ export function decompressIfNeeded(buffer, url) {
   return buffer;
 }
 
-export async function downloadBuffer(url) {
-  const response = await fetch(url);
+export async function downloadBuffer(url, options = {}) {
+  const headers = {};
+  if (options.bearerToken) {
+    headers.Authorization = `Bearer ${options.bearerToken}`;
+  }
+
+  const response = await fetch(url, {
+    headers,
+  });
   if (!response.ok) {
     throw new Error(`Failed to download ${url}: ${response.status} ${response.statusText}`);
   }
@@ -430,7 +449,7 @@ export async function processUrl(url, options = {}) {
   const itemOutDir = path.join(effectiveOptions.outDir, label);
   await mkdir(itemOutDir, { recursive: true });
 
-  const compressed = await downloadBuffer(url);
+  const compressed = await downloadBuffer(url, effectiveOptions);
   const decompressed = decompressIfNeeded(compressed, url);
   const text = decompressed.toString('utf8');
   const data = JSON.parse(text);
@@ -509,5 +528,4 @@ if (launchedDirectly) {
     process.exitCode = 1;
   });
 }
-
 


### PR DESCRIPTION
## Summary
Fully integrates the bonus list property across the auction data model, processing logic, and persistence layers.

## Type of change
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [x] 🧹 Code refactor
- [x] 🧪 Tests
- [x] 📚 Documentation
- [ ] 🔧 Build/CI
- [ ] 🔄 Other (describe below)

## What has been done?
- Introduced `bonus_lists` as a `List` in the `AuctionItemDTO` and a canonical `String` in the `AuctionItem` DBO.
- Extended database schema to include `bonus_lists` on `auction_item` and `bonus_key` on `hourly_auction_stats` and `daily_auction_stats` tables.
- Updated primary keys for hourly and daily auction statistics to incorporate `bonus_key`, ensuring unique identification of item variants.
- Modified `AuctionHousePrice` and `AuctionStatsId` to include `bonusKey` as part of their composite identifiers.
- Created `AuctionVariantKeyUtility` to standardize the generation of canonical `bonus_key` and `modifier_key` strings.
- Updated auction processing services (`BlizzardAuctionService`, `HourlyPriceStatisticsService`, `AuctionProcessorUtility`) to correctly handle, canonicalize, and persist bonus list data.
- Enhanced `AuctionHousePriceRepository` and `AuctionItemRepository` with new query methods that account for the `bonusKey`.
- Added comprehensive integration tests to validate the correct handling, canonicalization, and querying of bonus lists.
- Introduced a new command-line tool (`analyze-auction-field.mjs`) to assist with analyzing field distributions in auction payloads, including support for authenticated endpoints via bearer tokens.

## Motivation / Context
This change was necessary to properly represent and track auction items that feature bonus lists as distinct variants. By integrating `bonus_lists` at all levels, the system can accurately store, process, and retrieve price statistics and item details for these specific item configurations, improving data granularity and accuracy.

## Screenshots (if applicable)


## Checklist
- [ ] I’ve tested this manually
- [x] I’ve added tests if applicable
- [x] I’ve updated docs if needed
- [ ] I’ve followed the coding conventions

## Related Issues