### PR TITLE
Add item sync workflow for Blizzard item imports

### DIFF
--- a/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/LocaleSource.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/LocaleSource.kt
@@ -16,6 +16,7 @@ object LocaleSourceType {
     const val ITEM_SUBCLASS = "item_subclass"
     const val ITEM_QUALITY = "item_quality"
     const val INVENTORY_TYPE = "inventory_type"
+    const val ITEM_BINDING = "item_binding"
 }
 
 fun localeSourceKey(vararg parts: Any): String = parts.joinToString(":") { it.toString() }

--- a/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/item/ItemClassDBO.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/item/ItemClassDBO.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToMany
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 import net.jonasmf.auctionengine.dbo.rds.LocaleDBO
 
 @Entity
@@ -18,6 +19,7 @@ class ItemClassDBO(
     @Id
     val id: Int,
     @OneToOne(cascade = [CascadeType.ALL], fetch = FetchType.EAGER, orphanRemoval = true)
+    @JoinColumn(name = "name_id")
     val name: LocaleDBO,
     @OneToMany(cascade = [CascadeType.ALL], fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinColumn(name = "item_class_owner_id")
@@ -25,7 +27,12 @@ class ItemClassDBO(
 )
 
 @Entity
-@Table(name = "item_subclass")
+@Table(
+    name = "item_subclass",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_item_subclass_key", columnNames = ["class_id", "subclass_id"]),
+    ],
+)
 class ItemSubclassDBO(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,6 +40,7 @@ class ItemSubclassDBO(
     val classId: Int,
     val subclassId: Int,
     @OneToOne(cascade = [CascadeType.ALL], fetch = FetchType.EAGER, orphanRemoval = true)
+    @JoinColumn(name = "display_name_id")
     val displayName: LocaleDBO,
     val hideSubclassInTooltips: Boolean? = null,
 )

--- a/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/item/ItemDBO.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/item/ItemDBO.kt
@@ -10,30 +10,61 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.JoinTable
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 import net.jonasmf.auctionengine.dbo.rds.LocaleDBO
 
 @Entity
-@Table(name = "item_quality")
+@Table(
+    name = "item_quality",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_item_quality_type", columnNames = ["type"]),
+    ],
+)
 class ItemQualityDBO(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val internalId: Long? = null,
     val type: String,
     @OneToOne(cascade = [CascadeType.ALL], fetch = FetchType.EAGER, orphanRemoval = true)
+    @JoinColumn(name = "name_id")
     val name: LocaleDBO,
 )
 
 @Entity
-@Table(name = "inventory_type")
+@Table(
+    name = "inventory_type",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_inventory_type_type", columnNames = ["type"]),
+    ],
+)
 class InventoryTypeDBO(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val internalId: Long? = null,
     val type: String,
     @OneToOne(cascade = [CascadeType.ALL], fetch = FetchType.EAGER, orphanRemoval = true)
+    @JoinColumn(name = "name_id")
+    val name: LocaleDBO,
+)
+
+@Entity
+@Table(
+    name = "item_binding",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_item_binding_type", columnNames = ["type"]),
+    ],
+)
+class ItemBindingDBO(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val internalId: Long? = null,
+    val type: String,
+    @OneToOne(cascade = [CascadeType.ALL], fetch = FetchType.EAGER, orphanRemoval = true)
+    @JoinColumn(name = "name_id")
     val name: LocaleDBO,
 )
 
@@ -51,6 +82,7 @@ class ItemSummaryDBO(
     @Id
     val id: Int,
     @OneToOne(cascade = [CascadeType.ALL], fetch = FetchType.EAGER, orphanRemoval = true)
+    @JoinColumn(name = "name_id")
     val name: LocaleDBO,
     val href: String? = null,
 )
@@ -61,18 +93,26 @@ class ItemDBO(
     @Id
     val id: Int,
     @OneToOne(cascade = [CascadeType.ALL], fetch = FetchType.EAGER, orphanRemoval = true)
+    @JoinColumn(name = "name_id")
     val name: LocaleDBO,
-    @OneToOne(cascade = [CascadeType.ALL], fetch = FetchType.EAGER, orphanRemoval = true)
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "quality_id")
     val quality: ItemQualityDBO,
     val level: Int,
     val requiredLevel: Int,
     val mediaUrl: String,
-    @OneToOne(cascade = [CascadeType.ALL], fetch = FetchType.EAGER, orphanRemoval = true)
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "item_class_id")
     val itemClass: ItemClassDBO,
-    @OneToOne(cascade = [CascadeType.ALL], fetch = FetchType.EAGER, orphanRemoval = true)
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "item_subclass_id")
     val itemSubclass: ItemSubclassDBO,
-    @OneToOne(cascade = [CascadeType.ALL], fetch = FetchType.EAGER, orphanRemoval = true)
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "inventory_type_id")
     val inventoryType: InventoryTypeDBO,
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "binding_id")
+    val binding: ItemBindingDBO? = null,
     val purchasePrice: Int,
     val sellPrice: Int,
     val maxCount: Int,
@@ -85,6 +125,12 @@ class ItemDBO(
         joinColumns = [JoinColumn(name = "item_id")],
         inverseJoinColumns = [JoinColumn(name = "appearance_ref_id")],
         foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT),
+        uniqueConstraints = [
+            UniqueConstraint(
+                name = "uk_item_appearance_ref_pair",
+                columnNames = ["item_id", "appearance_ref_id"],
+            ),
+        ],
     )
     val appearances: MutableList<ItemAppearanceReferenceDBO> = mutableListOf(),
 )

--- a/src/main/kotlin/net/jonasmf/auctionengine/domain/item/Item.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/domain/item/Item.kt
@@ -12,6 +12,11 @@ data class InventoryType(
     val name: LocaleDTO,
 )
 
