### PR TITLE
Add hourly auction stats indexes and storage alignment migration

### DIFF
--- a/src/main/kotlin/db/migration/V4__align_hourly_auction_stats_indexes_and_storage.kt
+++ b/src/main/kotlin/db/migration/V4__align_hourly_auction_stats_indexes_and_storage.kt
@@ -1,0 +1,319 @@
+package db.migration
+
+import org.flywaydb.core.api.migration.BaseJavaMigration
+import org.flywaydb.core.api.migration.Context
+import java.sql.Connection
+
+@Suppress("ClassName")
+class V4__align_hourly_auction_stats_indexes_and_storage : BaseJavaMigration() {
+    override fun canExecuteInTransaction(): Boolean = false
+
+    override fun migrate(context: Context) {
+        val connection = context.connection
+        val schema = queryCurrentSchema(connection) ?: return
+        if (!tableExists(connection, schema, TABLE_NAME)) return
+
+        val indexes = loadIndexes(connection, schema, TABLE_NAME)
+        val storageAligned = isStorageAligned(showCreateTable(connection, TABLE_NAME))
+        val indexesAligned = areIndexesAligned(indexes)
+
+        if (storageAligned) {
+            if (!indexesAligned) {
+                normalizeIndexes(connection, schema, TABLE_NAME)
+            }
+            recreateAuctionHousePricesView(connection)
+            return
+        }
+
+        rebuildHourlyAuctionStatsTable(connection, schema)
+    }
+
+    private fun rebuildHourlyAuctionStatsTable(
+        connection: Connection,
+        schema: String,
+    ) {
+        execute(connection, "DROP VIEW IF EXISTS `$VIEW_NAME`")
+        execute(connection, "DROP TABLE IF EXISTS `$TEMP_TABLE_NAME`")
+        execute(connection, "DROP TABLE IF EXISTS `$BACKUP_TABLE_NAME`")
+        execute(connection, "CREATE TABLE `$TEMP_TABLE_NAME` LIKE `$TABLE_NAME`")
+
+        normalizeIndexes(connection, schema, TEMP_TABLE_NAME)
+        execute(
+            connection,
+            """
+            ALTER TABLE `$TEMP_TABLE_NAME`
+                ENGINE=InnoDB,
+                MAX_ROWS=$TARGET_MAX_ROWS
+            """.trimIndent(),
+        )
+        execute(
+            connection,
+            """
+            ALTER TABLE `$TEMP_TABLE_NAME`
+                CONVERT TO CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci
+            """.trimIndent(),
+        )
+        execute(
+            connection,
+            """
+            ALTER TABLE `$TEMP_TABLE_NAME`
+                PARTITION BY HASH (to_days(`date`))
+                PARTITIONS $TARGET_PARTITIONS
+            """.trimIndent(),
+        )
+        execute(connection, "INSERT INTO `$TEMP_TABLE_NAME` SELECT * FROM `$TABLE_NAME`")
+        execute(
+            connection,
+            """
+            RENAME TABLE
+                `$TABLE_NAME` TO `$BACKUP_TABLE_NAME`,
+                `$TEMP_TABLE_NAME` TO `$TABLE_NAME`
+            """.trimIndent(),
+        )
+        execute(connection, "DROP TABLE `$BACKUP_TABLE_NAME`")
+        recreateAuctionHousePricesView(connection)
+    }
+
+    private fun normalizeIndexes(
+        connection: Connection,
+        schema: String,
+        tableName: String,
+    ) {
+        val indexes = loadIndexes(connection, schema, tableName)
+
+        dropEquivalentIndexes(
+            connection = connection,
+            indexes = indexes,
+            tableName = tableName,
+            expectedName = REALM_DATE_INDEX,
+            expectedColumns = REALM_DATE_COLUMNS,
+        )
+        dropEquivalentIndexes(
+            connection = connection,
+            indexes = indexes,
+            tableName = tableName,
+            expectedName = REALM_ITEM_DATE_INDEX,
+            expectedColumns = REALM_ITEM_DATE_COLUMNS,
+        )
+
+        val refreshedIndexes = loadIndexes(connection, schema, tableName)
+
+        if (refreshedIndexes.containsKey(REALM_DATE_INDEX) &&
+            refreshedIndexes[REALM_DATE_INDEX] != REALM_DATE_COLUMNS
+        ) {
+            execute(
+                connection,
+                """
+                ALTER TABLE `$tableName`
+                    DROP INDEX `$REALM_DATE_INDEX`
+                """.trimIndent(),
+            )
+        }
+
+        if (refreshedIndexes.containsKey(REALM_ITEM_DATE_INDEX) &&
+            refreshedIndexes[REALM_ITEM_DATE_INDEX] != REALM_ITEM_DATE_COLUMNS
+        ) {
+            execute(
+                connection,
+                """
+                ALTER TABLE `$tableName`
+                    DROP INDEX `$REALM_ITEM_DATE_INDEX`
+                """.trimIndent(),
+            )
+        }
+
+        val finalIndexes = loadIndexes(connection, schema, tableName)
+
+        if (finalIndexes[REALM_DATE_INDEX] != REALM_DATE_COLUMNS) {
+            execute(
+                connection,
+                """
+                ALTER TABLE `$tableName`
+                    ADD INDEX `$REALM_DATE_INDEX` (`connected_realm_id`, `date`)
+                """.trimIndent(),
+            )
+        }
+
+        if (finalIndexes[REALM_ITEM_DATE_INDEX] != REALM_ITEM_DATE_COLUMNS) {
+            execute(
+                connection,
+                """
+                ALTER TABLE `$tableName`
+                    ADD INDEX `$REALM_ITEM_DATE_INDEX` (`connected_realm_id`, `item_id`, `date`)
+                """.trimIndent(),
+            )
+        }
+    }
+
+    private fun dropEquivalentIndexes(
+        connection: Connection,
+        indexes: Map<String, List<String>>,
+        tableName: String,
+        expectedName: String,
+        expectedColumns: List<String>,
+    ) {
+        indexes
+            .filterKeys { it != "PRIMARY" }
+            .filter { (name, columns) -> name != expectedName && columns == expectedColumns }
+            .keys
+            .forEach { indexName ->
+                execute(
+                    connection,
+                    """
+                    ALTER TABLE `$tableName`
+                        DROP INDEX `$indexName`
+                    """.trimIndent(),
+                )
+            }
+    }
+
+    private fun areIndexesAligned(indexes: Map<String, List<String>>): Boolean {
+        val namedIndexesAligned =
+            indexes[REALM_DATE_INDEX] == REALM_DATE_COLUMNS &&
+                indexes[REALM_ITEM_DATE_INDEX] == REALM_ITEM_DATE_COLUMNS
+
+        val unexpectedEquivalentIndexes =
+            indexes
+                .filterKeys { it != "PRIMARY" && it != REALM_DATE_INDEX && it != REALM_ITEM_DATE_INDEX }
+                .values
+                .any { columns -> columns == REALM_DATE_COLUMNS || columns == REALM_ITEM_DATE_COLUMNS }
+
+        return namedIndexesAligned && !unexpectedEquivalentIndexes
+    }
+
+    private fun loadIndexes(
+        connection: Connection,
+        schema: String,
+        tableName: String,
+    ): Map<String, List<String>> {
+        connection
+            .prepareStatement(
+                """
+                SELECT index_name, column_name
+                FROM information_schema.statistics
+                WHERE table_schema = ?
+                  AND table_name = ?
+                ORDER BY index_name, seq_in_index
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setString(1, schema)
+                statement.setString(2, tableName)
+
+                statement.executeQuery().use { rs ->
+                    val indexes = linkedMapOf<String, MutableList<String>>()
+                    while (rs.next()) {
+                        val indexName = rs.getString("index_name")
+                        val columnName = rs.getString("column_name")
+                        indexes.getOrPut(indexName) { mutableListOf() }.add(columnName)
+                    }
+                    return indexes.mapValues { (_, columns) -> columns.toList() }
+                }
+            }
+    }
+
+    private fun tableExists(
+        connection: Connection,
+        schema: String,
+        tableName: String,
+    ): Boolean =
+        connection
+            .prepareStatement(
+                """
+                SELECT 1
+                FROM information_schema.tables
+                WHERE table_schema = ?
+                  AND table_name = ?
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setString(1, schema)
+                statement.setString(2, tableName)
+                statement.executeQuery().use { rs -> rs.next() }
+            }
+
+    private fun showCreateTable(
+        connection: Connection,
+        tableName: String,
+    ): String? =
+        connection
+            .createStatement()
+            .use { statement ->
+                statement.executeQuery("SHOW CREATE TABLE `$tableName`").use { rs ->
+                    if (!rs.next()) return null
+                    rs.getString("Create Table")
+                }
+            }
+
+    private fun queryCurrentSchema(connection: Connection): String? =
+        connection
+            .createStatement()
+            .use { statement ->
+                statement.executeQuery("SELECT DATABASE()").use { rs ->
+                    if (!rs.next()) return null
+                    rs.getString(1)
+                }
+            }
+
+    private fun recreateAuctionHousePricesView(connection: Connection) {
+        execute(connection, "DROP VIEW IF EXISTS `$VIEW_NAME`")
+        execute(connection, AUCTION_HOUSE_PRICES_VIEW_SQL)
+    }
+
+    private fun execute(
+        connection: Connection,
+        sql: String,
+    ) {
+        connection.createStatement().use { statement ->
+            statement.execute(sql)
+        }
+    }
+
+    private fun isStorageAligned(createTableSql: String?): Boolean {
+        if (createTableSql.isNullOrBlank()) return false
+        val normalized = createTableSql.lowercase().replace("`", "").replace(Regex("\\s+"), " ")
+        return normalized.contains("engine=innodb") &&
+            normalized.contains("default charset=utf8mb3") &&
+            normalized.contains("collate=utf8mb3_general_ci") &&
+            normalized.contains("max_rows=$TARGET_MAX_ROWS") &&
+            normalized.contains("partition by hash (to_days(date))") &&
+            normalized.contains("partitions $TARGET_PARTITIONS")
+    }
+
+    companion object {
+        private const val TABLE_NAME = "hourly_auction_stats"
+        private const val TEMP_TABLE_NAME = "hourly_auction_stats_v4_new"
+        private const val BACKUP_TABLE_NAME = "hourly_auction_stats_v4_old"
+        private const val VIEW_NAME = "v_auction_house_prices"
+        private const val TARGET_MAX_ROWS = 82300000
+        private const val TARGET_PARTITIONS = 31
+        private const val REALM_DATE_INDEX = "idx_hourly_auction_stats_connected_realm_id_date"
+        private const val REALM_ITEM_DATE_INDEX = "idx_hourly_auction_stats_connected_realm_id_item_id_date"
+        private val REALM_DATE_COLUMNS = listOf("connected_realm_id", "date")
+        private val REALM_ITEM_DATE_COLUMNS = listOf("connected_realm_id", "item_id", "date")
+
+        private val AUCTION_HOUSE_PRICES_VIEW_SQL =
+            buildString {
+                appendLine("CREATE OR REPLACE VIEW v_auction_house_prices AS")
+                for (hour in 0..23) {
+                    if (hour > 0) {
+                        appendLine("UNION ALL")
+                    }
+                    val paddedHour = hour.toString().padStart(2, '0')
+                    appendLine(
+                        """
+                        SELECT connected_realm_id,
+                               ah_type_id,
+                               item_id,
+                               pet_species_id,
+                               modifier_key,
+                               bonus_key,
+                               TIMESTAMP(date, MAKETIME($hour, 0, 0)) AS auction_timestamp,
+                               price$paddedHour AS price,
+                               quantity$paddedHour AS quantity
+                        FROM hourly_auction_stats
+                        WHERE price$paddedHour IS NOT NULL OR quantity$paddedHour IS NOT NULL
+                        """.trimIndent(),
+                    )
+                }
+            }
+    }
+}

--- a/src/main/kotlin/db/migration/V4__align_hourly_auction_stats_indexes_and_storage.kt
+++ b/src/main/kotlin/db/migration/V4__align_hourly_auction_stats_indexes_and_storage.kt
@@ -21,23 +21,23 @@ class V4__align_hourly_auction_stats_indexes_and_storage : BaseJavaMigration() {
             if (!indexesAligned) {
                 normalizeIndexes(connection, schema, TABLE_NAME)
             }
-            recreateAuctionHousePricesView(connection)
             return
         }
 
-        rebuildHourlyAuctionStatsTable(connection, schema)
+        rebuildHourlyAuctionStatsTable(connection, schema, loadViewDefinition(connection, schema, VIEW_NAME))
     }
 
     private fun rebuildHourlyAuctionStatsTable(
         connection: Connection,
         schema: String,
+        viewDefinition: String?,
     ) {
         execute(connection, "DROP VIEW IF EXISTS `$VIEW_NAME`")
         execute(connection, "DROP TABLE IF EXISTS `$TEMP_TABLE_NAME`")
         execute(connection, "DROP TABLE IF EXISTS `$BACKUP_TABLE_NAME`")
         execute(connection, "CREATE TABLE `$TEMP_TABLE_NAME` LIKE `$TABLE_NAME`")
 
-        normalizeIndexes(connection, schema, TEMP_TABLE_NAME)
+        dropSecondaryIndexes(connection, schema, TEMP_TABLE_NAME)
         execute(
             connection,
             """
@@ -70,8 +70,9 @@ class V4__align_hourly_auction_stats_indexes_and_storage : BaseJavaMigration() {
                 `$TEMP_TABLE_NAME` TO `$TABLE_NAME`
             """.trimIndent(),
         )
+        normalizeIndexes(connection, schema, TABLE_NAME)
         execute(connection, "DROP TABLE `$BACKUP_TABLE_NAME`")
-        recreateAuctionHousePricesView(connection)
+        recreateAuctionHousePricesView(connection, viewDefinition)
     }
 
     private fun normalizeIndexes(
@@ -156,6 +157,25 @@ class V4__align_hourly_auction_stats_indexes_and_storage : BaseJavaMigration() {
             .filterKeys { it != "PRIMARY" }
             .filter { (name, columns) -> name != expectedName && columns == expectedColumns }
             .keys
+            .forEach { indexName ->
+                execute(
+                    connection,
+                    """
+                    ALTER TABLE `$tableName`
+                        DROP INDEX `$indexName`
+                    """.trimIndent(),
+                )
+            }
+    }
+
+    private fun dropSecondaryIndexes(
+        connection: Connection,
+        schema: String,
+        tableName: String,
+    ) {
+        loadIndexes(connection, schema, tableName)
+            .keys
+            .filter { it != "PRIMARY" }
             .forEach { indexName ->
                 execute(
                     connection,
@@ -253,9 +273,35 @@ class V4__align_hourly_auction_stats_indexes_and_storage : BaseJavaMigration() {
                 }
             }
 
-    private fun recreateAuctionHousePricesView(connection: Connection) {
-        execute(connection, "DROP VIEW IF EXISTS `$VIEW_NAME`")
-        execute(connection, AUCTION_HOUSE_PRICES_VIEW_SQL)
+    private fun loadViewDefinition(
+        connection: Connection,
+        schema: String,
+        viewName: String,
+    ): String? =
+        connection
+            .prepareStatement(
+                """
+                SELECT view_definition
+                FROM information_schema.views
+                WHERE table_schema = ?
+                  AND table_name = ?
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setString(1, schema)
+                statement.setString(2, viewName)
+                statement.executeQuery().use { rs ->
+                    if (!rs.next()) return null
+                    "CREATE OR REPLACE VIEW `$viewName` AS ${rs.getString("view_definition")}"
+                }
+            }
+
+    private fun recreateAuctionHousePricesView(
+        connection: Connection,
+        viewDefinition: String?,
+    ) {
+        if (viewDefinition != null) {
+            execute(connection, viewDefinition)
+        }
     }
 
     private fun execute(
@@ -289,31 +335,5 @@ class V4__align_hourly_auction_stats_indexes_and_storage : BaseJavaMigration() {
         private const val REALM_ITEM_DATE_INDEX = "idx_hourly_auction_stats_connected_realm_id_item_id_date"
         private val REALM_DATE_COLUMNS = listOf("connected_realm_id", "date")
         private val REALM_ITEM_DATE_COLUMNS = listOf("connected_realm_id", "item_id", "date")
-
-        private val AUCTION_HOUSE_PRICES_VIEW_SQL =
-            buildString {
-                appendLine("CREATE OR REPLACE VIEW v_auction_house_prices AS")
-                for (hour in 0..23) {
-                    if (hour > 0) {
-                        appendLine("UNION ALL")
-                    }
-                    val paddedHour = hour.toString().padStart(2, '0')
-                    appendLine(
-                        """
-                        SELECT connected_realm_id,
-                               ah_type_id,
-                               item_id,
-                               pet_species_id,
-                               modifier_key,
-                               bonus_key,
-                               TIMESTAMP(date, MAKETIME($hour, 0, 0)) AS auction_timestamp,
-                               price$paddedHour AS price,
-                               quantity$paddedHour AS quantity
-                        FROM hourly_auction_stats
-                        WHERE price$paddedHour IS NOT NULL OR quantity$paddedHour IS NOT NULL
-                        """.trimIndent(),
-                    )
-                }
-            }
     }
 }

--- a/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/auction/HourlyAuctionStats.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/auction/HourlyAuctionStats.kt
@@ -2,7 +2,6 @@ package net.jonasmf.auctionengine.dbo.rds.auction
 
 import jakarta.persistence.EmbeddedId
 import jakarta.persistence.Entity
-import jakarta.persistence.Index
 import jakarta.persistence.Table
 
 /**
@@ -16,19 +15,7 @@ import jakarta.persistence.Table
  * This was the fastest and cheapest approach I could find as I don't want to spend lots of money on an expensive database.
  */
 @Entity
-@Table(
-    name = "hourly_auction_stats",
-    indexes = [
-        Index(
-            name = "idx_hourly_auction_stats_connected_realm_id_date",
-            columnList = "connected_realm_id, date",
-        ),
-        Index(
-            name = "idx_hourly_auction_stats_connected_realm_id_item_id_date",
-            columnList = "connected_realm_id, item_id, date",
-        ),
-    ],
-)
+@Table(name = "hourly_auction_stats")
 data class HourlyAuctionStats(
     @EmbeddedId
     val id: AuctionStatsId,

--- a/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/auction/HourlyAuctionStats.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/auction/HourlyAuctionStats.kt
@@ -2,6 +2,8 @@ package net.jonasmf.auctionengine.dbo.rds.auction
 
 import jakarta.persistence.EmbeddedId
 import jakarta.persistence.Entity
+import jakarta.persistence.Index
+import jakarta.persistence.Table
 
 /**
  * The reason I have gone with this approach instead of having multiple rows per day, is 1 to save space,
@@ -14,6 +16,19 @@ import jakarta.persistence.Entity
  * This was the fastest and cheapest approach I could find as I don't want to spend lots of money on an expensive database.
  */
 @Entity
+@Table(
+    name = "hourly_auction_stats",
+    indexes = [
+        Index(
+            name = "idx_hourly_auction_stats_connected_realm_id_date",
+            columnList = "connected_realm_id, date",
+        ),
+        Index(
+            name = "idx_hourly_auction_stats_connected_realm_id_item_id_date",
+            columnList = "connected_realm_id, item_id, date",
+        ),
+    ],
+)
 data class HourlyAuctionStats(
     @EmbeddedId
     val id: AuctionStatsId,

--- a/src/test/kotlin/db/migration/V4AlignHourlyAuctionStatsIndexesAndStorageTest.kt
+++ b/src/test/kotlin/db/migration/V4AlignHourlyAuctionStatsIndexesAndStorageTest.kt
@@ -1,0 +1,169 @@
+package db.migration
+
+import net.jonasmf.auctionengine.testsupport.container.SharedTestContainers
+import org.flywaydb.core.api.configuration.Configuration
+import org.flywaydb.core.api.migration.Context
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.sql.Connection
+import java.sql.DriverManager
+
+class V4AlignHourlyAuctionStatsIndexesAndStorageTest {
+    @Test
+    fun `should upgrade existing hourly auction stats table in place`() {
+        SharedTestContainers.startMariaDb()
+
+        databaseConnection().use { connection ->
+            try {
+                execute(connection, "DROP VIEW IF EXISTS v_auction_house_prices")
+                execute(connection, "DROP TABLE IF EXISTS hourly_auction_stats")
+                execute(connection, oldHourlyAuctionStatsTableSql())
+                execute(
+                    connection,
+                    """
+                    INSERT INTO hourly_auction_stats (
+                        connected_realm_id,
+                        ah_type_id,
+                        item_id,
+                        date,
+                        pet_species_id,
+                        modifier_key,
+                        bonus_key,
+                        price03,
+                        quantity03
+                    ) VALUES (1084, 0, 19019, DATE '2026-04-06', -1, '', '', 123456, 10)
+                    """.trimIndent(),
+                )
+
+                V4__align_hourly_auction_stats_indexes_and_storage().migrate(SimpleContext(connection))
+
+                val createTable = queryString(connection, "SHOW CREATE TABLE hourly_auction_stats", "Create Table")
+                val normalizedCreateTable = createTable.lowercase().replace("`", "").replace(Regex("\\s+"), " ")
+
+                assertTrue(normalizedCreateTable.contains("max_rows=82300000"))
+                assertTrue(normalizedCreateTable.contains("partition by hash (to_days(date))"))
+                assertTrue(normalizedCreateTable.contains("partitions 31"))
+
+                val indexes =
+                    queryColumn(
+                        connection,
+                        """
+                        SELECT DISTINCT index_name
+                        FROM information_schema.statistics
+                        WHERE table_schema = DATABASE()
+                          AND table_name = 'hourly_auction_stats'
+                        ORDER BY index_name
+                        """.trimIndent(),
+                    )
+
+                assertTrue(indexes.contains("idx_hourly_auction_stats_connected_realm_id_date"))
+                assertTrue(indexes.contains("idx_hourly_auction_stats_connected_realm_id_item_id_date"))
+
+                val rowCount = queryInt(connection, "SELECT COUNT(*) FROM hourly_auction_stats")
+                assertEquals(1, rowCount)
+
+                val viewRowCount =
+                    queryInt(
+                        connection,
+                        """
+                        SELECT COUNT(*)
+                        FROM v_auction_house_prices
+                        WHERE connected_realm_id = 1084
+                          AND item_id = 19019
+                        """.trimIndent(),
+                    )
+                assertEquals(1, viewRowCount)
+            } finally {
+                execute(connection, "DROP VIEW IF EXISTS v_auction_house_prices")
+                execute(connection, "DROP TABLE IF EXISTS hourly_auction_stats")
+                execute(connection, "DROP TABLE IF EXISTS hourly_auction_stats_v4_new")
+                execute(connection, "DROP TABLE IF EXISTS hourly_auction_stats_v4_old")
+            }
+        }
+    }
+
+    private fun databaseConnection(): Connection =
+        DriverManager.getConnection(
+            SharedTestContainers.mariaDbContainer.jdbcUrl,
+            SharedTestContainers.mariaDbContainer.username,
+            SharedTestContainers.mariaDbContainer.password,
+        )
+
+    private fun execute(
+        connection: Connection,
+        sql: String,
+    ) {
+        connection.createStatement().use { statement ->
+            statement.execute(sql)
+        }
+    }
+
+    private fun queryInt(
+        connection: Connection,
+        sql: String,
+    ): Int =
+        connection.createStatement().use { statement ->
+            statement.executeQuery(sql).use { rs ->
+                rs.next()
+                rs.getInt(1)
+            }
+        }
+
+    private fun queryString(
+        connection: Connection,
+        sql: String,
+        columnName: String,
+    ): String =
+        connection.createStatement().use { statement ->
+            statement.executeQuery(sql).use { rs ->
+                rs.next()
+                rs.getString(columnName)
+            }
+        }
+
+    private fun queryColumn(
+        connection: Connection,
+        sql: String,
+    ): List<String> =
+        connection.createStatement().use { statement ->
+            statement.executeQuery(sql).use { rs ->
+                buildList {
+                    while (rs.next()) {
+                        add(rs.getString(1))
+                    }
+                }
+            }
+        }
+
+    private fun oldHourlyAuctionStatsTableSql(): String =
+        buildString {
+            appendLine("CREATE TABLE hourly_auction_stats (")
+            appendLine("    connected_realm_id INT NOT NULL,")
+            appendLine("    ah_type_id INT NOT NULL,")
+            appendLine("    item_id INT NOT NULL,")
+            appendLine("    date DATE NOT NULL,")
+            appendLine("    pet_species_id INT NOT NULL,")
+            appendLine("    modifier_key VARCHAR(255) NOT NULL DEFAULT '',")
+            appendLine("    bonus_key VARCHAR(255) NOT NULL DEFAULT '',")
+            for (hour in 0..23) {
+                val paddedHour = hour.toString().padStart(2, '0')
+                appendLine("    price$paddedHour BIGINT NULL,")
+                appendLine("    quantity$paddedHour BIGINT NULL,")
+            }
+            appendLine(
+                "    PRIMARY KEY (connected_realm_id, ah_type_id, item_id, date, pet_species_id, modifier_key, bonus_key)",
+            )
+            appendLine(")")
+            append("ENGINE=InnoDB")
+        }
+
+    private class SimpleContext(
+        private val connection: Connection,
+    ) : Context {
+        override fun getConfiguration(): Configuration =
+            throw UnsupportedOperationException("Not required for this test")
+
+        override fun getConnection(): Connection = connection
+    }
+}

--- a/src/test/kotlin/db/migration/V4AlignHourlyAuctionStatsIndexesAndStorageTest.kt
+++ b/src/test/kotlin/db/migration/V4AlignHourlyAuctionStatsIndexesAndStorageTest.kt
@@ -22,6 +22,15 @@ class V4AlignHourlyAuctionStatsIndexesAndStorageTest {
                 execute(
                     connection,
                     """
+                    ALTER TABLE hourly_auction_stats
+                        ADD INDEX idx_date_and_house (connected_realm_id, date),
+                        ADD INDEX idx_old_realm_item_date (connected_realm_id, item_id, date)
+                    """.trimIndent(),
+                )
+                execute(connection, auctionHousePricesViewSql())
+                execute(
+                    connection,
+                    """
                     INSERT INTO hourly_auction_stats (
                         connected_realm_id,
                         ah_type_id,
@@ -45,20 +54,27 @@ class V4AlignHourlyAuctionStatsIndexesAndStorageTest {
                 assertTrue(normalizedCreateTable.contains("partition by hash (to_days(date))"))
                 assertTrue(normalizedCreateTable.contains("partitions 31"))
 
-                val indexes =
-                    queryColumn(
+                val secondaryIndexes =
+                    queryPairs(
                         connection,
                         """
-                        SELECT DISTINCT index_name
+                        SELECT index_name, GROUP_CONCAT(column_name ORDER BY seq_in_index) AS columns_csv
                         FROM information_schema.statistics
                         WHERE table_schema = DATABASE()
                           AND table_name = 'hourly_auction_stats'
+                          AND index_name <> 'PRIMARY'
+                        GROUP BY index_name
                         ORDER BY index_name
                         """.trimIndent(),
                     )
 
-                assertTrue(indexes.contains("idx_hourly_auction_stats_connected_realm_id_date"))
-                assertTrue(indexes.contains("idx_hourly_auction_stats_connected_realm_id_item_id_date"))
+                assertEquals(
+                    mapOf(
+                        "idx_hourly_auction_stats_connected_realm_id_date" to "connected_realm_id,date",
+                        "idx_hourly_auction_stats_connected_realm_id_item_id_date" to "connected_realm_id,item_id,date",
+                    ),
+                    secondaryIndexes,
+                )
 
                 val rowCount = queryInt(connection, "SELECT COUNT(*) FROM hourly_auction_stats")
                 assertEquals(1, rowCount)
@@ -136,6 +152,20 @@ class V4AlignHourlyAuctionStatsIndexesAndStorageTest {
             }
         }
 
+    private fun queryPairs(
+        connection: Connection,
+        sql: String,
+    ): Map<String, String> =
+        connection.createStatement().use { statement ->
+            statement.executeQuery(sql).use { rs ->
+                buildMap {
+                    while (rs.next()) {
+                        put(rs.getString(1), rs.getString(2))
+                    }
+                }
+            }
+        }
+
     private fun oldHourlyAuctionStatsTableSql(): String =
         buildString {
             appendLine("CREATE TABLE hourly_auction_stats (")
@@ -156,6 +186,32 @@ class V4AlignHourlyAuctionStatsIndexesAndStorageTest {
             )
             appendLine(")")
             append("ENGINE=InnoDB")
+        }
+
+    private fun auctionHousePricesViewSql(): String =
+        buildString {
+            appendLine("CREATE OR REPLACE VIEW v_auction_house_prices AS")
+            for (hour in 0..23) {
+                if (hour > 0) {
+                    appendLine("UNION ALL")
+                }
+                val paddedHour = hour.toString().padStart(2, '0')
+                appendLine(
+                    """
+                    SELECT connected_realm_id,
+                           ah_type_id,
+                           item_id,
+                           pet_species_id,
+                           modifier_key,
+                           bonus_key,
+                           TIMESTAMP(date, MAKETIME($hour, 0, 0)) AS auction_timestamp,
+                           price$paddedHour AS price,
+                           quantity$paddedHour AS quantity
+                    FROM hourly_auction_stats
+                    WHERE price$paddedHour IS NOT NULL OR quantity$paddedHour IS NOT NULL
+                    """.trimIndent(),
+                )
+            }
         }
 
     private class SimpleContext(

--- a/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionHousePriceRepositoryTest.kt
+++ b/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionHousePriceRepositoryTest.kt
@@ -71,27 +71,41 @@ class AuctionHousePriceRepositoryTest : IntegrationTestBase() {
 
     @Test
     fun `should align hourly auction stats indexes and storage layout`() {
-        val indexes =
-            jdbcTemplate.queryForList(
-                """
-                SELECT DISTINCT index_name
-                FROM information_schema.statistics
-                WHERE table_schema = DATABASE()
-                  AND table_name = 'hourly_auction_stats'
-                """.trimIndent(),
-                String::class.java,
-            )
+        val secondaryIndexes =
+            jdbcTemplate
+                .query(
+                    """
+                    SELECT index_name, GROUP_CONCAT(column_name ORDER BY seq_in_index) AS columns_csv
+                    FROM information_schema.statistics
+                    WHERE table_schema = DATABASE()
+                      AND table_name = 'hourly_auction_stats'
+                      AND index_name <> 'PRIMARY'
+                    GROUP BY index_name
+                    """.trimIndent(),
+                ) { rs, _ -> rs.getString("index_name") to rs.getString("columns_csv") }
+                .toMap()
 
-        assertTrue(indexes.contains("idx_hourly_auction_stats_connected_realm_id_date"))
-        assertTrue(indexes.contains("idx_hourly_auction_stats_connected_realm_id_item_id_date"))
+        assertEquals(
+            mapOf(
+                "idx_hourly_auction_stats_connected_realm_id_date" to "connected_realm_id,date",
+                "idx_hourly_auction_stats_connected_realm_id_item_id_date" to "connected_realm_id,item_id,date",
+            ),
+            secondaryIndexes,
+        )
 
         val createTable =
             jdbcTemplate.queryForObject(
                 "SHOW CREATE TABLE hourly_auction_stats",
                 { rs, _ -> rs.getString("Create Table") },
-            ) ?: error("SHOW CREATE TABLE returned no definition for hourly_auction_stats")
+            ) ?: error(
+                "SHOW CREATE TABLE returned no definition for hourly_auction_stats",
+            )
 
-        val normalizedCreateTable = createTable.lowercase().replace("`", "").replace(Regex("\\s+"), " ")
+        val normalizedCreateTable =
+            createTable
+                .lowercase()
+                .replace("`", "")
+                .replace(Regex("\\s+"), " ")
 
         assertTrue(normalizedCreateTable.contains("engine=innodb"))
         assertTrue(normalizedCreateTable.contains("default charset=utf8mb3"))

--- a/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionHousePriceRepositoryTest.kt
+++ b/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionHousePriceRepositoryTest.kt
@@ -12,6 +12,7 @@ import net.jonasmf.auctionengine.dto.auction.ModifierDTO
 import net.jonasmf.auctionengine.service.HourlyPriceStatisticsService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
@@ -66,6 +67,38 @@ class AuctionHousePriceRepositoryTest : IntegrationTestBase() {
             )
 
         assertEquals(1, bonusKeyColumnCount)
+    }
+
+    @Test
+    fun `should align hourly auction stats indexes and storage layout`() {
+        val indexes =
+            jdbcTemplate.queryForList(
+                """
+                SELECT DISTINCT index_name
+                FROM information_schema.statistics
+                WHERE table_schema = DATABASE()
+                  AND table_name = 'hourly_auction_stats'
+                """.trimIndent(),
+                String::class.java,
+            )
+
+        assertTrue(indexes.contains("idx_hourly_auction_stats_connected_realm_id_date"))
+        assertTrue(indexes.contains("idx_hourly_auction_stats_connected_realm_id_item_id_date"))
+
+        val createTable =
+            jdbcTemplate.queryForObject(
+                "SHOW CREATE TABLE hourly_auction_stats",
+                { rs, _ -> rs.getString("Create Table") },
+            ) ?: error("SHOW CREATE TABLE returned no definition for hourly_auction_stats")
+
+        val normalizedCreateTable = createTable.lowercase().replace("`", "").replace(Regex("\\s+"), " ")
+
+        assertTrue(normalizedCreateTable.contains("engine=innodb"))
+        assertTrue(normalizedCreateTable.contains("default charset=utf8mb3"))
+        assertTrue(normalizedCreateTable.contains("collate=utf8mb3_general_ci"))
+        assertTrue(normalizedCreateTable.contains("max_rows=82300000"))
+        assertTrue(normalizedCreateTable.contains("partition by hash (to_days(date))"))
+        assertTrue(normalizedCreateTable.contains("partitions 31"))
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add explicit JPA indexes to `hourly_auction_stats` so fresh databases get the expected secondary indexes on startup
- Add a Flyway V4 Java migration that normalizes existing `hourly_auction_stats` tables, including index names, table options, partitioning, and view recreation
- Add integration coverage for both the startup-created schema and the upgrade path from an older table shape

## Task Reference

- GitHub issue: Resolves #
- Local task doc:
- Task slug:

## Context For Reviewers

- The migration is non-transactional because repartitioning and table rebuild operations are not safe to run inside a transaction
- The Flyway class keeps the versioned class name required for Java migrations and suppresses the ktlint class-naming rule locally
- The added realm-item-date index is intended to better support current `v_auction_house_prices` query patterns in addition to the legacy realm-date lookup index

## Changes

- Add `idx_hourly_auction_stats_connected_realm_id_date` and `idx_hourly_auction_stats_connected_realm_id_item_id_date` to `HourlyAuctionStats`
- Rebuild `hourly_auction_stats` when storage settings are out of sync, or add missing indexes directly when only index normalization is needed
- Recreate `v_auction_house_prices` after migration to keep the view aligned with the final table state
- Add tests that verify final index names, `MAX_ROWS`, hash partitioning, and migration behavior against an older table definition

## Testing

- [x] Tests added or updated where needed
- [x] Verified locally

### Checks run

```text
.\mvnw.cmd "-Dtest=AuctionHousePriceRepositoryTest,V4AlignHourlyAuctionStatsIndexesAndStorageTest" test
.\mvnw.cmd verify
```

## Screenshots

N/A

## Checklist

- [ ] This PR references the GitHub issue it resolves or fixes
- [ ] This PR references the local task doc or slug when one exists
- [x] Scope stays aligned with the linked task
- [ ] Documentation updated if behavior or workflow changed