+data class ItemBinding(
+    val type: String,
+    val name: LocaleDTO,
+)
+
 data class ItemAppearanceReference(
     val id: Int,
     val href: String,
@@ -33,6 +38,7 @@ data class Item(
     val itemClass: ItemClass,
     val itemSubclass: ItemSubclass,
     val inventoryType: InventoryType,
+    val binding: ItemBinding? = null,
     val purchasePrice: Int,
     val sellPrice: Int,
     val maxCount: Int,

--- a/src/main/kotlin/net/jonasmf/auctionengine/dto/item/ItemDTO.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/dto/item/ItemDTO.kt
@@ -23,6 +23,7 @@ data class ItemDTO(
     val itemSubclass: ItemSubclassReferenceDTO,
     @JsonProperty("inventory_type")
     val inventoryType: InventoryTypeDTO,
+    val binding: ItemBindingDTO? = null,
     @JsonProperty("purchase_price")
     val purchasePrice: Int = 0,
     @JsonProperty("sell_price")

--- a/src/main/kotlin/net/jonasmf/auctionengine/dto/item/ItemPreviewDTO.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/dto/item/ItemPreviewDTO.kt
@@ -20,4 +20,5 @@ data class ItemPreviewDTO(
     val itemSubclass: ItemSubclassReferenceDTO? = null,
     @JsonProperty("inventory_type")
     val inventoryType: InventoryTypeDTO? = null,
+    val binding: ItemBindingDTO? = null,
 )

--- a/src/main/kotlin/net/jonasmf/auctionengine/dto/item/ItemSupportDTO.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/dto/item/ItemSupportDTO.kt
@@ -31,6 +31,12 @@ data class InventoryTypeDTO(
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+data class ItemBindingDTO(
+    val type: String = "",
+    val name: LocaleDTO = LocaleDTO(),
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class ItemAppearanceReferenceDTO(
     val key: Href,
     val id: Int,

--- a/src/main/kotlin/net/jonasmf/auctionengine/integration/blizzard/ItemApiClient.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/integration/blizzard/ItemApiClient.kt
@@ -1,0 +1,57 @@
+package net.jonasmf.auctionengine.integration.blizzard
+
+import net.jonasmf.auctionengine.constant.Region
+import net.jonasmf.auctionengine.domain.item.Item
+import net.jonasmf.auctionengine.dto.item.ItemDTO
+import net.jonasmf.auctionengine.mapper.toDomain
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+private const val ITEM_API_RETRY_ATTEMPTS = 3L
+private val ITEM_API_RETRY_BACKOFF: Duration = Duration.ofSeconds(2)
+
+const val ITEM_BASE_PATH = "/data/wow/item"
+
+@Component
+class ItemApiClient(
+    private val blizzardApiSupport: BlizzardApiSupport,
+) {
+    private val logger: Logger = LoggerFactory.getLogger(ItemApiClient::class.java)
+
+    fun getById(id: Int): Item = getById(id, blizzardApiSupport.defaultRegion())
+
+    fun getById(
+        id: Int,
+        region: Region,
+    ): Item {
+        val uri =
+            blizzardApiSupport.buildRegionalUri(
+                region = region,
+                path = "$ITEM_BASE_PATH/$id",
+                namespace = blizzardApiSupport.staticNamespaceForRegion(region).value,
+            )
+        val item =
+            blizzardApiSupport
+                .webClient()
+                .get()
+                .uri(uri)
+                .retrieve()
+                .bodyToMono(ItemDTO::class.java)
+                .onErrorMap { error ->
+                    BlizzardApiClientException.from(
+                        error = error,
+                        operation = "fetch item",
+                        url = uri,
+                        timeout = ITEM_API_RETRY_BACKOFF,
+                    )
+                }.retryTransientBlizzardFailures(
+                    maxRetries = ITEM_API_RETRY_ATTEMPTS,
+                    backoff = ITEM_API_RETRY_BACKOFF,
+                ).doOnError { error ->
+                    logger.logBlizzardHttpFailure(error)
+                }.block()!!
+        return item.toDomain()
+    }
+}

--- a/src/main/kotlin/net/jonasmf/auctionengine/mapper/ItemMapper.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/mapper/ItemMapper.kt
@@ -4,6 +4,7 @@ import net.jonasmf.auctionengine.dbo.rds.LocaleSourceType
 import net.jonasmf.auctionengine.dbo.rds.item.InventoryTypeDBO
 import net.jonasmf.auctionengine.dbo.rds.item.ItemAppearanceDBO
 import net.jonasmf.auctionengine.dbo.rds.item.ItemAppearanceReferenceDBO
+import net.jonasmf.auctionengine.dbo.rds.item.ItemBindingDBO
 import net.jonasmf.auctionengine.dbo.rds.item.ItemClassDBO
 import net.jonasmf.auctionengine.dbo.rds.item.ItemDBO
 import net.jonasmf.auctionengine.dbo.rds.item.ItemQualityDBO
@@ -14,6 +15,7 @@ import net.jonasmf.auctionengine.domain.item.InventoryType
 import net.jonasmf.auctionengine.domain.item.Item
 import net.jonasmf.auctionengine.domain.item.ItemAppearance
 import net.jonasmf.auctionengine.domain.item.ItemAppearanceReference
+import net.jonasmf.auctionengine.domain.item.ItemBinding
 import net.jonasmf.auctionengine.domain.item.ItemClass
 import net.jonasmf.auctionengine.domain.item.ItemQuality
 import net.jonasmf.auctionengine.domain.item.ItemSubclass
@@ -21,6 +23,7 @@ import net.jonasmf.auctionengine.domain.item.ItemSummary
 import net.jonasmf.auctionengine.dto.ReferenceDTO
 import net.jonasmf.auctionengine.dto.item.InventoryTypeDTO
 import net.jonasmf.auctionengine.dto.item.ItemAppearanceReferenceDTO
+import net.jonasmf.auctionengine.dto.item.ItemBindingDTO
 import net.jonasmf.auctionengine.dto.item.ItemClassReferenceDTO
 import net.jonasmf.auctionengine.dto.item.ItemDTO
 import net.jonasmf.auctionengine.dto.item.ItemQualityDTO
@@ -37,6 +40,12 @@ fun ItemQualityDTO.toDomain() =
 
 fun InventoryTypeDTO.toDomain() =
     InventoryType(
+        type = type,
+        name = name,
+    )
+
+fun ItemBindingDTO.toDomain() =
+    ItemBinding(
         type = type,
         name = name,
     )
@@ -88,6 +97,7 @@ fun ItemDTO.toDomain() =
         itemClass = itemClass.toDomain(),
         itemSubclass = itemSubclass.toDomain(itemClass.id),
         inventoryType = inventoryType.toDomain(),
+        binding = binding?.toDomain() ?: previewItem?.binding?.toDomain(),
         purchasePrice = purchasePrice,
         sellPrice = sellPrice,
         maxCount = maxCount,
@@ -143,6 +153,18 @@ fun InventoryType.toDBO() =
 
 fun InventoryTypeDBO.toDomain() =
     InventoryType(
+        type = type,
+        name = name.toDTO(),
+    )
+
+fun ItemBinding.toDBO() =
+    ItemBindingDBO(
+        type = type,
+        name = name.toDBO(LocaleSourceType.ITEM_BINDING, localeSourceKey(type), "name"),
+    )
+
+fun ItemBindingDBO.toDomain() =
+    ItemBinding(
         type = type,
         name = name.toDTO(),
     )
@@ -219,6 +241,7 @@ fun Item.toDBO() =
         itemClass = itemClass.toDBO(),
         itemSubclass = itemSubclass.toDBO(),
         inventoryType = inventoryType.toDBO(),
+        binding = binding?.toDBO(),
         purchasePrice = purchasePrice,
         sellPrice = sellPrice,
         maxCount = maxCount,
@@ -239,6 +262,7 @@ fun ItemDBO.toDomain() =
         itemClass = itemClass.toDomain(),
         itemSubclass = itemSubclass.toDomain(),
         inventoryType = inventoryType.toDomain(),
+        binding = binding?.toDomain(),
         purchasePrice = purchasePrice,
         sellPrice = sellPrice,
         maxCount = maxCount,

--- a/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/ItemJdbcRepository.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/ItemJdbcRepository.kt
@@ -1,0 +1,593 @@
+package net.jonasmf.auctionengine.repository.rds
+
+import net.jonasmf.auctionengine.dbo.rds.LocaleSourceType
+import net.jonasmf.auctionengine.dbo.rds.localeSourceKey
+import net.jonasmf.auctionengine.domain.item.InventoryType
+import net.jonasmf.auctionengine.domain.item.Item
+import net.jonasmf.auctionengine.domain.item.ItemAppearanceReference
+import net.jonasmf.auctionengine.domain.item.ItemBinding
+import net.jonasmf.auctionengine.domain.item.ItemClass
+import net.jonasmf.auctionengine.domain.item.ItemQuality
+import net.jonasmf.auctionengine.domain.item.ItemSubclass
+import net.jonasmf.auctionengine.dto.LocaleDTO
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+private const val ITEM_JDBC_CHUNK_SIZE = 200
+
+data class ItemPersistenceSummary(
+    val localesUpserted: Int,
+    val itemQualitiesUpserted: Int,
+    val inventoryTypesUpserted: Int,
+    val itemBindingsUpserted: Int,
+    val itemClassesUpserted: Int,
+    val itemSubclassesUpserted: Int,
+    val itemAppearanceReferencesUpserted: Int,
+    val itemsUpserted: Int,
+    val itemAppearanceLinksUpserted: Int,
+)
+
+@Repository
+class ItemJdbcRepository(
+    private val jdbcTemplate: JdbcTemplate,
+) {
+    fun findDistinctAuctionItemIdsForDate(date: LocalDate): List<Int> =
+        jdbcTemplate.query(
+            """
+            SELECT DISTINCT item_id
+            FROM hourly_auction_stats
+            WHERE date = ?
+              AND pet_species_id = 0
+              AND item_id > 0
+            ORDER BY item_id
+            """.trimIndent(),
+            { rs, _ -> rs.getInt("item_id") },
+            date,
+        )
+
+    fun findExistingItemIds(itemIds: Collection<Int>): Set<Int> {
+        if (itemIds.isEmpty()) return emptySet()
+        return itemIds
+            .distinct()
+            .chunked(ITEM_JDBC_CHUNK_SIZE)
+            .flatMap { chunk ->
+                jdbcTemplate.query(
+                    "SELECT id FROM `item` WHERE id IN (${placeholders(chunk.size)})",
+                    { rs, _ -> rs.getInt("id") },
+                    *chunk.toTypedArray(),
+                )
+            }.toSet()
+    }
+
+    @Transactional
+    fun syncItems(items: List<Item>): ItemPersistenceSummary {
+        val groupedItems = items.distinctBy(Item::id)
+        if (groupedItems.isEmpty()) {
+            return ItemPersistenceSummary(0, 0, 0, 0, 0, 0, 0, 0, 0)
+        }
+
+        val localeRecords = buildLocaleRecords(groupedItems)
+        upsertLocales(localeRecords.values.toList())
+        val localeIds = findLocaleIds(localeRecords.keys)
+
+        val qualities = groupedItems.map(Item::quality).distinctBy(ItemQuality::type)
+        upsertItemQualities(qualities, localeIds)
+        val qualityIds = findNaturalIds("item_quality", "type", qualities.map(ItemQuality::type))
+
+        val inventoryTypes = groupedItems.map(Item::inventoryType).distinctBy(InventoryType::type)
+        upsertInventoryTypes(inventoryTypes, localeIds)
+        val inventoryTypeIds = findNaturalIds("inventory_type", "type", inventoryTypes.map(InventoryType::type))
+
+        val bindings = groupedItems.mapNotNull(Item::binding).distinctBy(ItemBinding::type)
+        upsertItemBindings(bindings, localeIds)
+        val bindingIds = findNaturalIds("item_binding", "type", bindings.map(ItemBinding::type))
+
+        val itemClasses = groupedItems.map(Item::itemClass).distinctBy(ItemClass::id)
+        upsertItemClasses(itemClasses, localeIds)
+
+        val itemSubclasses =
+            groupedItems
+                .map(Item::itemSubclass)
+                .distinctBy { subclassKey(it.classId, it.subclassId) }
+        upsertItemSubclasses(itemSubclasses, localeIds)
+        val itemSubclassIds = findItemSubclassIds(itemSubclasses)
+
+        val appearanceReferences =
+            groupedItems
+                .flatMap(Item::appearances)
+                .distinctBy(ItemAppearanceReference::id)
+        upsertItemAppearanceReferences(appearanceReferences)
+
+        upsertItems(
+            items = groupedItems,
+            localeIds = localeIds,
+            qualityIds = qualityIds,
+            inventoryTypeIds = inventoryTypeIds,
+            bindingIds = bindingIds,
+            itemSubclassIds = itemSubclassIds,
+        )
+        upsertItemAppearanceLinks(groupedItems)
+
+        return ItemPersistenceSummary(
+            localesUpserted = localeRecords.size,
+            itemQualitiesUpserted = qualities.size,
+            inventoryTypesUpserted = inventoryTypes.size,
+            itemBindingsUpserted = bindings.size,
+            itemClassesUpserted = itemClasses.size,
+            itemSubclassesUpserted = itemSubclasses.size,
+            itemAppearanceReferencesUpserted = appearanceReferences.size,
+            itemsUpserted = groupedItems.size,
+            itemAppearanceLinksUpserted = groupedItems.sumOf { item -> item.appearances.distinctBy { it.id }.size },
+        )
+    }
+
+    private fun buildLocaleRecords(items: List<Item>): Map<LocaleNaturalKey, LocaleRecord> {
+        val records = linkedMapOf<LocaleNaturalKey, LocaleRecord>()
+        items.forEach { item ->
+            records[LocaleNaturalKey(LocaleSourceType.ITEM, localeSourceKey(item.id), "name")] =
+                LocaleRecord(LocaleSourceType.ITEM, localeSourceKey(item.id), "name", item.name)
+
+            records[LocaleNaturalKey(LocaleSourceType.ITEM_QUALITY, localeSourceKey(item.quality.type), "name")] =
+                LocaleRecord(
+                    LocaleSourceType.ITEM_QUALITY,
+                    localeSourceKey(item.quality.type),
+                    "name",
+                    item.quality.name,
+                )
+
+            records[
+                LocaleNaturalKey(
+                    LocaleSourceType.INVENTORY_TYPE,
+                    localeSourceKey(item.inventoryType.type),
+                    "name",
+                ),
+            ] =
+                LocaleRecord(
+                    LocaleSourceType.INVENTORY_TYPE,
+                    localeSourceKey(item.inventoryType.type),
+                    "name",
+                    item.inventoryType.name,
+                )
+
+            item.binding?.let { binding ->
+                records[LocaleNaturalKey(LocaleSourceType.ITEM_BINDING, localeSourceKey(binding.type), "name")] =
+                    LocaleRecord(
+                        LocaleSourceType.ITEM_BINDING,
+                        localeSourceKey(binding.type),
+                        "name",
+                        binding.name,
+                    )
+            }
+
+            records[LocaleNaturalKey(LocaleSourceType.ITEM_CLASS, localeSourceKey(item.itemClass.id), "name")] =
+                LocaleRecord(
+                    LocaleSourceType.ITEM_CLASS,
+                    localeSourceKey(item.itemClass.id),
+                    "name",
+                    item.itemClass.name,
+                )
+
+            records[
+                LocaleNaturalKey(
+                    LocaleSourceType.ITEM_SUBCLASS,
+                    localeSourceKey(item.itemSubclass.classId, item.itemSubclass.subclassId),
+                    "display_name",
+                ),
+            ] =
+                LocaleRecord(
+                    LocaleSourceType.ITEM_SUBCLASS,
+                    localeSourceKey(item.itemSubclass.classId, item.itemSubclass.subclassId),
+                    "display_name",
+                    item.itemSubclass.displayName,
+                )
+        }
+        return records
+    }
+
+    private fun upsertLocales(records: List<LocaleRecord>) {
+        if (records.isEmpty()) return
+        records.chunked(ITEM_JDBC_CHUNK_SIZE).forEach { chunk ->
+            val sql =
+                buildString {
+                    append(
+                        """
+                        INSERT INTO locale (
+                            source_type,
+                            source_key,
+                            source_field,
+                            en_us,
+                            es_mx,
+                            pt_br,
+                            pt_pt,
+                            de_de,
+                            en_gb,
+                            es_es,
+                            fr_fr,
+                            it_it,
+                            ru_ru,
+                            ko_kr,
+                            zh_tw,
+                            zh_cn
+                        ) VALUES
+                        """.trimIndent(),
+                    )
+                    append(' ')
+                    append(chunk.joinToString(",") { "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)" })
+                    append(
+                        """
+                        
+                        ON DUPLICATE KEY UPDATE
+                            en_us = VALUES(en_us),
+                            es_mx = VALUES(es_mx),
+                            pt_br = VALUES(pt_br),
+                            pt_pt = VALUES(pt_pt),
+                            de_de = VALUES(de_de),
+                            en_gb = VALUES(en_gb),
+                            es_es = VALUES(es_es),
+                            fr_fr = VALUES(fr_fr),
+                            it_it = VALUES(it_it),
+                            ru_ru = VALUES(ru_ru),
+                            ko_kr = VALUES(ko_kr),
+                            zh_tw = VALUES(zh_tw),
+                            zh_cn = VALUES(zh_cn)
+                        """.trimIndent(),
+                    )
+                }
+            val params =
+                chunk.flatMap { record ->
+                    listOf(
+                        record.sourceType,
+                        record.sourceKey,
+                        record.sourceField,
+                        record.locale.en_US,
+                        record.locale.es_MX,
+                        record.locale.pt_BR,
+                        record.locale.pt_PT,
+                        record.locale.de_DE,
+                        record.locale.en_GB,
+                        record.locale.es_ES,
+                        record.locale.fr_FR,
+                        record.locale.it_IT,
+                        record.locale.ru_RU,
+                        record.locale.ko_KR,
+                        record.locale.zh_TW,
+                        record.locale.zh_CN,
+                    )
+                }
+            jdbcTemplate.update(sql, *params.toTypedArray())
+        }
+    }
+
+    private fun findLocaleIds(keys: Collection<LocaleNaturalKey>): Map<LocaleNaturalKey, Long> {
+        if (keys.isEmpty()) return emptyMap()
+        val results = linkedMapOf<LocaleNaturalKey, Long>()
+        keys.chunked(ITEM_JDBC_CHUNK_SIZE).forEach { chunk ->
+            val conditions = chunk.joinToString(" OR ") { "(source_type = ? AND source_key = ? AND source_field = ?)" }
+            val params =
+                chunk.flatMap { key -> listOf(key.sourceType, key.sourceKey, key.sourceField) }
+            jdbcTemplate.query(
+                "SELECT id, source_type, source_key, source_field FROM locale WHERE $conditions",
+                { rs ->
+                    val key =
+                        LocaleNaturalKey(
+                            rs.getString("source_type"),
+                            rs.getString("source_key"),
+                            rs.getString("source_field"),
+                        )
+                    results[key] = rs.getLong("id")
+                },
+                *params.toTypedArray(),
+            )
+        }
+        return results
+    }
+
+    private fun upsertItemQualities(
+        qualities: List<ItemQuality>,
+        localeIds: Map<LocaleNaturalKey, Long>,
+    ) {
+        if (qualities.isEmpty()) return
+        qualities.chunked(ITEM_JDBC_CHUNK_SIZE).forEach { chunk ->
+            val sql =
+                """
+                INSERT INTO item_quality (type, name_id)
+                VALUES ${chunk.joinToString(",") { "(?, ?)" }}
+                ON DUPLICATE KEY UPDATE
+                    name_id = VALUES(name_id)
+                """.trimIndent()
+            val params =
+                chunk.flatMap { quality ->
+                    listOf<Any?>(
+                        quality.type,
+                        localeIds.getValue(
+                            LocaleNaturalKey(LocaleSourceType.ITEM_QUALITY, localeSourceKey(quality.type), "name"),
+                        ),
+                    )
+                }
+            jdbcTemplate.update(sql, *params.toTypedArray())
+        }
+    }
+
+    private fun upsertInventoryTypes(
+        inventoryTypes: List<InventoryType>,
+        localeIds: Map<LocaleNaturalKey, Long>,
+    ) {
+        if (inventoryTypes.isEmpty()) return
+        inventoryTypes.chunked(ITEM_JDBC_CHUNK_SIZE).forEach { chunk ->
+            val sql =
+                """
+                INSERT INTO inventory_type (type, name_id)
+                VALUES ${chunk.joinToString(",") { "(?, ?)" }}
+                ON DUPLICATE KEY UPDATE
+                    name_id = VALUES(name_id)
+                """.trimIndent()
+            val params =
+                chunk.flatMap { inventoryType ->
+                    listOf<Any?>(
+                        inventoryType.type,
+                        localeIds.getValue(
+                            LocaleNaturalKey(
+                                LocaleSourceType.INVENTORY_TYPE,
+                                localeSourceKey(inventoryType.type),
+                                "name",
+                            ),
+                        ),
+                    )
+                }
+            jdbcTemplate.update(sql, *params.toTypedArray())
+        }
+    }
+
+    private fun upsertItemBindings(
+        bindings: List<ItemBinding>,
+        localeIds: Map<LocaleNaturalKey, Long>,
+    ) {
+        if (bindings.isEmpty()) return
+        bindings.chunked(ITEM_JDBC_CHUNK_SIZE).forEach { chunk ->
+            val sql =
+                """
+                INSERT INTO item_binding (type, name_id)
+                VALUES ${chunk.joinToString(",") { "(?, ?)" }}
+                ON DUPLICATE KEY UPDATE
+                    name_id = VALUES(name_id)
+                """.trimIndent()
+            val params =
+                chunk.flatMap { binding ->
+                    listOf<Any?>(
+                        binding.type,
+                        localeIds.getValue(
+                            LocaleNaturalKey(LocaleSourceType.ITEM_BINDING, localeSourceKey(binding.type), "name"),
+                        ),
+                    )
+                }
+            jdbcTemplate.update(sql, *params.toTypedArray())
+        }
+    }
+
+    private fun upsertItemClasses(
+        itemClasses: List<ItemClass>,
+        localeIds: Map<LocaleNaturalKey, Long>,
+    ) {
+        if (itemClasses.isEmpty()) return
+        itemClasses.chunked(ITEM_JDBC_CHUNK_SIZE).forEach { chunk ->
+            val sql =
+                """
+                INSERT INTO item_class (id, name_id)
+                VALUES ${chunk.joinToString(",") { "(?, ?)" }}
+                ON DUPLICATE KEY UPDATE
+                    name_id = VALUES(name_id)
+                """.trimIndent()
+            val params =
+                chunk.flatMap { itemClass ->
+                    listOf<Any?>(
+                        itemClass.id,
+                        localeIds.getValue(
+                            LocaleNaturalKey(LocaleSourceType.ITEM_CLASS, localeSourceKey(itemClass.id), "name"),
+                        ),
+                    )
+                }
+            jdbcTemplate.update(sql, *params.toTypedArray())
+        }
+    }
+
+    private fun upsertItemSubclasses(
+        itemSubclasses: List<ItemSubclass>,
+        localeIds: Map<LocaleNaturalKey, Long>,
+    ) {
+        if (itemSubclasses.isEmpty()) return
+        itemSubclasses.chunked(ITEM_JDBC_CHUNK_SIZE).forEach { chunk ->
+            val sql =
+                """
+                INSERT INTO item_subclass (class_id, subclass_id, display_name_id, hide_subclass_in_tooltips)
+                VALUES ${chunk.joinToString(",") { "(?, ?, ?, ?)" }}
+                ON DUPLICATE KEY UPDATE
+                    display_name_id = VALUES(display_name_id),
+                    hide_subclass_in_tooltips = VALUES(hide_subclass_in_tooltips)
+                """.trimIndent()
+            val params =
+                chunk.flatMap { itemSubclass ->
+                    listOf<Any?>(
+                        itemSubclass.classId,
+                        itemSubclass.subclassId,
+                        localeIds.getValue(
+                            LocaleNaturalKey(
+                                LocaleSourceType.ITEM_SUBCLASS,
+                                localeSourceKey(itemSubclass.classId, itemSubclass.subclassId),
+                                "display_name",
+                            ),
+                        ),
+                        itemSubclass.hideSubclassInTooltips,
+                    )
+                }
+            jdbcTemplate.update(sql, *params.toTypedArray())
+        }
+    }
+
+    private fun findItemSubclassIds(itemSubclasses: Collection<ItemSubclass>): Map<String, Long> {
+        if (itemSubclasses.isEmpty()) return emptyMap()
+        val results = linkedMapOf<String, Long>()
+        itemSubclasses
+            .distinctBy { subclassKey(it.classId, it.subclassId) }
+            .chunked(ITEM_JDBC_CHUNK_SIZE)
+            .forEach { chunk ->
+                val conditions = chunk.joinToString(" OR ") { "(class_id = ? AND subclass_id = ?)" }
+                val params = chunk.flatMap { listOf(it.classId, it.subclassId) }
+                jdbcTemplate.query(
+                    "SELECT internal_id, class_id, subclass_id FROM item_subclass WHERE $conditions",
+                    { rs ->
+                        results[subclassKey(rs.getInt("class_id"), rs.getInt("subclass_id"))] =
+                            rs.getLong("internal_id")
+                    },
+                    *params.toTypedArray(),
+                )
+            }
+        return results
+    }
+
+    private fun upsertItemAppearanceReferences(appearanceReferences: List<ItemAppearanceReference>) {
+        if (appearanceReferences.isEmpty()) return
+        appearanceReferences.chunked(ITEM_JDBC_CHUNK_SIZE).forEach { chunk ->
+            val sql =
+                """
+                INSERT INTO item_appearance_ref (id, href)
+                VALUES ${chunk.joinToString(",") { "(?, ?)" }}
+                ON DUPLICATE KEY UPDATE
+                    href = VALUES(href)
+                """.trimIndent()
+            val params =
+                chunk.flatMap { appearanceReference ->
+                    listOf<Any?>(appearanceReference.id, appearanceReference.href)
+                }
+            jdbcTemplate.update(sql, *params.toTypedArray())
+        }
+    }
+
+    private fun upsertItems(
+        items: List<Item>,
+        localeIds: Map<LocaleNaturalKey, Long>,
+        qualityIds: Map<String, Long>,
+        inventoryTypeIds: Map<String, Long>,
+        bindingIds: Map<String, Long>,
+        itemSubclassIds: Map<String, Long>,
+    ) {
+        items.chunked(ITEM_JDBC_CHUNK_SIZE).forEach { chunk ->
+            val sql =
+                """
+                INSERT INTO `item` (
+                    id,
+                    name_id,
+                    quality_id,
+                    level,
+                    required_level,
+                    media_url,
+                    item_class_id,
+                    item_subclass_id,
+                    inventory_type_id,
+                    binding_id,
+                    purchase_price,
+                    sell_price,
+                    max_count,
+                    is_equippable,
+                    is_stackable,
+                    purchase_quantity
+                ) VALUES ${chunk.joinToString(",") { "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)" }}
+                ON DUPLICATE KEY UPDATE
+                    name_id = VALUES(name_id),
+                    quality_id = VALUES(quality_id),
+                    level = VALUES(level),
+                    required_level = VALUES(required_level),
+                    media_url = VALUES(media_url),
+                    item_class_id = VALUES(item_class_id),
+                    item_subclass_id = VALUES(item_subclass_id),
+                    inventory_type_id = VALUES(inventory_type_id),
+                    binding_id = VALUES(binding_id),
+                    purchase_price = VALUES(purchase_price),
+                    sell_price = VALUES(sell_price),
+                    max_count = VALUES(max_count),
+                    is_equippable = VALUES(is_equippable),
+                    is_stackable = VALUES(is_stackable),
+                    purchase_quantity = VALUES(purchase_quantity)
+                """.trimIndent()
+            val params =
+                chunk.flatMap { item ->
+                    listOf<Any?>(
+                        item.id,
+                        localeIds.getValue(LocaleNaturalKey(LocaleSourceType.ITEM, localeSourceKey(item.id), "name")),
+                        qualityIds.getValue(item.quality.type),
+                        item.level,
+                        item.requiredLevel,
+                        item.mediaUrl,
+                        item.itemClass.id,
+                        itemSubclassIds.getValue(subclassKey(item.itemSubclass.classId, item.itemSubclass.subclassId)),
+                        inventoryTypeIds.getValue(item.inventoryType.type),
+                        item.binding?.type?.let(bindingIds::get),
+                        item.purchasePrice,
+                        item.sellPrice,
+                        item.maxCount,
+                        item.isEquippable,
+                        item.isStackable,
+                        item.purchaseQuantity,
+                    )
+                }
+            jdbcTemplate.update(sql, *params.toTypedArray())
+        }
+    }
+
+    private fun upsertItemAppearanceLinks(items: List<Item>) {
+        val links =
+            items.flatMap { item ->
+                item.appearances.distinctBy(ItemAppearanceReference::id).map { appearance -> item.id to appearance.id }
+            }
+        if (links.isEmpty()) return
+        links.chunked(ITEM_JDBC_CHUNK_SIZE).forEach { chunk ->
+            val sql =
+                """
+                INSERT INTO item_appearance_refs (item_id, appearance_ref_id)
+                VALUES ${chunk.joinToString(",") { "(?, ?)" }}
+                ON DUPLICATE KEY UPDATE
+                    appearance_ref_id = VALUES(appearance_ref_id)
+                """.trimIndent()
+            val params = chunk.flatMap { (itemId, appearanceRefId) -> listOf(itemId, appearanceRefId) }
+            jdbcTemplate.update(sql, *params.toTypedArray())
+        }
+    }
+
+    private fun findNaturalIds(
+        tableName: String,
+        keyColumn: String,
+        keys: Collection<String>,
+    ): Map<String, Long> {
+        if (keys.isEmpty()) return emptyMap()
+        val results = linkedMapOf<String, Long>()
+        keys.distinct().chunked(ITEM_JDBC_CHUNK_SIZE).forEach { chunk ->
+            jdbcTemplate.query(
+                "SELECT internal_id, $keyColumn FROM $tableName WHERE $keyColumn IN (${placeholders(chunk.size)})",
+                { rs -> results[rs.getString(keyColumn)] = rs.getLong("internal_id") },
+                *chunk.toTypedArray(),
+            )
+        }
+        return results
+    }
+
+    private fun placeholders(count: Int): String = List(count) { "?" }.joinToString(",")
+
+    private fun subclassKey(
+        classId: Int,
+        subclassId: Int,
+    ): String = "$classId:$subclassId"
+}
+
+private data class LocaleNaturalKey(
+    val sourceType: String,
+    val sourceKey: String,
+    val sourceField: String,
+)
+
+private data class LocaleRecord(
+    val sourceType: String,
+    val sourceKey: String,
+    val sourceField: String,
+    val locale: LocaleDTO,
+)

--- a/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/ItemJdbcRepository.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/ItemJdbcRepository.kt
@@ -29,23 +29,143 @@ data class ItemPersistenceSummary(
     val itemAppearanceLinksUpserted: Int,
 )
 
+data class ItemSourceDiscovery(
+    val auctionSourceCount: Int,
+    val recipeCraftedSourceCount: Int,
+    val recipeReagentSourceCount: Int,
+    val candidateItemCount: Int,
+    val existingItemCount: Int,
+    val missingItemIds: List<Int>,
+)
+
 @Repository
 class ItemJdbcRepository(
     private val jdbcTemplate: JdbcTemplate,
 ) {
-    fun findDistinctAuctionItemIdsForDate(date: LocalDate): List<Int> =
+    fun findMissingItemIdsForDate(date: LocalDate): ItemSourceDiscovery {
+        val missingItemIds = mutableListOf<Int>()
+        var auctionSourceCount = 0
+        var recipeCraftedSourceCount = 0
+        var recipeReagentSourceCount = 0
+        var candidateItemCount = 0
+        var existingItemCount = 0
+
         jdbcTemplate.query(
             """
-            SELECT DISTINCT item_id
-            FROM hourly_auction_stats
-            WHERE date = ?
-              AND pet_species_id = 0
-              AND item_id > 0
-            ORDER BY item_id
+            WITH auction_source AS (
+                SELECT item_id
+                FROM hourly_auction_stats
+                WHERE date = ?
+                  AND item_id > 0
+                  AND (pet_species_id IS NULL OR pet_species_id IN (-1, 0))
+                GROUP BY item_id
+            ),
+            crafted_source AS (
+                SELECT crafted_item_id AS item_id
+                FROM recipe
+                WHERE crafted_item_id IS NOT NULL
+                GROUP BY crafted_item_id
+            ),
+            reagent_source AS (
+                SELECT item_id
+                FROM recipe_reagent
+                WHERE item_id IS NOT NULL
+                GROUP BY item_id
+            ),
+            source_ids AS (
+                SELECT item_id, 1 AS from_auction, 0 AS from_crafted, 0 AS from_reagent FROM auction_source
+                UNION ALL
+                SELECT item_id, 0 AS from_auction, 1 AS from_crafted, 0 AS from_reagent FROM crafted_source
+                UNION ALL
+                SELECT item_id, 0 AS from_auction, 0 AS from_crafted, 1 AS from_reagent FROM reagent_source
+            ),
+            aggregated AS (
+                SELECT
+                    item_id,
+                    MAX(from_auction) AS from_auction,
+                    MAX(from_crafted) AS from_crafted,
+                    MAX(from_reagent) AS from_reagent
+                FROM source_ids
+                GROUP BY item_id
+            ),
+            classified AS (
+                SELECT
+                    aggregated.item_id,
+                    aggregated.from_auction,
+                    aggregated.from_crafted,
+                    aggregated.from_reagent,
+                    CASE WHEN item.id IS NULL THEN 1 ELSE 0 END AS is_missing
+                FROM aggregated
+                LEFT JOIN `item` item ON item.id = aggregated.item_id
+            ),
+            summary AS (
+                SELECT
+                    COALESCE(SUM(from_auction), 0) AS auction_source_count,
+                    COALESCE(SUM(from_crafted), 0) AS recipe_crafted_source_count,
+                    COALESCE(SUM(from_reagent), 0) AS recipe_reagent_source_count,
+                    COUNT(*) AS candidate_item_count,
+                    COALESCE(SUM(CASE WHEN is_missing = 0 THEN 1 ELSE 0 END), 0) AS existing_item_count,
+                    COALESCE(SUM(is_missing), 0) AS missing_item_count
+                FROM classified
+            )
+            SELECT
+                sort_order,
+                item_id,
+                auction_source_count,
+                recipe_crafted_source_count,
+                recipe_reagent_source_count,
+                candidate_item_count,
+                existing_item_count,
+                missing_item_count
+            FROM (
+                SELECT
+                    0 AS sort_order,
+                    NULL AS item_id,
+                    auction_source_count,
+                    recipe_crafted_source_count,
+                    recipe_reagent_source_count,
+                    candidate_item_count,
+                    existing_item_count,
+                    missing_item_count
+                FROM summary
+                UNION ALL
+                SELECT
+                    1 AS sort_order,
+                    classified.item_id,
+                    NULL AS auction_source_count,
+                    NULL AS recipe_crafted_source_count,
+                    NULL AS recipe_reagent_source_count,
+                    NULL AS candidate_item_count,
+                    NULL AS existing_item_count,
+                    NULL AS missing_item_count
+                FROM classified
+                WHERE is_missing = 1
+            ) result
+            ORDER BY sort_order, item_id
             """.trimIndent(),
-            { rs, _ -> rs.getInt("item_id") },
+            { rs ->
+                if (rs.getInt("sort_order") == 0) {
+                    auctionSourceCount = rs.getInt("auction_source_count")
+                    recipeCraftedSourceCount = rs.getInt("recipe_crafted_source_count")
+                    recipeReagentSourceCount = rs.getInt("recipe_reagent_source_count")
+                    candidateItemCount = rs.getInt("candidate_item_count")
+                    existingItemCount = rs.getInt("existing_item_count")
+                } else {
+                    missingItemIds += rs.getInt("item_id")
+                }
+            },
             date,
         )
+
+        return ItemSourceDiscovery(
+            auctionSourceCount = auctionSourceCount,
+            recipeCraftedSourceCount = recipeCraftedSourceCount,
+            recipeReagentSourceCount = recipeReagentSourceCount,
+            candidateItemCount = candidateItemCount,
+            existingItemCount = existingItemCount,
+            missingItemIds = missingItemIds,
+        )
+    }
 
     fun findExistingItemIds(itemIds: Collection<Int>): Set<Int> {
         if (itemIds.isEmpty()) return emptySet()

--- a/src/main/kotlin/net/jonasmf/auctionengine/schedules/ItemSchedule.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/schedules/ItemSchedule.kt
@@ -1,0 +1,84 @@
+package net.jonasmf.auctionengine.schedules
+
+import net.jonasmf.auctionengine.config.BlizzardApiProperties
+import net.jonasmf.auctionengine.config.WaeS3Properties
+import net.jonasmf.auctionengine.service.ItemSyncService
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.util.concurrent.atomic.AtomicBoolean
+
+@Component
+class ItemSchedule(
+    private val properties: BlizzardApiProperties,
+    private val s3Properties: WaeS3Properties,
+    private val itemSyncService: ItemSyncService,
+    @Value("\${spring.cloud.aws.region.static}")
+    private val deploymentAwsRegion: String,
+) {
+    private val log = LoggerFactory.getLogger(ItemSchedule::class.java)
+    private val syncRunning = AtomicBoolean(false)
+
+    @Scheduled(
+        cron = "\${app.scheduling.item-sync-cron:0 0 * * * *}",
+        zone = "\${app.scheduling.item-sync-zone:GMT+1}",
+    )
+    fun syncItemsOnSchedule() {
+        if (!shouldRunInCurrentDeploymentRegion("scheduled")) return
+        runSync("scheduled")
+    }
+
+    @Scheduled(
+        initialDelayString = "\${app.scheduling.item-sync-startup-delay:PT30S}",
+        fixedDelayString = "\${app.scheduling.item-sync-startup-repeat-delay:P3650D}",
+    )
+    fun syncItemsAfterStartup() {
+        if (!shouldRunInCurrentDeploymentRegion("startup")) return
+        runSync("startup")
+    }
+
+    fun syncItems() {
+        runSync("manual")
+    }
+
+    private fun shouldRunInCurrentDeploymentRegion(trigger: String): Boolean {
+        val expectedAwsRegion = s3Properties.bucketFor(properties.staticDataRegion).bucketRegion
+        if (deploymentAwsRegion != expectedAwsRegion) {
+            log.info(
+                "Skipping {} item sync because deployment AWS region {} does not match static data region {} bucket region {}.",
+                trigger,
+                deploymentAwsRegion,
+                properties.staticDataRegion,
+                expectedAwsRegion,
+            )
+            return false
+        }
+        return true
+    }
+
+    private fun runSync(trigger: String) {
+        if (!syncRunning.compareAndSet(false, true)) {
+            log.info("Skipping {} item sync because sync already running.", trigger)
+            return
+        }
+
+        try {
+            log.info(
+                "Starting {} item sync for region {} (configured regions={})",
+                trigger,
+                properties.staticDataRegion,
+                properties.configuredRegions,
+            )
+            itemSyncService.syncConfiguredStaticDataRegion()
+            log.info(
+                "Completed {} item sync for region {} (configured regions={})",
+                trigger,
+                properties.staticDataRegion,
+                properties.configuredRegions,
+            )
+        } finally {
+            syncRunning.set(false)
+        }
+    }
+}

--- a/src/main/kotlin/net/jonasmf/auctionengine/service/ItemBulkSyncService.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/service/ItemBulkSyncService.kt
@@ -1,0 +1,15 @@
+package net.jonasmf.auctionengine.service
+
+import net.jonasmf.auctionengine.domain.item.Item
+import net.jonasmf.auctionengine.repository.rds.ItemJdbcRepository
+import net.jonasmf.auctionengine.repository.rds.ItemPersistenceSummary
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ItemBulkSyncService(
+    private val itemJdbcRepository: ItemJdbcRepository,
+) {
+    @Transactional
+    fun syncItems(items: List<Item>): ItemPersistenceSummary = itemJdbcRepository.syncItems(items)
+}

--- a/src/main/kotlin/net/jonasmf/auctionengine/service/ItemSyncService.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/service/ItemSyncService.kt
@@ -1,0 +1,150 @@
+package net.jonasmf.auctionengine.service
+
+import net.jonasmf.auctionengine.config.BlizzardApiProperties
+import net.jonasmf.auctionengine.constant.Region
+import net.jonasmf.auctionengine.domain.item.Item
+import net.jonasmf.auctionengine.integration.blizzard.ItemApiClient
+import net.jonasmf.auctionengine.repository.rds.ItemJdbcRepository
+import net.jonasmf.auctionengine.repository.rds.ItemPersistenceSummary
+import net.jonasmf.auctionengine.repository.rds.RecipeRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
+import java.time.Clock
+import java.time.LocalDate
+
+private const val ITEM_FETCH_CONCURRENCY = 20
+
+private data class ItemFetchOutcome(
+    val itemId: Int,
+    val item: Item? = null,
+    val error: Throwable? = null,
+)
+
+data class ItemSyncResult(
+    val region: Region,
+    val auctionSourceCount: Int,
+    val recipeCraftedSourceCount: Int,
+    val recipeReagentSourceCount: Int,
+    val candidateItemCount: Int,
+    val existingItemCount: Int,
+    val missingItemCount: Int,
+    val fetchedItemCount: Int,
+    val itemFetchFailures: Int,
+    val persistenceSummary: ItemPersistenceSummary,
+    val durationMs: Long,
+)
+
+@Service
+class ItemSyncService(
+    private val properties: BlizzardApiProperties,
+    private val itemApiClient: ItemApiClient,
+    private val itemJdbcRepository: ItemJdbcRepository,
+    private val recipeRepository: RecipeRepository,
+    private val itemBulkSyncService: ItemBulkSyncService,
+    private val clock: Clock = Clock.systemDefaultZone(),
+) {
+    private val log = LoggerFactory.getLogger(ItemSyncService::class.java)
+
+    fun syncAllConfiguredRegions(): List<ItemSyncResult> = listOf(syncConfiguredStaticDataRegion())
+
+    fun syncConfiguredStaticDataRegion(): ItemSyncResult = syncRegion(properties.staticDataRegion)
+
+    fun syncRegion(region: Region): ItemSyncResult {
+        val startTime = System.currentTimeMillis()
+        val today = LocalDate.now(clock)
+        log.info("Starting item sync for region {} date={}", region, today)
+
+        val auctionSourceIds = itemJdbcRepository.findDistinctAuctionItemIdsForDate(today)
+        val recipeCraftedIds =
+            runCatching { recipeRepository.findDistinctCraftedItemIds() }
+                .onFailure { error ->
+                    log.warn(
+                        "Recipe crafted item source unavailable for region {}: {}",
+                        region,
+                        error.message ?: "unknown",
+                    )
+                }.getOrDefault(emptyList())
+        val recipeReagentIds =
+            runCatching { recipeRepository.findDistinctReagentItemIds() }
+                .onFailure { error ->
+                    log.warn(
+                        "Recipe reagent item source unavailable for region {}: {}",
+                        region,
+                        error.message ?: "unknown",
+                    )
+                }.getOrDefault(emptyList())
+
+        val candidateIds = (auctionSourceIds + recipeCraftedIds + recipeReagentIds).distinct().sorted()
+        val existingIds = itemJdbcRepository.findExistingItemIds(candidateIds)
+        val missingIds = candidateIds.filterNot(existingIds::contains)
+
+        log.info(
+            "Discovered item sync sources region={} auction={} crafted={} reagents={} candidates={} existing={} missing={}",
+            region,
+            auctionSourceIds.size,
+            recipeCraftedIds.size,
+            recipeReagentIds.size,
+            candidateIds.size,
+            existingIds.size,
+            missingIds.size,
+        )
+
+        val fetchOutcomes =
+            Flux
+                .fromIterable(missingIds)
+                .flatMap({ itemId ->
+                    Mono
+                        .fromCallable { itemApiClient.getById(itemId, region) }
+                        .map<ItemFetchOutcome> { item -> ItemFetchOutcome(itemId = itemId, item = item) }
+                        .subscribeOn(Schedulers.boundedElastic())
+                        .onErrorResume { error -> Mono.just(ItemFetchOutcome(itemId = itemId, error = error)) }
+                }, ITEM_FETCH_CONCURRENCY)
+                .collectList()
+                .block()
+                .orEmpty()
+
+        fetchOutcomes.filter { it.error != null }.forEach { failure ->
+            log.warn(
+                "Skipping item {} for region {} after fetch failure: {}",
+                failure.itemId,
+                region,
+                failure.error?.message ?: failure.error?.javaClass?.simpleName ?: "unknown error",
+            )
+        }
+
+        val fetchedItems = fetchOutcomes.mapNotNull(ItemFetchOutcome::item)
+        val persistenceSummary = itemBulkSyncService.syncItems(fetchedItems)
+
+        return ItemSyncResult(
+            region = region,
+            auctionSourceCount = auctionSourceIds.size,
+            recipeCraftedSourceCount = recipeCraftedIds.size,
+            recipeReagentSourceCount = recipeReagentIds.size,
+            candidateItemCount = candidateIds.size,
+            existingItemCount = existingIds.size,
+            missingItemCount = missingIds.size,
+            fetchedItemCount = fetchedItems.size,
+            itemFetchFailures = fetchOutcomes.count { it.error != null },
+            persistenceSummary = persistenceSummary,
+            durationMs = System.currentTimeMillis() - startTime,
+        ).also { result ->
+            log.info(
+                "Finished item sync for region {} in {}ms auction={} crafted={} reagents={} candidates={} existing={} missing={} fetched={} failed={} persistedItems={}",
+                result.region,
+                result.durationMs,
+                result.auctionSourceCount,
+                result.recipeCraftedSourceCount,
+                result.recipeReagentSourceCount,
+                result.candidateItemCount,
+                result.existingItemCount,
+                result.missingItemCount,
+                result.fetchedItemCount,
+                result.itemFetchFailures,
+                result.persistenceSummary.itemsUpserted,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/net/jonasmf/auctionengine/service/ItemSyncService.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/service/ItemSyncService.kt
@@ -6,7 +6,6 @@ import net.jonasmf.auctionengine.domain.item.Item
 import net.jonasmf.auctionengine.integration.blizzard.ItemApiClient
 import net.jonasmf.auctionengine.repository.rds.ItemJdbcRepository
 import net.jonasmf.auctionengine.repository.rds.ItemPersistenceSummary
-import net.jonasmf.auctionengine.repository.rds.RecipeRepository
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Flux
@@ -15,6 +14,7 @@ import reactor.core.scheduler.Schedulers
 import java.time.Clock
 import java.time.LocalDate
 
+private const val ITEM_FETCH_BATCH_SIZE = 100
 private const val ITEM_FETCH_CONCURRENCY = 20
 
 private data class ItemFetchOutcome(
@@ -33,6 +33,7 @@ data class ItemSyncResult(
     val missingItemCount: Int,
     val fetchedItemCount: Int,
     val itemFetchFailures: Int,
+    val persistedItemCount: Int,
     val persistenceSummary: ItemPersistenceSummary,
     val durationMs: Long,
 )
@@ -42,7 +43,6 @@ class ItemSyncService(
     private val properties: BlizzardApiProperties,
     private val itemApiClient: ItemApiClient,
     private val itemJdbcRepository: ItemJdbcRepository,
-    private val recipeRepository: RecipeRepository,
     private val itemBulkSyncService: ItemBulkSyncService,
     private val clock: Clock = Clock.systemDefaultZone(),
 ) {
@@ -57,82 +57,156 @@ class ItemSyncService(
         val today = LocalDate.now(clock)
         log.info("Starting item sync for region {} date={}", region, today)
 
-        val auctionSourceIds = itemJdbcRepository.findDistinctAuctionItemIdsForDate(today)
-        val recipeCraftedIds =
-            runCatching { recipeRepository.findDistinctCraftedItemIds() }
-                .onFailure { error ->
-                    log.warn(
-                        "Recipe crafted item source unavailable for region {}: {}",
-                        region,
-                        error.message ?: "unknown",
-                    )
-                }.getOrDefault(emptyList())
-        val recipeReagentIds =
-            runCatching { recipeRepository.findDistinctReagentItemIds() }
-                .onFailure { error ->
-                    log.warn(
-                        "Recipe reagent item source unavailable for region {}: {}",
-                        region,
-                        error.message ?: "unknown",
-                    )
-                }.getOrDefault(emptyList())
-
-        val candidateIds = (auctionSourceIds + recipeCraftedIds + recipeReagentIds).distinct().sorted()
-        val existingIds = itemJdbcRepository.findExistingItemIds(candidateIds)
-        val missingIds = candidateIds.filterNot(existingIds::contains)
+        val discovery = itemJdbcRepository.findMissingItemIdsForDate(today)
+        val missingIds = discovery.missingItemIds
 
         log.info(
             "Discovered item sync sources region={} auction={} crafted={} reagents={} candidates={} existing={} missing={}",
             region,
-            auctionSourceIds.size,
-            recipeCraftedIds.size,
-            recipeReagentIds.size,
-            candidateIds.size,
-            existingIds.size,
+            discovery.auctionSourceCount,
+            discovery.recipeCraftedSourceCount,
+            discovery.recipeReagentSourceCount,
+            discovery.candidateItemCount,
+            discovery.existingItemCount,
             missingIds.size,
         )
 
-        val fetchOutcomes =
-            Flux
-                .fromIterable(missingIds)
-                .flatMap({ itemId ->
-                    Mono
-                        .fromCallable { itemApiClient.getById(itemId, region) }
-                        .map<ItemFetchOutcome> { item -> ItemFetchOutcome(itemId = itemId, item = item) }
-                        .subscribeOn(Schedulers.boundedElastic())
-                        .onErrorResume { error -> Mono.just(ItemFetchOutcome(itemId = itemId, error = error)) }
-                }, ITEM_FETCH_CONCURRENCY)
-                .collectList()
-                .block()
-                .orEmpty()
+        val missingIdBatches = missingIds.chunked(ITEM_FETCH_BATCH_SIZE)
+        val allFetchedIds = mutableListOf<Int>()
+        var totalFetchFailures = 0
+        var totalFetchedItems = 0
+        var totalLocalesUpserted = 0
+        var totalItemQualitiesUpserted = 0
+        var totalInventoryTypesUpserted = 0
+        var totalItemBindingsUpserted = 0
+        var totalItemClassesUpserted = 0
+        var totalItemSubclassesUpserted = 0
+        var totalItemAppearanceReferencesUpserted = 0
+        var totalItemsUpserted = 0
+        var totalItemAppearanceLinksUpserted = 0
 
-        fetchOutcomes.filter { it.error != null }.forEach { failure ->
-            log.warn(
-                "Skipping item {} for region {} after fetch failure: {}",
-                failure.itemId,
+        missingIdBatches.forEachIndexed { index, batchIds ->
+            val batchNumber = index + 1
+            log.info(
+                "Starting item fetch batch region={} batch={}/{} batchSize={} completedBefore={}/{}",
                 region,
-                failure.error?.message ?: failure.error?.javaClass?.simpleName ?: "unknown error",
+                batchNumber,
+                missingIdBatches.size,
+                batchIds.size,
+                index * ITEM_FETCH_BATCH_SIZE,
+                missingIds.size,
             )
+
+            val batchOutcomes =
+                Flux
+                    .fromIterable(batchIds)
+                    .flatMap({ itemId ->
+                        Mono
+                            .fromCallable { itemApiClient.getById(itemId, region) }
+                            .map<ItemFetchOutcome> { item -> ItemFetchOutcome(itemId = itemId, item = item) }
+                            .subscribeOn(Schedulers.boundedElastic())
+                            .onErrorResume { error -> Mono.just(ItemFetchOutcome(itemId = itemId, error = error)) }
+                    }, ITEM_FETCH_CONCURRENCY)
+                    .collectList()
+                    .block()
+                    .orEmpty()
+
+            val batchSucceeded = batchOutcomes.count { it.error == null }
+            val batchFailed = batchOutcomes.size - batchSucceeded
+            val completedAfterBatch = index * ITEM_FETCH_BATCH_SIZE + batchOutcomes.size
+            log.info(
+                "Completed item fetch batch region={} batch={}/{} completed={}/{} succeeded={} failed={}",
+                region,
+                batchNumber,
+                missingIdBatches.size,
+                completedAfterBatch,
+                missingIds.size,
+                batchSucceeded,
+                batchFailed,
+            )
+
+            batchOutcomes.filter { it.error != null }.forEach { failure ->
+                log.warn(
+                    "Skipping item {} for region {} after fetch failure: {}",
+                    failure.itemId,
+                    region,
+                    failure.error?.message ?: failure.error?.javaClass?.simpleName ?: "unknown error",
+                )
+            }
+
+            val batchItems = batchOutcomes.mapNotNull(ItemFetchOutcome::item)
+            if (batchItems.isNotEmpty()) {
+                log.info(
+                    "Persisting item batch region={} batch={}/{} itemCount={}",
+                    region,
+                    batchNumber,
+                    missingIdBatches.size,
+                    batchItems.size,
+                )
+                val batchPersistenceSummary = itemBulkSyncService.syncItems(batchItems)
+                totalLocalesUpserted += batchPersistenceSummary.localesUpserted
+                totalItemQualitiesUpserted += batchPersistenceSummary.itemQualitiesUpserted
+                totalInventoryTypesUpserted += batchPersistenceSummary.inventoryTypesUpserted
+                totalItemBindingsUpserted += batchPersistenceSummary.itemBindingsUpserted
+                totalItemClassesUpserted += batchPersistenceSummary.itemClassesUpserted
+                totalItemSubclassesUpserted += batchPersistenceSummary.itemSubclassesUpserted
+                totalItemAppearanceReferencesUpserted += batchPersistenceSummary.itemAppearanceReferencesUpserted
+                totalItemsUpserted += batchPersistenceSummary.itemsUpserted
+                totalItemAppearanceLinksUpserted += batchPersistenceSummary.itemAppearanceLinksUpserted
+                totalFetchedItems += batchItems.size
+                allFetchedIds += batchItems.map(Item::id)
+                log.info(
+                    "Persisted item batch region={} batch={}/{} itemCount={} attemptedItemUpserts={}",
+                    region,
+                    batchNumber,
+                    missingIdBatches.size,
+                    batchItems.size,
+                    batchPersistenceSummary.itemsUpserted,
+                )
+            }
+
+            totalFetchFailures += batchFailed
         }
 
-        val fetchedItems = fetchOutcomes.mapNotNull(ItemFetchOutcome::item)
-        val persistenceSummary = itemBulkSyncService.syncItems(fetchedItems)
+        val persistenceSummary =
+            ItemPersistenceSummary(
+                localesUpserted = totalLocalesUpserted,
+                itemQualitiesUpserted = totalItemQualitiesUpserted,
+                inventoryTypesUpserted = totalInventoryTypesUpserted,
+                itemBindingsUpserted = totalItemBindingsUpserted,
+                itemClassesUpserted = totalItemClassesUpserted,
+                itemSubclassesUpserted = totalItemSubclassesUpserted,
+                itemAppearanceReferencesUpserted = totalItemAppearanceReferencesUpserted,
+                itemsUpserted = totalItemsUpserted,
+                itemAppearanceLinksUpserted = totalItemAppearanceLinksUpserted,
+            )
+        val persistedItemCount = itemJdbcRepository.findExistingItemIds(allFetchedIds).size
 
         return ItemSyncResult(
             region = region,
-            auctionSourceCount = auctionSourceIds.size,
-            recipeCraftedSourceCount = recipeCraftedIds.size,
-            recipeReagentSourceCount = recipeReagentIds.size,
-            candidateItemCount = candidateIds.size,
-            existingItemCount = existingIds.size,
+            auctionSourceCount = discovery.auctionSourceCount,
+            recipeCraftedSourceCount = discovery.recipeCraftedSourceCount,
+            recipeReagentSourceCount = discovery.recipeReagentSourceCount,
+            candidateItemCount = discovery.candidateItemCount,
+            existingItemCount = discovery.existingItemCount,
             missingItemCount = missingIds.size,
-            fetchedItemCount = fetchedItems.size,
-            itemFetchFailures = fetchOutcomes.count { it.error != null },
+            fetchedItemCount = totalFetchedItems,
+            itemFetchFailures = totalFetchFailures,
+            persistedItemCount = persistedItemCount,
             persistenceSummary = persistenceSummary,
             durationMs = System.currentTimeMillis() - startTime,
         ).also { result ->
+            if (result.persistedItemCount != result.fetchedItemCount) {
+                log.warn(
+                    "Item sync persistence mismatch for region {} fetched={} persisted={} attemptedUpserts={}",
+                    result.region,
+                    result.fetchedItemCount,
+                    result.persistedItemCount,
+                    result.persistenceSummary.itemsUpserted,
+                )
+            }
             log.info(
-                "Finished item sync for region {} in {}ms auction={} crafted={} reagents={} candidates={} existing={} missing={} fetched={} failed={} persistedItems={}",
+                "Finished item sync for region {} in {}ms auction={} crafted={} reagents={} candidates={} existing={} missing={} fetched={} failed={} persistedItems={} attemptedItemUpserts={}",
                 result.region,
                 result.durationMs,
                 result.auctionSourceCount,
@@ -143,6 +217,7 @@ class ItemSyncService(
                 result.missingItemCount,
                 result.fetchedItemCount,
                 result.itemFetchFailures,
+                result.persistedItemCount,
                 result.persistenceSummary.itemsUpserted,
             )
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,6 +50,10 @@ app:
   scheduling:
     enabled: true
     initial-delay: PT30S
+    item-sync-cron: "0 0 * * * *"
+    item-sync-zone: GMT+1
+    item-sync-startup-delay: PT30S
+    item-sync-startup-repeat-delay: P3650D
     profession-recipe-sync-cron: "0 0 8 ? * WED"
     profession-recipe-sync-zone: GMT+1
     profession-recipe-sync-startup-delay: PT30S

--- a/src/main/resources/db/migration/V10__add_item_sync_source_indexes.sql
+++ b/src/main/resources/db/migration/V10__add_item_sync_source_indexes.sql
@@ -1,0 +1,60 @@
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS ensure_index_if_table_exists$$
+
+CREATE PROCEDURE ensure_index_if_table_exists(
+    IN in_table_name VARCHAR(64),
+    IN in_index_name VARCHAR(64),
+    IN in_index_columns VARCHAR(255)
+)
+ensure_index_proc: BEGIN
+    DECLARE target_table_exists INT DEFAULT 0;
+    DECLARE existing_index_name VARCHAR(64) DEFAULT NULL;
+
+    SELECT COUNT(*)
+    INTO target_table_exists
+    FROM information_schema.TABLES
+    WHERE table_schema = DATABASE()
+      AND table_name = in_table_name;
+
+    IF target_table_exists = 0 THEN
+        LEAVE ensure_index_proc;
+    END IF;
+
+    SELECT index_name
+    INTO existing_index_name
+    FROM information_schema.STATISTICS
+    WHERE table_schema = DATABASE()
+      AND table_name = in_table_name
+      AND index_name = in_index_name
+    LIMIT 1;
+
+    IF existing_index_name IS NULL THEN
+        SET @create_index_sql = CONCAT(
+            'ALTER TABLE `', in_table_name, '` ADD INDEX `', in_index_name, '` ', in_index_columns
+        );
+        PREPARE create_index_stmt FROM @create_index_sql;
+        EXECUTE create_index_stmt;
+        DEALLOCATE PREPARE create_index_stmt;
+    END IF;
+END$$
+
+DELIMITER ;
+
+CALL ensure_index_if_table_exists(
+    'hourly_auction_stats',
+    'idx_hourly_auction_stats_date_pet_species_item_id',
+    '(date, pet_species_id, item_id)'
+);
+CALL ensure_index_if_table_exists(
+    'recipe',
+    'idx_recipe_crafted_item_id',
+    '(crafted_item_id)'
+);
+CALL ensure_index_if_table_exists(
+    'recipe_reagent',
+    'idx_recipe_reagent_item_id',
+    '(item_id)'
+);
+
+DROP PROCEDURE ensure_index_if_table_exists;

--- a/src/main/resources/db/migration/V8__migrate_item_locale_fks_to_locale.sql
+++ b/src/main/resources/db/migration/V8__migrate_item_locale_fks_to_locale.sql
@@ -1,0 +1,88 @@
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS migrate_item_locale_fk$$
+
+CREATE PROCEDURE migrate_item_locale_fk(
+    IN in_table_name VARCHAR(64),
+    IN in_column_name VARCHAR(64),
+    IN in_fk_name VARCHAR(64)
+)
+BEGIN
+    DECLARE has_locale_table INT DEFAULT 0;
+    DECLARE has_target_column INT DEFAULT 0;
+    DECLARE old_fk_name VARCHAR(64) DEFAULT NULL;
+    DECLARE current_fk_name VARCHAR(64) DEFAULT NULL;
+
+    SELECT COUNT(*)
+    INTO has_locale_table
+    FROM information_schema.TABLES
+    WHERE table_schema = DATABASE()
+      AND table_name = 'locale';
+
+    SELECT COUNT(*)
+    INTO has_target_column
+    FROM information_schema.COLUMNS
+    WHERE table_schema = DATABASE()
+      AND table_name = in_table_name
+      AND column_name = in_column_name;
+
+    IF has_locale_table > 0 AND has_target_column > 0 THEN
+        item_locale_dbo_fk_loop: LOOP
+            SET old_fk_name = NULL;
+
+            SELECT constraint_name
+            INTO old_fk_name
+            FROM information_schema.KEY_COLUMN_USAGE
+            WHERE table_schema = DATABASE()
+              AND table_name = in_table_name
+              AND column_name = in_column_name
+              AND referenced_table_name = 'locale_dbo'
+            LIMIT 1;
+
+            IF old_fk_name IS NULL THEN
+                LEAVE item_locale_dbo_fk_loop;
+            END IF;
+
+            SET @drop_old_fk_sql = CONCAT(
+                'ALTER TABLE `', in_table_name, '` DROP FOREIGN KEY `', old_fk_name, '`'
+            );
+            PREPARE drop_old_fk_stmt FROM @drop_old_fk_sql;
+            EXECUTE drop_old_fk_stmt;
+            DEALLOCATE PREPARE drop_old_fk_stmt;
+        END LOOP;
+
+        SET current_fk_name = NULL;
+
+        SELECT constraint_name
+        INTO current_fk_name
+        FROM information_schema.KEY_COLUMN_USAGE
+        WHERE table_schema = DATABASE()
+          AND table_name = in_table_name
+          AND column_name = in_column_name
+          AND referenced_table_name = 'locale'
+        LIMIT 1;
+
+        IF current_fk_name IS NULL THEN
+            SET @add_locale_fk_sql = CONCAT(
+                'ALTER TABLE `', in_table_name, '` ',
+                'ADD CONSTRAINT `', in_fk_name, '` ',
+                'FOREIGN KEY (`', in_column_name, '`) REFERENCES `locale` (`id`)'
+            );
+            PREPARE add_locale_fk_stmt FROM @add_locale_fk_sql;
+            EXECUTE add_locale_fk_stmt;
+            DEALLOCATE PREPARE add_locale_fk_stmt;
+        END IF;
+    END IF;
+END$$
+
+DELIMITER ;
+
+CALL migrate_item_locale_fk('item_quality', 'name_id', 'fk_item_quality_name_locale');
+CALL migrate_item_locale_fk('inventory_type', 'name_id', 'fk_inventory_type_name_locale');
+CALL migrate_item_locale_fk('item_binding', 'name_id', 'fk_item_binding_name_locale');
+CALL migrate_item_locale_fk('item_class', 'name_id', 'fk_item_class_name_locale');
+CALL migrate_item_locale_fk('item_subclass', 'display_name_id', 'fk_item_subclass_display_name_locale');
+CALL migrate_item_locale_fk('item_summary', 'name_id', 'fk_item_summary_name_locale');
+CALL migrate_item_locale_fk('item', 'name_id', 'fk_item_name_locale');
+
+DROP PROCEDURE migrate_item_locale_fk;

--- a/src/main/resources/db/migration/V9__drop_item_class_unique_constraint.sql
+++ b/src/main/resources/db/migration/V9__drop_item_class_unique_constraint.sql
@@ -1,0 +1,95 @@
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS drop_unique_indexes_for_column$$
+
+CREATE PROCEDURE drop_unique_indexes_for_column(
+    IN in_table_name VARCHAR(64),
+    IN in_column_name VARCHAR(64)
+)
+drop_unique_indexes_proc: BEGIN
+    DECLARE target_table_exists INT DEFAULT 0;
+    DECLARE target_index_name VARCHAR(64) DEFAULT NULL;
+
+    SELECT COUNT(*)
+    INTO target_table_exists
+    FROM information_schema.TABLES
+    WHERE table_schema = DATABASE()
+      AND table_name = in_table_name;
+
+    IF target_table_exists = 0 THEN
+        LEAVE drop_unique_indexes_proc;
+    END IF;
+
+    drop_index_loop: LOOP
+        SET target_index_name = NULL;
+
+        SELECT index_name
+        INTO target_index_name
+        FROM information_schema.STATISTICS
+        WHERE table_schema = DATABASE()
+          AND table_name = in_table_name
+          AND column_name = in_column_name
+          AND non_unique = 0
+          AND index_name <> 'PRIMARY'
+        LIMIT 1;
+
+        IF target_index_name IS NULL THEN
+            LEAVE drop_index_loop;
+        END IF;
+
+        SET @drop_index_sql = CONCAT(
+            'ALTER TABLE `', in_table_name, '` DROP INDEX `', target_index_name, '`'
+        );
+        PREPARE drop_index_stmt FROM @drop_index_sql;
+        EXECUTE drop_index_stmt;
+        DEALLOCATE PREPARE drop_index_stmt;
+    END LOOP;
+END$$
+
+DROP PROCEDURE IF EXISTS ensure_non_unique_index_for_column$$
+
+CREATE PROCEDURE ensure_non_unique_index_for_column(
+    IN in_table_name VARCHAR(64),
+    IN in_column_name VARCHAR(64),
+    IN in_index_name VARCHAR(64)
+)
+ensure_non_unique_index_proc: BEGIN
+    DECLARE target_table_exists INT DEFAULT 0;
+    DECLARE existing_index_name VARCHAR(64) DEFAULT NULL;
+
+    SELECT COUNT(*)
+    INTO target_table_exists
+    FROM information_schema.TABLES
+    WHERE table_schema = DATABASE()
+      AND table_name = in_table_name;
+
+    IF target_table_exists = 0 THEN
+        LEAVE ensure_non_unique_index_proc;
+    END IF;
+
+    SELECT index_name
+    INTO existing_index_name
+    FROM information_schema.STATISTICS
+    WHERE table_schema = DATABASE()
+      AND table_name = in_table_name
+      AND column_name = in_column_name
+      AND index_name = in_index_name
+    LIMIT 1;
+
+    IF existing_index_name IS NULL THEN
+        SET @create_index_sql = CONCAT(
+            'ALTER TABLE `', in_table_name, '` ADD INDEX `', in_index_name, '` (`', in_column_name, '`)'
+        );
+        PREPARE create_index_stmt FROM @create_index_sql;
+        EXECUTE create_index_stmt;
+        DEALLOCATE PREPARE create_index_stmt;
+    END IF;
+END$$
+
+DELIMITER ;
+
+CALL ensure_non_unique_index_for_column('item', 'item_class_id', 'idx_item_item_class_id');
+CALL drop_unique_indexes_for_column('item', 'item_class_id');
+
+DROP PROCEDURE ensure_non_unique_index_for_column;
+DROP PROCEDURE drop_unique_indexes_for_column;

--- a/src/test/kotlin/net/jonasmf/auctionengine/integration/blizzard/ItemApiClientTest.kt
+++ b/src/test/kotlin/net/jonasmf/auctionengine/integration/blizzard/ItemApiClientTest.kt
@@ -1,0 +1,46 @@
+package net.jonasmf.auctionengine.integration.blizzard
+
+import net.jonasmf.auctionengine.constant.Region
+import net.jonasmf.auctionengine.testsupport.BlizzardApiCallSupport.Companion.buildWebClient
+import net.jonasmf.auctionengine.testsupport.BlizzardApiCallSupport.Companion.createSupport
+import net.jonasmf.auctionengine.testsupport.BlizzardApiCallSupport.Companion.okJson
+import net.jonasmf.auctionengine.testsupport.loadFixture
+import org.junit.jupiter.api.Test
+import org.springframework.web.reactive.function.client.ClientRequest
+import org.springframework.web.reactive.function.client.ClientResponse
+import reactor.core.publisher.Mono
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class ItemApiClientTest {
+    @Test
+    fun `getById returns item details from fixtures`() {
+        val webClient = buildWebClient { handleRequest(it) }
+        val client = ItemApiClient(createSupport(webClient))
+        val itemIds = listOf(171374, 171388, 171391, 171412, 171428, 171441, 171828, 172230, 180733, 251285)
+
+        val items = itemIds.map { itemId -> client.getById(itemId, Region.Europe) }
+
+        assertEquals(itemIds, items.map { it.id })
+        assertEquals("ON_EQUIP", items.first().binding?.type)
+        assertEquals(
+            "Armor",
+            items
+                .first()
+                .itemClass.name.en_US,
+        )
+        assertNotNull(items[1].binding)
+        assertEquals(true, items[5].isStackable)
+        assertEquals(true, items[0].appearances.isNotEmpty())
+    }
+
+    private fun itemById(id: Int): String = loadFixture(this, "/blizzard/item/$id-response.json")
+
+    private fun handleRequest(request: ClientRequest): Mono<ClientResponse> {
+        val path = request.url().path
+        return when {
+            path.matches(Regex(".*/item/\\d+$")) -> okJson(itemById(path.substringAfterLast('/').toInt()))
+            else -> error("Unexpected request: ${request.method()} ${request.url()}")
+        }
+    }
+}

--- a/src/test/kotlin/net/jonasmf/auctionengine/mapper/BlizzardMapperTest.kt
+++ b/src/test/kotlin/net/jonasmf/auctionengine/mapper/BlizzardMapperTest.kt
@@ -188,6 +188,8 @@ class BlizzardMapperTest {
         assertEquals(item.id.toString(), itemDbo.name.sourceKey)
         assertEquals("item_class", itemDbo.itemClass.name.sourceType)
         assertEquals("item_subclass", itemDbo.itemSubclass.displayName.sourceType)
+        assertEquals("item_binding", itemDbo.binding?.name?.sourceType)
+        assertEquals("ON_EQUIP", roundTripItem.binding?.type)
         assertEquals("inventory_type", itemAppearanceDbo.slot.name.sourceType)
         assertEquals(4, itemClass.id)
         assertEquals(4, itemSubclass.subclassId)

--- a/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionHousePriceRepositoryTest.kt
+++ b/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionHousePriceRepositoryTest.kt
@@ -89,6 +89,7 @@ class AuctionHousePriceRepositoryTest : IntegrationTestBase() {
             mapOf(
                 "idx_hourly_auction_stats_connected_realm_id_date" to "connected_realm_id,date",
                 "idx_hourly_auction_stats_connected_realm_id_item_id_date" to "connected_realm_id,item_id,date",
+                "idx_hourly_auction_stats_date_pet_species_item_id" to "date,pet_species_id,item_id",
             ),
             secondaryIndexes,
         )

--- a/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/ItemJdbcRepositoryTest.kt
+++ b/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/ItemJdbcRepositoryTest.kt
@@ -1,0 +1,182 @@
+package net.jonasmf.auctionengine.repository.rds
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import net.jonasmf.auctionengine.config.IntegrationTestBase
+import net.jonasmf.auctionengine.constant.GameBuildVersion
+import net.jonasmf.auctionengine.dbo.rds.realm.AuctionHouse
+import net.jonasmf.auctionengine.dbo.rds.realm.ConnectedRealm
+import net.jonasmf.auctionengine.dto.item.ItemDTO
+import net.jonasmf.auctionengine.mapper.toDomain
+import net.jonasmf.auctionengine.testsupport.loadFixture
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.jdbc.core.JdbcTemplate
+import java.time.LocalDate
+import java.time.ZonedDateTime
+
+class ItemJdbcRepositoryTest : IntegrationTestBase() {
+    @Autowired
+    lateinit var itemJdbcRepository: ItemJdbcRepository
+
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    @Autowired
+    lateinit var connectedRealmRepository: ConnectedRealmRepository
+
+    private val mapper = jacksonObjectMapper()
+
+    @Test
+    fun `syncItems upserts grouped item graph without duplicates on rerun`() {
+        val firstItem = loadItem(171374)
+        val secondItem = loadItem(171391)
+
+        itemJdbcRepository.syncItems(listOf(firstItem, secondItem))
+        itemJdbcRepository.syncItems(listOf(firstItem, secondItem))
+
+        assertEquals(2, countRows("`item`"))
+        assertEquals(1, countRows("item_quality"))
+        assertEquals(2, countRows("inventory_type"))
+        assertEquals(1, countRows("item_binding"))
+        assertEquals(1, countRows("item_class"))
+        assertEquals(2, countRows("item_subclass"))
+        assertEquals(2, countRows("item_appearance_ref"))
+        assertEquals(2, countRows("item_appearance_refs"))
+        assertEquals(
+            9,
+            countRowsWhere(
+                "locale",
+                "source_type IN ('item','item_quality','item_binding','item_class','item_subclass','inventory_type')",
+            ),
+        )
+    }
+
+    @Test
+    fun `findDistinctAuctionItemIdsForDate only returns todays non-pet item ids`() {
+        val today = LocalDate.of(2026, 4, 14)
+        val yesterday = today.minusDays(1)
+        connectedRealmRepository.save(
+            ConnectedRealm(
+                id = 1,
+                auctionHouse =
+                    AuctionHouse(
+                        lastModified = null,
+                        lastRequested = null,
+                        nextUpdate = ZonedDateTime.now(),
+                        lowestDelay = 0L,
+                        highestDelay = 0L,
+                        tsmFile = null,
+                        statsFile = null,
+                        auctionFile = null,
+                    ),
+            ),
+        )
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO hourly_auction_stats (
+                connected_realm_id,
+                ah_type_id,
+                item_id,
+                date,
+                pet_species_id,
+                modifier_key,
+                bonus_key
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """.trimIndent(),
+            1,
+            GameBuildVersion.RETAIL.ordinal,
+            1001,
+            today,
+            0,
+            "",
+            "",
+        )
+        jdbcTemplate.update(
+            """
+            INSERT INTO hourly_auction_stats (
+                connected_realm_id,
+                ah_type_id,
+                item_id,
+                date,
+                pet_species_id,
+                modifier_key,
+                bonus_key
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """.trimIndent(),
+            1,
+            GameBuildVersion.RETAIL.ordinal,
+            1001,
+            today,
+            0,
+            "mod",
+            "bonus",
+        )
+        jdbcTemplate.update(
+            """
+            INSERT INTO hourly_auction_stats (
+                connected_realm_id,
+                ah_type_id,
+                item_id,
+                date,
+                pet_species_id,
+                modifier_key,
+                bonus_key
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """.trimIndent(),
+            1,
+            GameBuildVersion.RETAIL.ordinal,
+            1002,
+            yesterday,
+            0,
+            "",
+            "",
+        )
+        jdbcTemplate.update(
+            """
+            INSERT INTO hourly_auction_stats (
+                connected_realm_id,
+                ah_type_id,
+                item_id,
+                date,
+                pet_species_id,
+                modifier_key,
+                bonus_key
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """.trimIndent(),
+            1,
+            GameBuildVersion.RETAIL.ordinal,
+            2000,
+            today,
+            55,
+            "",
+            "",
+        )
+
+        val itemIds = itemJdbcRepository.findDistinctAuctionItemIdsForDate(today)
+
+        assertEquals(listOf(1001), itemIds)
+    }
+
+    @Test
+    fun `findExistingItemIds returns only ids already in canonical item table`() {
+        itemJdbcRepository.syncItems(listOf(loadItem(171374), loadItem(171391)))
+
+        val existingIds = itemJdbcRepository.findExistingItemIds(listOf(171374, 171391, 999999))
+
+        assertEquals(setOf(171374, 171391), existingIds)
+    }
+
+    private fun loadItem(itemId: Int) =
+        mapper.readValue<ItemDTO>(loadFixture(this, "/blizzard/item/$itemId-response.json")).toDomain()
+
+    private fun countRows(tableName: String): Int =
+        jdbcTemplate.queryForObject("SELECT COUNT(*) FROM $tableName", Int::class.java)!!
+
+    private fun countRowsWhere(
+        tableName: String,
+        condition: String,
+    ): Int = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM $tableName WHERE $condition", Int::class.java)!!
+}

--- a/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/ItemJdbcRepositoryTest.kt
+++ b/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/ItemJdbcRepositoryTest.kt
@@ -54,7 +54,7 @@ class ItemJdbcRepositoryTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `findDistinctAuctionItemIdsForDate only returns todays non-pet item ids`() {
+    fun `findMissingItemIdsForDate returns combined missing ids without loading existing ids in memory`() {
         val today = LocalDate.of(2026, 4, 14)
         val yesterday = today.minusDays(1)
         connectedRealmRepository.save(
@@ -90,7 +90,7 @@ class ItemJdbcRepositoryTest : IntegrationTestBase() {
             GameBuildVersion.RETAIL.ordinal,
             1001,
             today,
-            0,
+            -1,
             "",
             "",
         )
@@ -110,7 +110,7 @@ class ItemJdbcRepositoryTest : IntegrationTestBase() {
             GameBuildVersion.RETAIL.ordinal,
             1001,
             today,
-            0,
+            -1,
             "mod",
             "bonus",
         )
@@ -130,7 +130,7 @@ class ItemJdbcRepositoryTest : IntegrationTestBase() {
             GameBuildVersion.RETAIL.ordinal,
             1002,
             yesterday,
-            0,
+            -1,
             "",
             "",
         )
@@ -154,10 +154,32 @@ class ItemJdbcRepositoryTest : IntegrationTestBase() {
             "",
             "",
         )
+        jdbcTemplate.update(
+            "INSERT INTO recipe (id, crafted_item_id) VALUES (?, ?)",
+            5001,
+            3001,
+        )
+        jdbcTemplate.update(
+            "INSERT INTO recipe (id, crafted_item_id) VALUES (?, ?)",
+            5002,
+            171374,
+        )
+        jdbcTemplate.update(
+            "INSERT INTO recipe_reagent (internal_id, item_id, quantity) VALUES (?, ?, ?)",
+            7001,
+            4001,
+            2,
+        )
+        itemJdbcRepository.syncItems(listOf(loadItem(171374)))
 
-        val itemIds = itemJdbcRepository.findDistinctAuctionItemIdsForDate(today)
+        val discovery = itemJdbcRepository.findMissingItemIdsForDate(today)
 
-        assertEquals(listOf(1001), itemIds)
+        assertEquals(1, discovery.auctionSourceCount)
+        assertEquals(2, discovery.recipeCraftedSourceCount)
+        assertEquals(1, discovery.recipeReagentSourceCount)
+        assertEquals(4, discovery.candidateItemCount)
+        assertEquals(1, discovery.existingItemCount)
+        assertEquals(listOf(1001, 3001, 4001), discovery.missingItemIds)
     }
 
     @Test

--- a/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/ItemJdbcRepositoryTest.kt
+++ b/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/ItemJdbcRepositoryTest.kt
@@ -13,8 +13,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
+import java.time.Instant
 import java.time.LocalDate
-import java.time.ZonedDateTime
 
 class ItemJdbcRepositoryTest : IntegrationTestBase() {
     @Autowired
@@ -64,7 +64,7 @@ class ItemJdbcRepositoryTest : IntegrationTestBase() {
                     AuctionHouse(
                         lastModified = null,
                         lastRequested = null,
-                        nextUpdate = ZonedDateTime.now(),
+                        nextUpdate = Instant.now(),
                         lowestDelay = 0L,
                         highestDelay = 0L,
                         tsmFile = null,

--- a/src/test/kotlin/net/jonasmf/auctionengine/schedules/ItemScheduleTest.kt
+++ b/src/test/kotlin/net/jonasmf/auctionengine/schedules/ItemScheduleTest.kt
@@ -1,0 +1,139 @@
+package net.jonasmf.auctionengine.schedules
+
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.jonasmf.auctionengine.config.BlizzardApiProperties
+import net.jonasmf.auctionengine.config.BucketConfig
+import net.jonasmf.auctionengine.config.WaeS3Properties
+import net.jonasmf.auctionengine.constant.Region
+import net.jonasmf.auctionengine.repository.rds.ItemPersistenceSummary
+import net.jonasmf.auctionengine.service.ItemSyncResult
+import net.jonasmf.auctionengine.service.ItemSyncService
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class ItemScheduleTest {
+    private val properties =
+        BlizzardApiProperties(
+            baseUrl = "https://example.test/",
+            tokenUrl = "https://example.test/token",
+            clientId = "id",
+            clientSecret = "secret",
+            regions = listOf(Region.Europe, Region.Taiwan),
+        )
+    private val s3Properties =
+        WaeS3Properties(
+            buckets =
+                mapOf(
+                    "europe" to BucketConfig("wah-data-eu", "eu-west-1"),
+                    "northamerica" to BucketConfig("wah-data-us", "us-west-1"),
+                    "korea" to BucketConfig("wah-data-as", "ap-northeast-2"),
+                    "taiwan" to BucketConfig("wah-data-as", "ap-northeast-2"),
+                ),
+        )
+
+    @Test
+    fun `syncItems skips and logs when sync already running`() {
+        val service = mockk<ItemSyncService>()
+        val started = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val executor = Executors.newSingleThreadExecutor()
+        val listAppender = attachAppender()
+
+        every { service.syncConfiguredStaticDataRegion() } answers {
+            started.countDown()
+            release.await(5, TimeUnit.SECONDS)
+            syncResult()
+        }
+
+        try {
+            val schedule = ItemSchedule(properties, s3Properties, service, "eu-west-1")
+            val future = executor.submit<Unit> { schedule.syncItems() }
+            assertTrue(started.await(5, TimeUnit.SECONDS))
+
+            schedule.syncItems()
+
+            val messages = listAppender.list.map(ILoggingEvent::getFormattedMessage)
+            assertTrue(messages.any { it.contains("Skipping manual item sync because sync already running.") })
+            verify(exactly = 1) { service.syncConfiguredStaticDataRegion() }
+
+            release.countDown()
+            future.get(5, TimeUnit.SECONDS)
+        } finally {
+            release.countDown()
+            executor.shutdownNow()
+            detachAppender(listAppender)
+        }
+    }
+
+    @Test
+    fun `scheduled sync skips when deployment region does not match static data region`() {
+        val service = mockk<ItemSyncService>()
+        val listAppender = attachAppender()
+        val schedule = ItemSchedule(properties, s3Properties, service, "us-west-1")
+
+        try {
+            schedule.syncItemsOnSchedule()
+
+            val messages = listAppender.list.map(ILoggingEvent::getFormattedMessage)
+            assertTrue(
+                messages.any {
+                    it.contains(
+                        "Skipping scheduled item sync because deployment AWS region us-west-1 does not match static data region Europe bucket region eu-west-1.",
+                    )
+                },
+            )
+            verify(exactly = 0) { service.syncConfiguredStaticDataRegion() }
+        } finally {
+            detachAppender(listAppender)
+        }
+    }
+
+    private fun syncResult() =
+        ItemSyncResult(
+            region = Region.Europe,
+            auctionSourceCount = 0,
+            recipeCraftedSourceCount = 0,
+            recipeReagentSourceCount = 0,
+            candidateItemCount = 0,
+            existingItemCount = 0,
+            missingItemCount = 0,
+            fetchedItemCount = 0,
+            itemFetchFailures = 0,
+            persistenceSummary =
+                ItemPersistenceSummary(
+                    localesUpserted = 0,
+                    itemQualitiesUpserted = 0,
+                    inventoryTypesUpserted = 0,
+                    itemBindingsUpserted = 0,
+                    itemClassesUpserted = 0,
+                    itemSubclassesUpserted = 0,
+                    itemAppearanceReferencesUpserted = 0,
+                    itemsUpserted = 0,
+                    itemAppearanceLinksUpserted = 0,
+                ),
+            durationMs = 1,
+        )
+
+    private fun attachAppender(): ListAppender<ILoggingEvent> {
+        val logger = LoggerFactory.getLogger(ItemSchedule::class.java) as Logger
+        return ListAppender<ILoggingEvent>().also {
+            it.start()
+            logger.addAppender(it)
+        }
+    }
+
+    private fun detachAppender(appender: ListAppender<ILoggingEvent>) {
+        val logger = LoggerFactory.getLogger(ItemSchedule::class.java) as Logger
+        logger.detachAppender(appender)
+        appender.stop()
+    }
+}

--- a/src/test/kotlin/net/jonasmf/auctionengine/schedules/ItemScheduleTest.kt
+++ b/src/test/kotlin/net/jonasmf/auctionengine/schedules/ItemScheduleTest.kt
@@ -108,6 +108,7 @@ class ItemScheduleTest {
             missingItemCount = 0,
             fetchedItemCount = 0,
             itemFetchFailures = 0,
+            persistedItemCount = 0,
             persistenceSummary =
                 ItemPersistenceSummary(
                     localesUpserted = 0,

--- a/src/test/kotlin/net/jonasmf/auctionengine/service/ItemSyncServiceTest.kt
+++ b/src/test/kotlin/net/jonasmf/auctionengine/service/ItemSyncServiceTest.kt
@@ -15,7 +15,7 @@ import net.jonasmf.auctionengine.dto.LocaleDTO
 import net.jonasmf.auctionengine.integration.blizzard.ItemApiClient
 import net.jonasmf.auctionengine.repository.rds.ItemJdbcRepository
 import net.jonasmf.auctionengine.repository.rds.ItemPersistenceSummary
-import net.jonasmf.auctionengine.repository.rds.RecipeRepository
+import net.jonasmf.auctionengine.repository.rds.ItemSourceDiscovery
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.time.Clock
@@ -33,7 +33,6 @@ class ItemSyncServiceTest {
         )
     private val itemApiClient = mockk<ItemApiClient>()
     private val itemJdbcRepository = mockk<ItemJdbcRepository>()
-    private val recipeRepository = mockk<RecipeRepository>()
     private val itemBulkSyncService = mockk<ItemBulkSyncService>()
     private val clock = Clock.fixed(Instant.parse("2026-04-14T08:00:00Z"), ZoneOffset.UTC)
 
@@ -42,7 +41,6 @@ class ItemSyncServiceTest {
             properties = properties,
             itemApiClient = itemApiClient,
             itemJdbcRepository = itemJdbcRepository,
-            recipeRepository = recipeRepository,
             itemBulkSyncService = itemBulkSyncService,
             clock = clock,
         )
@@ -52,10 +50,16 @@ class ItemSyncServiceTest {
         val service = createService()
         val item = item(1001)
 
-        every { itemJdbcRepository.findDistinctAuctionItemIdsForDate(any()) } returns listOf(1001, 1002)
-        every { recipeRepository.findDistinctCraftedItemIds() } returns listOf(1002, 1003)
-        every { recipeRepository.findDistinctReagentItemIds() } returns listOf(1003, 1004)
-        every { itemJdbcRepository.findExistingItemIds(listOf(1001, 1002, 1003, 1004)) } returns setOf(1002, 1004)
+        every { itemJdbcRepository.findMissingItemIdsForDate(any()) } returns
+            ItemSourceDiscovery(
+                auctionSourceCount = 2,
+                recipeCraftedSourceCount = 2,
+                recipeReagentSourceCount = 2,
+                candidateItemCount = 4,
+                existingItemCount = 2,
+                missingItemIds = listOf(1001, 1003),
+            )
+        every { itemJdbcRepository.findExistingItemIds(listOf(1001)) } returns setOf(1001)
         every { itemApiClient.getById(1001, Region.Europe) } returns item
         every { itemApiClient.getById(1003, Region.Europe) } throws RuntimeException("boom")
         every { itemBulkSyncService.syncItems(listOf(item)) } returns summary(items = 1)
@@ -70,20 +74,27 @@ class ItemSyncServiceTest {
         assertEquals(2, result.missingItemCount)
         assertEquals(1, result.fetchedItemCount)
         assertEquals(1, result.itemFetchFailures)
+        assertEquals(1, result.persistedItemCount)
         assertEquals(1, result.persistenceSummary.itemsUpserted)
         verify(exactly = 1) { itemApiClient.getById(1001, Region.Europe) }
         verify(exactly = 1) { itemApiClient.getById(1003, Region.Europe) }
     }
 
     @Test
-    fun `syncRegion continues with auction source when recipe queries fail`() {
+    fun `syncRegion uses combined source discovery query`() {
         val service = createService()
         val item = item(2001)
 
-        every { itemJdbcRepository.findDistinctAuctionItemIdsForDate(any()) } returns listOf(2001)
-        every { recipeRepository.findDistinctCraftedItemIds() } throws RuntimeException("crafted unavailable")
-        every { recipeRepository.findDistinctReagentItemIds() } throws RuntimeException("reagent unavailable")
-        every { itemJdbcRepository.findExistingItemIds(listOf(2001)) } returns emptySet()
+        every { itemJdbcRepository.findMissingItemIdsForDate(any()) } returns
+            ItemSourceDiscovery(
+                auctionSourceCount = 1,
+                recipeCraftedSourceCount = 0,
+                recipeReagentSourceCount = 0,
+                candidateItemCount = 1,
+                existingItemCount = 0,
+                missingItemIds = listOf(2001),
+            )
+        every { itemJdbcRepository.findExistingItemIds(listOf(2001)) } returns setOf(2001)
         every { itemApiClient.getById(2001, Region.Europe) } returns item
         every { itemBulkSyncService.syncItems(listOf(item)) } returns summary(items = 1)
 
@@ -93,6 +104,8 @@ class ItemSyncServiceTest {
         assertEquals(0, result.recipeCraftedSourceCount)
         assertEquals(0, result.recipeReagentSourceCount)
         assertEquals(1, result.fetchedItemCount)
+        assertEquals(1, result.persistedItemCount)
+        verify(exactly = 1) { itemJdbcRepository.findMissingItemIdsForDate(any()) }
     }
 
     private fun item(id: Int) =

--- a/src/test/kotlin/net/jonasmf/auctionengine/service/ItemSyncServiceTest.kt
+++ b/src/test/kotlin/net/jonasmf/auctionengine/service/ItemSyncServiceTest.kt
@@ -1,0 +1,132 @@
+package net.jonasmf.auctionengine.service
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.jonasmf.auctionengine.config.BlizzardApiProperties
+import net.jonasmf.auctionengine.constant.Region
+import net.jonasmf.auctionengine.domain.item.InventoryType
+import net.jonasmf.auctionengine.domain.item.Item
+import net.jonasmf.auctionengine.domain.item.ItemBinding
+import net.jonasmf.auctionengine.domain.item.ItemClass
+import net.jonasmf.auctionengine.domain.item.ItemQuality
+import net.jonasmf.auctionengine.domain.item.ItemSubclass
+import net.jonasmf.auctionengine.dto.LocaleDTO
+import net.jonasmf.auctionengine.integration.blizzard.ItemApiClient
+import net.jonasmf.auctionengine.repository.rds.ItemJdbcRepository
+import net.jonasmf.auctionengine.repository.rds.ItemPersistenceSummary
+import net.jonasmf.auctionengine.repository.rds.RecipeRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+class ItemSyncServiceTest {
+    private val properties =
+        BlizzardApiProperties(
+            baseUrl = "https://example.test/",
+            tokenUrl = "https://example.test/token",
+            clientId = "id",
+            clientSecret = "secret",
+            regions = listOf(Region.Europe),
+        )
+    private val itemApiClient = mockk<ItemApiClient>()
+    private val itemJdbcRepository = mockk<ItemJdbcRepository>()
+    private val recipeRepository = mockk<RecipeRepository>()
+    private val itemBulkSyncService = mockk<ItemBulkSyncService>()
+    private val clock = Clock.fixed(Instant.parse("2026-04-14T08:00:00Z"), ZoneOffset.UTC)
+
+    private fun createService() =
+        ItemSyncService(
+            properties = properties,
+            itemApiClient = itemApiClient,
+            itemJdbcRepository = itemJdbcRepository,
+            recipeRepository = recipeRepository,
+            itemBulkSyncService = itemBulkSyncService,
+            clock = clock,
+        )
+
+    @Test
+    fun `syncRegion deduplicates sources and skips existing items before fetch`() {
+        val service = createService()
+        val item = item(1001)
+
+        every { itemJdbcRepository.findDistinctAuctionItemIdsForDate(any()) } returns listOf(1001, 1002)
+        every { recipeRepository.findDistinctCraftedItemIds() } returns listOf(1002, 1003)
+        every { recipeRepository.findDistinctReagentItemIds() } returns listOf(1003, 1004)
+        every { itemJdbcRepository.findExistingItemIds(listOf(1001, 1002, 1003, 1004)) } returns setOf(1002, 1004)
+        every { itemApiClient.getById(1001, Region.Europe) } returns item
+        every { itemApiClient.getById(1003, Region.Europe) } throws RuntimeException("boom")
+        every { itemBulkSyncService.syncItems(listOf(item)) } returns summary(items = 1)
+
+        val result = service.syncRegion(Region.Europe)
+
+        assertEquals(2, result.auctionSourceCount)
+        assertEquals(2, result.recipeCraftedSourceCount)
+        assertEquals(2, result.recipeReagentSourceCount)
+        assertEquals(4, result.candidateItemCount)
+        assertEquals(2, result.existingItemCount)
+        assertEquals(2, result.missingItemCount)
+        assertEquals(1, result.fetchedItemCount)
+        assertEquals(1, result.itemFetchFailures)
+        assertEquals(1, result.persistenceSummary.itemsUpserted)
+        verify(exactly = 1) { itemApiClient.getById(1001, Region.Europe) }
+        verify(exactly = 1) { itemApiClient.getById(1003, Region.Europe) }
+    }
+
+    @Test
+    fun `syncRegion continues with auction source when recipe queries fail`() {
+        val service = createService()
+        val item = item(2001)
+
+        every { itemJdbcRepository.findDistinctAuctionItemIdsForDate(any()) } returns listOf(2001)
+        every { recipeRepository.findDistinctCraftedItemIds() } throws RuntimeException("crafted unavailable")
+        every { recipeRepository.findDistinctReagentItemIds() } throws RuntimeException("reagent unavailable")
+        every { itemJdbcRepository.findExistingItemIds(listOf(2001)) } returns emptySet()
+        every { itemApiClient.getById(2001, Region.Europe) } returns item
+        every { itemBulkSyncService.syncItems(listOf(item)) } returns summary(items = 1)
+
+        val result = service.syncRegion(Region.Europe)
+
+        assertEquals(1, result.auctionSourceCount)
+        assertEquals(0, result.recipeCraftedSourceCount)
+        assertEquals(0, result.recipeReagentSourceCount)
+        assertEquals(1, result.fetchedItemCount)
+    }
+
+    private fun item(id: Int) =
+        Item(
+            id = id,
+            name = locale("Item $id"),
+            quality = ItemQuality("COMMON", locale("Common")),
+            level = 10,
+            requiredLevel = 5,
+            mediaUrl = "https://example.test/item/$id",
+            itemClass = ItemClass(2, locale("Weapon")),
+            itemSubclass = ItemSubclass(2, 0, locale("Axe")),
+            inventoryType = InventoryType("WEAPON", locale("Weapon")),
+            binding = ItemBinding("ON_EQUIP", locale("Binds when equipped")),
+            purchasePrice = 100,
+            sellPrice = 10,
+            maxCount = 1,
+            isEquippable = true,
+            isStackable = false,
+            purchaseQuantity = 1,
+        )
+
+    private fun summary(items: Int) =
+        ItemPersistenceSummary(
+            localesUpserted = 1,
+            itemQualitiesUpserted = 1,
+            inventoryTypesUpserted = 1,
+            itemBindingsUpserted = 1,
+            itemClassesUpserted = 1,
+            itemSubclassesUpserted = 1,
+            itemAppearanceReferencesUpserted = 0,
+            itemsUpserted = items,
+            itemAppearanceLinksUpserted = 0,
+        )
+
+    private fun locale(value: String) = LocaleDTO(en_US = value, en_GB = value)
+}


### PR DESCRIPTION
## Summary
- Add a bulk item sync workflow to import and persist Blizzard item data.
- Extend item domain, DTO, mapping, and repository layers to support synced item metadata and localized fields.
- Wire scheduled sync execution and configuration updates for automated item ingestion.

## Task Reference
- GitHub issue: Resolves #2 
- Local task doc:
- Task slug:

## Context For Reviewers
- The change spans API integration, mapping, persistence, and scheduling for item synchronization.
- Tests were updated across client, mapper, repository, schedule, and service coverage.

## Changes
- Add and update item sync services for bulk and scheduled item imports.
- Update Blizzard item client handling and item mapping logic.
- Expand item-related domain, DBO, and DTO models.
- Adjust JDBC persistence and application configuration for the new sync flow.

## Testing
- [x] Tests added or updated where needed
- [ ] Verified locally

### Checks run
```text
Not run (not requested)
```

## Screenshots
- N/A

## Checklist
- [ ] This PR references the GitHub issue it resolves or fixes
- [ ] This PR references the local task doc or slug when one exists
- [x] Scope stays aligned with the linked task
- [ ] Documentation updated if behavior or workflow changed