### PR TITLE
Refactor current auction persistence to use bulk snapshot upserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Format Kotlin sources:
 
 ## Documentation
 
+- [Auction snapshot storage and query patterns](docs/auction-snapshot-storage.md)
 - [Production memory footprint and cost action criteria](docs/production-memory-footprint.md)
 - [AWS deployment and regional operations](infra/README.md)
 

--- a/docs/auction-snapshot-storage.md
+++ b/docs/auction-snapshot-storage.md
@@ -1,0 +1,117 @@
+# Auction Snapshot Storage and Querying
+
+This project keeps a compact "current snapshot" of auctions in MariaDB alongside the aggregated hourly price statistics.
+
+The snapshot schema is intentionally optimized for heavy hourly upserts first, while still supporting targeted read paths for browsing the latest active auctions.
+
+## Data model
+
+### `auction`
+
+One row per live-or-recently-seen auction identity within a connected realm.
+
+Important columns:
+
+- `connected_realm_id`: realm partition key
+- `id`: Blizzard auction ID inside the connected realm
+- `item_id`: foreign key to `auction_item.id` (this is **not** the base Blizzard item ID)
+- `first_seen`: first snapshot timestamp where this auction was observed
+- `last_seen`: most recent snapshot timestamp where this auction was observed
+- `deleted_at`: soft-delete timestamp when an auction disappeared from the latest snapshot
+- `update_history_id`: snapshot batch that last touched the row
+
+Primary key:
+
+- `(connected_realm_id, id)`
+
+### `auction_item`
+
+Canonical item-variant row shared by many auctions.
+
+Important columns:
+
+- `id`: surrogate key referenced by `auction.item_id`
+- `item_id`: base Blizzard item ID
+- `variant_hash`: canonical hash of item ID + bonuses + modifiers + context + pet metadata
+
+### `auction_item_modifier` and `auction_item_modifier_link`
+
+Normalized modifier storage for item variants.
+
+## Why `auction.item_id` is not base item ID
+
+`auction.item_id` references `auction_item.id`, because many auctions can share the same canonical item variant.
+
+That means "find auctions for connected realm X and base item Y" is a join problem:
+
+```sql
+SELECT a.*
+FROM auction a
+JOIN auction_item ai ON ai.id = a.item_id
+WHERE a.connected_realm_id = ?
+  AND ai.item_id = ?;
+```
+
+This design avoids copying variant metadata into every auction row and keeps snapshot upserts smaller.
+
+## Snapshot-oriented indexes
+
+Current important indexes for the snapshot tables:
+
+### `auction`
+
+- primary key: `(connected_realm_id, id)`
+- `idx_auction_connected_realm_update_deleted (connected_realm_id, update_history_id, deleted_at)`
+  - supports snapshot completion and soft-delete marking paths
+- `idx_auction_deleted_at (deleted_at)`
+  - supports cleanup of aged soft-deleted rows
+- `idx_auction_item_realm_deleted_last_seen (item_id, connected_realm_id, deleted_at, last_seen)`
+  - supports read-side lookup of active auctions by item variant within a realm, ordered/filterable by recency
+
+### `auction_item`
+
+- unique `uk_auction_item_variant_hash (variant_hash)`
+  - supports canonical variant lookup/upsert
+- `idx_auction_item_item_id (item_id, id)`
+  - supports base-item to variant-ID expansion before joining into `auction`
+
+## Recommended read query shape
+
+For current active-auction reads by base item and connected realm, prefer this shape:
+
+```sql
+SELECT a.id,
+       a.quantity,
+       a.unit_price,
+       a.buyout,
+       a.time_left,
+       a.first_seen,
+       a.last_seen
+FROM auction a
+JOIN auction_item ai ON ai.id = a.item_id
+WHERE ai.item_id = :itemId
+  AND a.connected_realm_id = :connectedRealmId
+  AND a.deleted_at IS NULL
+  AND a.last_seen >= :cutoff
+ORDER BY a.last_seen DESC
+LIMIT :limit;
+```
+
+Why this shape works well:
+
+1. `auction_item(item_id, id)` narrows the variant IDs for the base item.
+2. `auction(item_id, connected_realm_id, deleted_at, last_seen)` probes the matching auction rows efficiently.
+3. `deleted_at IS NULL` keeps the query on the active snapshot.
+
+## Tradeoff note
+
+We intentionally keep the number of `auction` indexes low.
+
+This table is write-heavy during hourly snapshot ingestion, so every added index increases insert/upsert cost. The current index set is meant to cover:
+
+- snapshot persistence
+- soft-delete marking
+- aged-row cleanup
+- targeted current-auction reads by realm + item + recency
+
+If a new query pattern becomes hot, check `EXPLAIN` against production-like data before adding another index.

--- a/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/auction/Auction.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/auction/Auction.kt
@@ -5,69 +5,131 @@ import jakarta.persistence.Column
 import jakarta.persistence.Embeddable
 import jakarta.persistence.EmbeddedId
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
+import jakarta.persistence.JoinTable
+import jakarta.persistence.ManyToMany
 import jakarta.persistence.ManyToOne
-import jakarta.persistence.OneToMany
-import jakarta.persistence.OneToOne
+import jakarta.persistence.MapsId
+import jakarta.persistence.OrderColumn
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 import net.jonasmf.auctionengine.constant.AuctionTimeLeft
 import net.jonasmf.auctionengine.dbo.rds.realm.ConnectedRealm
 import net.jonasmf.auctionengine.dbo.rds.realm.ConnectedRealmUpdateHistory
-import org.springframework.beans.factory.annotation.Value
-import java.time.ZonedDateTime
+import java.time.OffsetDateTime
 
 @Embeddable
 data class AuctionId(
     @Column(name = "id")
-    val id: Long,
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "connected_realm_id")
-    val connectedRealm: ConnectedRealm,
+    val id: Long = 0,
+    @Column(name = "connected_realm_id")
+    val connectedRealmId: Int = 0,
 )
 
 @Entity
+@Table(
+    name = "auction_item_modifier",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_auction_item_modifier_type_value",
+            columnNames = ["type", "value"],
+        ),
+    ],
+)
 data class AuctionItemModifier(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     val id: Long? = null,
+    @Column(nullable = false)
     val type: String,
+    @Column(nullable = false)
     val value: Int,
 )
 
 @Entity
+@Table(
+    name = "auction_item",
+    indexes = [
+        Index(name = "idx_auction_item_item_id", columnList = "item_id"),
+    ],
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_auction_item_variant_hash",
+            columnNames = ["variant_hash"],
+        ),
+    ],
+)
 data class AuctionItem(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     val id: Long? = null,
+    @Column(name = "item_id", nullable = false)
     val itemId: Int,
-    @OneToMany(cascade = [CascadeType.ALL], fetch = FetchType.EAGER)
-    val modifiers: MutableList<AuctionItemModifier>? = mutableListOf(),
-    @Column(name = "bonus_lists")
+    @Column(name = "variant_hash", nullable = false, length = 64)
+    val variantHash: String,
+    @ManyToMany(fetch = FetchType.EAGER, cascade = [CascadeType.PERSIST, CascadeType.MERGE])
+    @JoinTable(
+        name = "auction_item_modifier_link",
+        joinColumns = [JoinColumn(name = "auction_item_id")],
+        inverseJoinColumns = [JoinColumn(name = "modifier_id")],
+    )
+    @OrderColumn(name = "sort_order")
+    val modifiers: MutableList<AuctionItemModifier> = mutableListOf(),
+    @Column(name = "bonus_lists", nullable = false)
     val bonusLists: String = "",
-    val context: Int?,
-    val petBreedId: Int?,
-    val petLevel: Int?,
-    val petQualityId: Int?,
-    val petSpeciesId: Int?,
+    val context: Int? = null,
+    @Column(name = "pet_breed_id")
+    val petBreedId: Int? = null,
+    @Column(name = "pet_level")
+    val petLevel: Int? = null,
+    @Column(name = "pet_quality_id")
+    val petQualityId: Int? = null,
+    @Column(name = "pet_species_id")
+    val petSpeciesId: Int? = null,
 )
 
 @Entity
+@Table(
+    name = "auction",
+    indexes = [
+        Index(
+            name = "idx_auction_connected_realm_update_deleted",
+            columnList = "connected_realm_id, update_history_id, deleted_at",
+        ),
+        Index(name = "idx_auction_deleted_at", columnList = "deleted_at"),
+    ],
+)
 data class Auction(
     @EmbeddedId
     val id: AuctionId,
-    @OneToOne(fetch = FetchType.EAGER, cascade = [CascadeType.REMOVE])
+    @MapsId("connectedRealmId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "connected_realm_id", nullable = false)
+    val connectedRealm: ConnectedRealm,
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "item_id", nullable = false)
     val item: AuctionItem,
     val quantity: Long,
     val bid: Long?,
+    @Column(name = "unit_price")
     val unitPrice: Long?,
+    @Enumerated(EnumType.ORDINAL)
+    @Column(name = "time_left", nullable = false)
     val timeLeft: AuctionTimeLeft,
     val buyout: Long?,
-    @Value("CURRENT_TIMESTAMP")
-    val firstSeen: ZonedDateTime?,
-    val lastSeen: ZonedDateTime?,
+    @Column(name = "first_seen", columnDefinition = "DATETIME(6)")
+    val firstSeen: OffsetDateTime?,
+    @Column(name = "last_seen", columnDefinition = "DATETIME(6)")
+    val lastSeen: OffsetDateTime?,
+    @Column(name = "deleted_at", columnDefinition = "DATETIME(6)")
+    val deletedAt: OffsetDateTime? = null,
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "update_history_id")
     val updateHistory: ConnectedRealmUpdateHistory,

--- a/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/auction/Auction.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/auction/Auction.kt
@@ -104,8 +104,8 @@ data class AuctionItem(
             columnList = "connected_realm_id, update_history_id, deleted_at",
         ),
         Index(
-            name = "idx_auction_realm_item_deleted_last_seen",
-            columnList = "connected_realm_id, item_id, deleted_at, last_seen",
+            name = "idx_auction_item_realm_deleted_last_seen",
+            columnList = "item_id, connected_realm_id, deleted_at, last_seen",
         ),
         Index(name = "idx_auction_deleted_at", columnList = "deleted_at"),
     ],

--- a/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/auction/Auction.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/dbo/rds/auction/Auction.kt
@@ -57,7 +57,7 @@ data class AuctionItemModifier(
 @Table(
     name = "auction_item",
     indexes = [
-        Index(name = "idx_auction_item_item_id", columnList = "item_id"),
+        Index(name = "idx_auction_item_item_id", columnList = "item_id, id"),
     ],
     uniqueConstraints = [
         UniqueConstraint(
@@ -102,6 +102,10 @@ data class AuctionItem(
         Index(
             name = "idx_auction_connected_realm_update_deleted",
             columnList = "connected_realm_id, update_history_id, deleted_at",
+        ),
+        Index(
+            name = "idx_auction_realm_item_deleted_last_seen",
+            columnList = "connected_realm_id, item_id, deleted_at, last_seen",
         ),
         Index(name = "idx_auction_deleted_at", columnList = "deleted_at"),
     ],

--- a/src/main/kotlin/net/jonasmf/auctionengine/dto/auction/AuctionDTO.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/dto/auction/AuctionDTO.kt
@@ -2,10 +2,6 @@ package net.jonasmf.auctionengine.dto.auction
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import net.jonasmf.auctionengine.constant.AuctionTimeLeft
-import net.jonasmf.auctionengine.dbo.rds.auction.Auction
-import net.jonasmf.auctionengine.dbo.rds.auction.AuctionId
-import net.jonasmf.auctionengine.dbo.rds.realm.ConnectedRealm
-import net.jonasmf.auctionengine.dbo.rds.realm.ConnectedRealmUpdateHistory
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class AuctionDTO(
@@ -16,25 +12,4 @@ data class AuctionDTO(
     val unit_price: Long?, // Commodity price
     val buyout: Long?, // Realm price
     val time_left: AuctionTimeLeft,
-) {
-    fun toDBO(
-        connectedRealm: ConnectedRealm,
-        updateHistory: ConnectedRealmUpdateHistory,
-    ): Auction =
-        Auction(
-            id =
-                AuctionId(
-                    id = id,
-                    connectedRealm = connectedRealm,
-                ),
-            item = item.toDBO(),
-            quantity = quantity,
-            bid = bid,
-            unitPrice = unit_price,
-            buyout = buyout,
-            timeLeft = time_left,
-            firstSeen = null,
-            lastSeen = null,
-            updateHistory = updateHistory,
-        )
-}
+)

--- a/src/main/kotlin/net/jonasmf/auctionengine/dto/auction/AuctionItemDTO.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/dto/auction/AuctionItemDTO.kt
@@ -1,8 +1,6 @@
 package net.jonasmf.auctionengine.dto.auction
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import net.jonasmf.auctionengine.dbo.rds.auction.AuctionItem
-import net.jonasmf.auctionengine.utility.AuctionVariantKeyUtility
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class AuctionItemDTO(
@@ -15,17 +13,4 @@ data class AuctionItemDTO(
     val pet_level: Int? = null,
     val pet_quality_id: Int? = null,
     val pet_species_id: Int? = null,
-) {
-    fun toDBO(): AuctionItem =
-        AuctionItem(
-            id = null,
-            itemId = id,
-            modifiers = modifiers?.map { it.toDBO() }?.toMutableList(),
-            bonusLists = AuctionVariantKeyUtility.canonicalBonusKey(bonus_lists),
-            context = context,
-            petBreedId = pet_breed_id,
-            petLevel = pet_level,
-            petQualityId = pet_quality_id,
-            petSpeciesId = pet_species_id,
-        )
-}
+)

--- a/src/main/kotlin/net/jonasmf/auctionengine/dto/auction/ModifierDTO.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/dto/auction/ModifierDTO.kt
@@ -1,14 +1,6 @@
 package net.jonasmf.auctionengine.dto.auction
 
-import net.jonasmf.auctionengine.dbo.rds.auction.AuctionItemModifier
-
 data class ModifierDTO( // TODO: Fix? or is it ok?
     val type: String,
     val value: Int,
-) {
-    fun toDBO(): AuctionItemModifier =
-        AuctionItemModifier(
-            type = type,
-            value = value,
-        )
-}
+)

--- a/src/main/kotlin/net/jonasmf/auctionengine/mapper/AuctionMapper.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/mapper/AuctionMapper.kt
@@ -1,0 +1,183 @@
+package net.jonasmf.auctionengine.mapper
+
+import net.jonasmf.auctionengine.dbo.rds.auction.Auction
+import net.jonasmf.auctionengine.dbo.rds.auction.AuctionId
+import net.jonasmf.auctionengine.dbo.rds.auction.AuctionItem
+import net.jonasmf.auctionengine.dbo.rds.auction.AuctionItemModifier
+import net.jonasmf.auctionengine.dbo.rds.realm.ConnectedRealm
+import net.jonasmf.auctionengine.dbo.rds.realm.ConnectedRealmUpdateHistory
+import net.jonasmf.auctionengine.dto.auction.AuctionDTO
+import net.jonasmf.auctionengine.dto.auction.AuctionItemDTO
+import net.jonasmf.auctionengine.dto.auction.ModifierDTO
+import net.jonasmf.auctionengine.repository.rds.AuctionItemModifierLinkUpsertRow
+import net.jonasmf.auctionengine.repository.rds.AuctionItemUpsertRow
+import net.jonasmf.auctionengine.repository.rds.AuctionModifierUpsertRow
+import net.jonasmf.auctionengine.repository.rds.AuctionUpsertRow
+import net.jonasmf.auctionengine.utility.AuctionVariantKeyUtility
+import java.time.OffsetDateTime
+
+data class AuctionModifierKey(
+    val type: String,
+    val value: Int,
+)
+
+data class AuctionItemVariant(
+    val variantHash: String,
+    val itemId: Int,
+    val bonusKey: String,
+    val context: Int?,
+    val petBreedId: Int?,
+    val petLevel: Int?,
+    val petQualityId: Int?,
+    val petSpeciesId: Int?,
+    val modifiers: List<AuctionModifierKey>,
+)
+
+data class SnapshotAuction(
+    val auctionId: Long,
+    val itemVariant: AuctionItemVariant,
+    val quantity: Long,
+    val bid: Long?,
+    val unitPrice: Long?,
+    val buyout: Long?,
+    val timeLeftOrdinal: Int,
+)
+
+fun ModifierDTO.toAuctionModifierKey(): AuctionModifierKey =
+    AuctionModifierKey(
+        type = type,
+        value = value,
+    )
+
+fun AuctionItemDTO.toAuctionItemVariant(): AuctionItemVariant {
+    val bonusKey = AuctionVariantKeyUtility.canonicalBonusKey(bonus_lists)
+    val modifiers = modifiers.orEmpty().map(ModifierDTO::toAuctionModifierKey)
+    val modifierKey = AuctionVariantKeyUtility.canonicalTypedModifierKey(this.modifiers)
+    return AuctionItemVariant(
+        variantHash =
+            AuctionVariantKeyUtility.variantHash(
+                itemId = id,
+                bonusKey = bonusKey,
+                modifierKey = modifierKey,
+                context = context,
+                petBreedId = pet_breed_id,
+                petLevel = pet_level,
+                petQualityId = pet_quality_id,
+                petSpeciesId = pet_species_id,
+            ),
+        itemId = id,
+        bonusKey = bonusKey,
+        context = context,
+        petBreedId = pet_breed_id,
+        petLevel = pet_level,
+        petQualityId = pet_quality_id,
+        petSpeciesId = pet_species_id,
+        modifiers = modifiers.sortedWith(compareBy(AuctionModifierKey::type, AuctionModifierKey::value)),
+    )
+}
+
+fun AuctionDTO.toSnapshotAuction(): SnapshotAuction =
+    SnapshotAuction(
+        auctionId = id,
+        itemVariant = item.toAuctionItemVariant(),
+        quantity = quantity,
+        bid = bid,
+        unitPrice = unit_price,
+        buyout = buyout,
+        timeLeftOrdinal = time_left.ordinal,
+    )
+
+fun AuctionModifierKey.toUpsertRow(): AuctionModifierUpsertRow =
+    AuctionModifierUpsertRow(
+        type = type,
+        value = value,
+    )
+
+fun AuctionItemVariant.toUpsertRow(): AuctionItemUpsertRow =
+    AuctionItemUpsertRow(
+        variantHash = variantHash,
+        itemId = itemId,
+        bonusLists = bonusKey,
+        context = context,
+        petBreedId = petBreedId,
+        petLevel = petLevel,
+        petQualityId = petQualityId,
+        petSpeciesId = petSpeciesId,
+    )
+
+fun SnapshotAuction.toUpsertRow(
+    connectedRealmId: Int,
+    auctionItemId: Long,
+    updateHistoryId: Long,
+    snapshotTime: OffsetDateTime,
+): AuctionUpsertRow =
+    AuctionUpsertRow(
+        id = auctionId,
+        connectedRealmId = connectedRealmId,
+        itemId = auctionItemId,
+        quantity = quantity,
+        bid = bid,
+        unitPrice = unitPrice,
+        timeLeft = timeLeftOrdinal,
+        buyout = buyout,
+        firstSeen = snapshotTime,
+        lastSeen = snapshotTime,
+        updateHistoryId = updateHistoryId,
+    )
+
+fun AuctionItemVariant.toModifierLinkRows(
+    auctionItemId: Long,
+    modifierIds: Map<AuctionModifierKey, Long>,
+): List<AuctionItemModifierLinkUpsertRow> =
+    modifiers.mapIndexed { index, modifier ->
+        AuctionItemModifierLinkUpsertRow(
+            auctionItemId = auctionItemId,
+            sortOrder = index,
+            modifierId = modifierIds.getValue(modifier),
+        )
+    }
+
+fun ModifierDTO.toDBO(): AuctionItemModifier =
+    AuctionItemModifier(
+        type = type,
+        value = value,
+    )
+
+fun AuctionItemDTO.toDBO(): AuctionItem {
+    val item =
+        AuctionItem(
+            itemId = id,
+            variantHash = toAuctionItemVariant().variantHash,
+            bonusLists = AuctionVariantKeyUtility.canonicalBonusKey(bonus_lists),
+            context = context,
+            petBreedId = pet_breed_id,
+            petLevel = pet_level,
+            petQualityId = pet_quality_id,
+            petSpeciesId = pet_species_id,
+        )
+    item.modifiers.addAll(modifiers.orEmpty().map(ModifierDTO::toDBO))
+    return item
+}
+
+fun AuctionDTO.toDBO(
+    connectedRealm: ConnectedRealm,
+    updateHistory: ConnectedRealmUpdateHistory,
+): Auction =
+    Auction(
+        id =
+            AuctionId(
+                id = id,
+                connectedRealmId = connectedRealm.id,
+            ),
+        connectedRealm = connectedRealm,
+        item = item.toDBO(),
+        quantity = quantity,
+        bid = bid,
+        unitPrice = unit_price,
+        buyout = buyout,
+        timeLeft = time_left,
+        firstSeen = null,
+        lastSeen = null,
+        deletedAt = null,
+        updateHistory = updateHistory,
+    )

--- a/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionItemRepository.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionItemRepository.kt
@@ -8,57 +8,10 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface AuctionItemRepository : JpaRepository<AuctionItem, Long> {
-    @Query("SELECT ai FROM AuctionItem ai WHERE ai.itemId = :itemId")
-    fun findByItemId(
-        @Param("itemId") itemId: Int,
-    ): AuctionItem?
+    fun findByVariantHash(variantHash: String): AuctionItem?
 
-    @Query("SELECT ai FROM AuctionItem ai WHERE ai.itemId IN :itemIds")
-    fun findByItemIds(
-        @Param("itemIds") itemIds: List<Int>,
-    ): List<AuctionItem>
-
-    @Query(
-        """
-        SELECT ai FROM AuctionItem ai 
-        WHERE ai.itemId = :itemId 
-        AND ai.petBreedId = :petBreedId 
-        AND ai.petLevel = :petLevel 
-        AND ai.petQualityId = :petQualityId 
-        AND ai.petSpeciesId = :petSpeciesId 
-        AND ai.context = :context
-        AND ai.bonusLists = :bonusLists
-    """,
-    )
-    fun findByCompositeKey(
-        @Param("itemId") itemId: Int,
-        @Param("petBreedId") petBreedId: Int?,
-        @Param("petLevel") petLevel: Int?,
-        @Param("petQualityId") petQualityId: Int?,
-        @Param("petSpeciesId") petSpeciesId: Int?,
-        @Param("context") context: Int?,
-        @Param("bonusLists") bonusLists: String,
-    ): AuctionItem?
-
-    @Query(
-        """
-        SELECT ai FROM AuctionItem ai 
-        WHERE ai.itemId = :itemId 
-        AND (ai.petBreedId = :petBreedId OR (ai.petBreedId IS NULL AND :petBreedId IS NULL))
-        AND (ai.petLevel = :petLevel OR (ai.petLevel IS NULL AND :petLevel IS NULL))
-        AND (ai.petQualityId = :petQualityId OR (ai.petQualityId IS NULL AND :petQualityId IS NULL))
-        AND (ai.petSpeciesId = :petSpeciesId OR (ai.petSpeciesId IS NULL AND :petSpeciesId IS NULL))
-        AND (ai.context = :context OR (ai.context IS NULL AND :context IS NULL))
-        AND ai.bonusLists = :bonusLists
-    """,
-    )
-    fun findByCompositeKeyWithNullHandlingList(
-        @Param("itemId") itemId: Int,
-        @Param("petBreedId") petBreedId: Int?,
-        @Param("petLevel") petLevel: Int?,
-        @Param("petQualityId") petQualityId: Int?,
-        @Param("petSpeciesId") petSpeciesId: Int?,
-        @Param("context") context: Int?,
-        @Param("bonusLists") bonusLists: String,
+    @Query("SELECT ai FROM AuctionItem ai WHERE ai.variantHash IN :variantHashes")
+    fun findAllByVariantHashes(
+        @Param("variantHashes") variantHashes: Collection<String>,
     ): List<AuctionItem>
 }

--- a/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionJDBCRepository.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionJDBCRepository.kt
@@ -4,9 +4,33 @@ import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
 import java.sql.Timestamp
-import java.time.ZonedDateTime
+import java.time.OffsetDateTime
 
-data class UpsertAuctionParams(
+private const val AUCTION_JDBC_CHUNK_SIZE = 1_000
+
+data class AuctionModifierUpsertRow(
+    val type: String,
+    val value: Int,
+)
+
+data class AuctionItemUpsertRow(
+    val variantHash: String,
+    val itemId: Int,
+    val bonusLists: String,
+    val context: Int?,
+    val petBreedId: Int?,
+    val petLevel: Int?,
+    val petQualityId: Int?,
+    val petSpeciesId: Int?,
+)
+
+data class AuctionItemModifierLinkUpsertRow(
+    val auctionItemId: Long,
+    val sortOrder: Int,
+    val modifierId: Long,
+)
+
+data class AuctionUpsertRow(
     val id: Long,
     val connectedRealmId: Int,
     val itemId: Long,
@@ -15,8 +39,8 @@ data class UpsertAuctionParams(
     val unitPrice: Long?,
     val timeLeft: Int,
     val buyout: Long?,
-    val firstSeen: ZonedDateTime?,
-    val lastSeen: ZonedDateTime?,
+    val firstSeen: OffsetDateTime,
+    val lastSeen: OffsetDateTime,
     val updateHistoryId: Long,
 )
 
@@ -25,56 +49,219 @@ class AuctionJDBCRepository(
     private val jdbcTemplate: JdbcTemplate,
 ) {
     @Transactional
-    fun upsertAuctions(auctions: List<UpsertAuctionParams>): Int {
-        if (auctions.isEmpty()) return 0
-
-        // chunk to avoid creating excessively large SQL statements/parameter lists
-        val chunkSize = 5_000
+    fun upsertModifiers(modifiers: Collection<AuctionModifierUpsertRow>): Int {
+        if (modifiers.isEmpty()) return 0
         var totalRows = 0
-
-        auctions.chunked(chunkSize).forEach { chunk ->
-            val placeholders = chunk.joinToString(",") { "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)" }
-
-            val sqlPrefix = (
-                "INSERT INTO auction (id, connected_realm_id, item_id, quantity, " +
-                    "bid, unit_price, time_left, buyout, first_seen, last_seen, update_history_id) VALUES "
-            )
-            val updateClause = (
-                " ON DUPLICATE KEY UPDATE " +
-                    "quantity = VALUES(quantity), " +
-                    "bid = VALUES(bid), " +
-                    "unit_price = VALUES(unit_price), " +
-                    "time_left = VALUES(time_left), " +
-                    "buyout = VALUES(buyout), " +
-                    "last_seen = VALUES(last_seen), " +
-                    "update_history_id = VALUES(update_history_id)"
-            )
-
+        modifiers.distinct().chunked(AUCTION_JDBC_CHUNK_SIZE).forEach { chunk ->
             val sql =
-                StringBuilder()
-                    .append(sqlPrefix)
-                    .append(placeholders)
-                    .append(updateClause)
-                    .toString()
-
-            val params = ArrayList<Any?>(chunk.size * 11)
-            for (auction in chunk) {
-                params.add(auction.id)
-                params.add(auction.connectedRealmId)
-                params.add(auction.itemId)
-                params.add(auction.quantity)
-                params.add(auction.bid)
-                params.add(auction.unitPrice)
-                params.add(auction.timeLeft)
-                params.add(auction.buyout)
-                params.add(auction.firstSeen?.let { Timestamp.from(it.toInstant()) })
-                params.add(auction.lastSeen?.let { Timestamp.from(it.toInstant()) })
-                params.add(auction.updateHistoryId)
-            }
-
+                """
+                INSERT INTO auction_item_modifier (type, value)
+                VALUES ${chunk.joinToString(",") { "(?, ?)" }}
+                ON DUPLICATE KEY UPDATE
+                    type = VALUES(type)
+                """.trimIndent()
+            val params = chunk.flatMap<AuctionModifierUpsertRow, Any?> { listOf(it.type, it.value) }
             totalRows += jdbcTemplate.update(sql, *params.toTypedArray())
         }
-
         return totalRows
     }
+
+    fun findModifierIds(modifiers: Collection<AuctionModifierUpsertRow>): Map<AuctionModifierUpsertRow, Long> {
+        if (modifiers.isEmpty()) return emptyMap()
+        val rows = linkedMapOf<AuctionModifierUpsertRow, Long>()
+        modifiers.distinct().chunked(AUCTION_JDBC_CHUNK_SIZE).forEach { chunk ->
+            val whereClause = chunk.joinToString(" OR ") { "(type = ? AND value = ?)" }
+            val params = chunk.flatMap<AuctionModifierUpsertRow, Any?> { listOf(it.type, it.value) }
+            jdbcTemplate.query(
+                "SELECT id, type, value FROM auction_item_modifier WHERE $whereClause",
+                { rs ->
+                    rows[
+                        AuctionModifierUpsertRow(
+                            type = rs.getString("type"),
+                            value = rs.getInt("value"),
+                        ),
+                    ] = rs.getLong("id")
+                },
+                *params.toTypedArray(),
+            )
+        }
+        return rows
+    }
+
+    @Transactional
+    fun upsertAuctionItems(items: Collection<AuctionItemUpsertRow>): Int {
+        if (items.isEmpty()) return 0
+        var totalRows = 0
+        items.distinctBy(AuctionItemUpsertRow::variantHash).chunked(AUCTION_JDBC_CHUNK_SIZE).forEach { chunk ->
+            val sql =
+                """
+                INSERT INTO auction_item (
+                    variant_hash,
+                    item_id,
+                    bonus_lists,
+                    context,
+                    pet_breed_id,
+                    pet_level,
+                    pet_quality_id,
+                    pet_species_id
+                ) VALUES ${chunk.joinToString(",") { "(?, ?, ?, ?, ?, ?, ?, ?)" }}
+                ON DUPLICATE KEY UPDATE
+                    item_id = VALUES(item_id),
+                    bonus_lists = VALUES(bonus_lists),
+                    context = VALUES(context),
+                    pet_breed_id = VALUES(pet_breed_id),
+                    pet_level = VALUES(pet_level),
+                    pet_quality_id = VALUES(pet_quality_id),
+                    pet_species_id = VALUES(pet_species_id)
+                """.trimIndent()
+            val params =
+                chunk.flatMap<AuctionItemUpsertRow, Any?> {
+                    listOf(
+                        it.variantHash,
+                        it.itemId,
+                        it.bonusLists,
+                        it.context,
+                        it.petBreedId,
+                        it.petLevel,
+                        it.petQualityId,
+                        it.petSpeciesId,
+                    )
+                }
+            totalRows += jdbcTemplate.update(sql, *params.toTypedArray())
+        }
+        return totalRows
+    }
+
+    fun findAuctionItemIds(variantHashes: Collection<String>): Map<String, Long> {
+        if (variantHashes.isEmpty()) return emptyMap()
+        val rows = linkedMapOf<String, Long>()
+        variantHashes.distinct().chunked(AUCTION_JDBC_CHUNK_SIZE).forEach { chunk ->
+            val sql =
+                "SELECT id, variant_hash FROM auction_item WHERE variant_hash IN (${placeholders(chunk.size)})"
+            jdbcTemplate.query(
+                sql,
+                { rs ->
+                    rows[rs.getString("variant_hash")] = rs.getLong("id")
+                },
+                *chunk.toTypedArray(),
+            )
+        }
+        return rows
+    }
+
+    @Transactional
+    fun upsertAuctionItemModifierLinks(links: Collection<AuctionItemModifierLinkUpsertRow>): Int {
+        if (links.isEmpty()) return 0
+        var totalRows = 0
+        links
+            .distinctBy { Triple(it.auctionItemId, it.sortOrder, it.modifierId) }
+            .chunked(AUCTION_JDBC_CHUNK_SIZE)
+            .forEach { chunk ->
+                val sql =
+                    """
+                    INSERT INTO auction_item_modifier_link (
+                        auction_item_id,
+                        sort_order,
+                        modifier_id
+                    ) VALUES ${chunk.joinToString(",") { "(?, ?, ?)" }}
+                    ON DUPLICATE KEY UPDATE
+                        modifier_id = VALUES(modifier_id)
+                    """.trimIndent()
+                val params =
+                    chunk.flatMap<AuctionItemModifierLinkUpsertRow, Any?> {
+                        listOf(it.auctionItemId, it.sortOrder, it.modifierId)
+                    }
+                totalRows += jdbcTemplate.update(sql, *params.toTypedArray())
+            }
+        return totalRows
+    }
+
+    @Transactional
+    fun upsertAuctions(auctions: Collection<AuctionUpsertRow>): Int {
+        if (auctions.isEmpty()) return 0
+        var totalRows = 0
+        auctions.chunked(AUCTION_JDBC_CHUNK_SIZE).forEach { chunk ->
+            val sql =
+                """
+                INSERT INTO auction (
+                    id,
+                    connected_realm_id,
+                    item_id,
+                    quantity,
+                    bid,
+                    unit_price,
+                    time_left,
+                    buyout,
+                    first_seen,
+                    last_seen,
+                    deleted_at,
+                    update_history_id
+                ) VALUES ${chunk.joinToString(",") { "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)" }}
+                ON DUPLICATE KEY UPDATE
+                    item_id = VALUES(item_id),
+                    quantity = VALUES(quantity),
+                    bid = VALUES(bid),
+                    unit_price = VALUES(unit_price),
+                    time_left = VALUES(time_left),
+                    buyout = VALUES(buyout),
+                    first_seen = COALESCE(first_seen, VALUES(first_seen)),
+                    last_seen = VALUES(last_seen),
+                    deleted_at = NULL,
+                    update_history_id = VALUES(update_history_id)
+                """.trimIndent()
+            val params =
+                ArrayList<Any?>(chunk.size * 12).apply {
+                    chunk.forEach { auction ->
+                        add(auction.id)
+                        add(auction.connectedRealmId)
+                        add(auction.itemId)
+                        add(auction.quantity)
+                        add(auction.bid)
+                        add(auction.unitPrice)
+                        add(auction.timeLeft)
+                        add(auction.buyout)
+                        add(auction.firstSeen.toSqlTimestamp())
+                        add(auction.lastSeen.toSqlTimestamp())
+                        add(null)
+                        add(auction.updateHistoryId)
+                    }
+                }
+            totalRows += jdbcTemplate.update(sql, *params.toTypedArray())
+        }
+        return totalRows
+    }
+
+    @Transactional
+    fun markMissingAuctionsDeleted(
+        connectedRealmId: Int,
+        updateHistoryId: Long,
+        deletedAt: OffsetDateTime,
+    ): Int =
+        jdbcTemplate.update(
+            """
+            UPDATE auction
+            SET deleted_at = ?
+            WHERE connected_realm_id = ?
+              AND update_history_id <> ?
+              AND deleted_at IS NULL
+            """.trimIndent(),
+            deletedAt.toSqlTimestamp(),
+            connectedRealmId,
+            updateHistoryId,
+        )
+
+    @Transactional
+    fun deleteSoftDeletedAuctionsOlderThan(cutoff: OffsetDateTime): Int =
+        jdbcTemplate.update(
+            """
+            DELETE FROM auction
+            WHERE deleted_at IS NOT NULL
+              AND deleted_at < ?
+            """.trimIndent(),
+            cutoff.toSqlTimestamp(),
+        )
+
+    private fun placeholders(count: Int): String = List(count) { "?" }.joinToString(",")
 }
+
+private fun OffsetDateTime.toSqlTimestamp(): Timestamp = Timestamp.from(toInstant())

--- a/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionRepository.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionRepository.kt
@@ -3,43 +3,7 @@ package net.jonasmf.auctionengine.repository.rds
 import net.jonasmf.auctionengine.dbo.rds.auction.Auction
 import net.jonasmf.auctionengine.dbo.rds.auction.AuctionId
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Modifying
-import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
-import org.springframework.transaction.annotation.Transactional
-import java.time.ZonedDateTime
 
 @Repository
-interface AuctionRepository : JpaRepository<Auction, AuctionId> {
-    @Modifying
-    @Transactional
-    @Query(
-        """
-        INSERT INTO auction (id, connected_realm_id, item_id, quantity, bid, unit_price, time_left, buyout, first_seen, last_seen, update_history_id)
-        VALUES (:id, :connectedRealmId, :itemId, :quantity, :bid, :unitPrice, :timeLeft, :buyout, :firstSeen, :lastSeen, :updateHistoryId)
-        ON DUPLICATE KEY UPDATE
-            quantity = VALUES(quantity),
-            bid = VALUES(bid),
-            unit_price = VALUES(unit_price),
-            time_left = VALUES(time_left),
-            buyout = VALUES(buyout),
-            last_seen = VALUES(last_seen),
-            update_history_id = VALUES(update_history_id)
-    """,
-        nativeQuery = true,
-    )
-    fun upsertAuction(
-        @Param("id") id: Long,
-        @Param("connectedRealmId") connectedRealmId: Int,
-        @Param("itemId") itemId: Long,
-        @Param("quantity") quantity: Long,
-        @Param("bid") bid: Long?,
-        @Param("unitPrice") unitPrice: Long?,
-        @Param("timeLeft") timeLeft: Int,
-        @Param("buyout") buyout: Long?,
-        @Param("firstSeen") firstSeen: ZonedDateTime?,
-        @Param("lastSeen") lastSeen: ZonedDateTime?,
-        @Param("updateHistoryId") updateHistoryId: Long,
-    ): Int
-}
+interface AuctionRepository : JpaRepository<Auction, AuctionId>

--- a/src/main/kotlin/net/jonasmf/auctionengine/schedules/DeletedAuctionCleanupSchedule.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/schedules/DeletedAuctionCleanupSchedule.kt
@@ -1,0 +1,26 @@
+package net.jonasmf.auctionengine.schedules
+
+import net.jonasmf.auctionengine.service.AuctionSnapshotPersistenceService
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+@Component
+class DeletedAuctionCleanupSchedule(
+    private val auctionSnapshotPersistenceService: AuctionSnapshotPersistenceService,
+) {
+    private val logger: Logger = LoggerFactory.getLogger(DeletedAuctionCleanupSchedule::class.java)
+
+    @Scheduled(
+        cron = "\${app.scheduling.deleted-auction-cleanup-cron:0 0 4 * * *}",
+        zone = "\${app.scheduling.deleted-auction-cleanup-zone:GMT+1}",
+    )
+    fun deleteSoftDeletedAuctions() {
+        val cutoff = OffsetDateTime.now(ZoneOffset.UTC).minusDays(7)
+        val deletedRows = auctionSnapshotPersistenceService.deleteSoftDeletedAuctionsOlderThan(cutoff)
+        logger.info("Deleted {} soft-deleted auctions older than {}", deletedRows, cutoff)
+    }
+}

--- a/src/main/kotlin/net/jonasmf/auctionengine/service/AuctionSnapshotPersistenceService.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/service/AuctionSnapshotPersistenceService.kt
@@ -1,0 +1,197 @@
+package net.jonasmf.auctionengine.service
+
+import com.fasterxml.jackson.core.JsonFactory
+import com.fasterxml.jackson.core.JsonToken
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import net.jonasmf.auctionengine.dbo.rds.realm.ConnectedRealm
+import net.jonasmf.auctionengine.dto.auction.AuctionDTO
+import net.jonasmf.auctionengine.mapper.SnapshotAuction
+import net.jonasmf.auctionengine.mapper.toModifierLinkRows
+import net.jonasmf.auctionengine.mapper.toSnapshotAuction
+import net.jonasmf.auctionengine.mapper.toUpsertRow
+import net.jonasmf.auctionengine.repository.rds.AuctionJDBCRepository
+import net.jonasmf.auctionengine.utility.JvmRuntimeDiagnostics
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.nio.file.Path
+import java.time.OffsetDateTime
+import java.time.ZonedDateTime
+
+data class AuctionSnapshotPersistenceSummary(
+    val processedAuctions: Int,
+    val batchCount: Int,
+    val softDeletedAuctions: Int,
+)
+
+@Service
+class AuctionSnapshotPersistenceService(
+    private val auctionJdbcRepository: AuctionJDBCRepository,
+    private val updateHistoryService: ConnectedRealmUpdateHistoryService,
+) {
+    private val logger: Logger = LoggerFactory.getLogger(AuctionSnapshotPersistenceService::class.java)
+    private val snapshotBatchSize = 5_000
+
+    fun saveSnapshot(
+        payloadPath: Path,
+        connectedRealm: ConnectedRealm,
+        auctionCount: Int,
+        lastModified: ZonedDateTime,
+    ): AuctionSnapshotPersistenceSummary {
+        val snapshotStartTime = System.currentTimeMillis()
+        val updateHistory = updateHistoryService.startUpdate(connectedRealm, auctionCount, lastModified)
+        var processedAuctions = 0
+        var batchCount = 0
+
+        logger.info(
+            "Persisting current auction snapshot for realm {} auctions={} {}",
+            connectedRealm.id,
+            auctionCount,
+            JvmRuntimeDiagnostics.snapshot(),
+        )
+
+        streamAuctionBatches(payloadPath) { batch ->
+            batchCount++
+            persistBatch(
+                auctions = batch,
+                connectedRealmId = connectedRealm.id,
+                updateHistoryId = updateHistory.id,
+                snapshotTime = lastModified.toOffsetDateTime(),
+            )
+            processedAuctions += batch.size
+            logger.info(
+                "Persisted auction snapshot batch {}/? for realm {} processed={}/{} {}",
+                batchCount,
+                connectedRealm.id,
+                processedAuctions,
+                auctionCount,
+                JvmRuntimeDiagnostics.snapshot(),
+            )
+        }
+
+        val softDeletedAuctions =
+            auctionJdbcRepository.markMissingAuctionsDeleted(
+                connectedRealmId = connectedRealm.id,
+                updateHistoryId = updateHistory.id,
+                deletedAt = lastModified.toOffsetDateTime(),
+            )
+        updateHistoryService.setUpdateToCompleted(connectedRealm.id, lastModified)
+
+        logger.info(
+            "Completed auction snapshot persistence for realm {} in {}ms batches={} processed={} softDeleted={} {}",
+            connectedRealm.id,
+            System.currentTimeMillis() - snapshotStartTime,
+            batchCount,
+            processedAuctions,
+            softDeletedAuctions,
+            JvmRuntimeDiagnostics.snapshot(),
+        )
+
+        return AuctionSnapshotPersistenceSummary(
+            processedAuctions = processedAuctions,
+            batchCount = batchCount,
+            softDeletedAuctions = softDeletedAuctions,
+        )
+    }
+
+    fun saveAuction(
+        auction: AuctionDTO,
+        connectedRealm: ConnectedRealm,
+        lastModified: ZonedDateTime = ZonedDateTime.now(),
+    ) {
+        val updateHistory = updateHistoryService.startUpdate(connectedRealm, 1, lastModified)
+        persistBatch(
+            auctions = listOf(auction.toSnapshotAuction()),
+            connectedRealmId = connectedRealm.id,
+            updateHistoryId = updateHistory.id,
+            snapshotTime = lastModified.toOffsetDateTime(),
+        )
+        updateHistoryService.setUpdateToCompleted(connectedRealm.id, lastModified)
+    }
+
+    fun deleteSoftDeletedAuctionsOlderThan(cutoff: OffsetDateTime): Int =
+        auctionJdbcRepository.deleteSoftDeletedAuctionsOlderThan(cutoff)
+
+    private fun persistBatch(
+        auctions: List<SnapshotAuction>,
+        connectedRealmId: Int,
+        updateHistoryId: Long,
+        snapshotTime: OffsetDateTime,
+    ) {
+        if (auctions.isEmpty()) return
+
+        val itemVariants = auctions.map(SnapshotAuction::itemVariant).distinctBy { it.variantHash }
+        val modifierRows = itemVariants.flatMap { variant -> variant.modifiers }.distinct().map { it.toUpsertRow() }
+        auctionJdbcRepository.upsertModifiers(modifierRows)
+        val modifierIds =
+            auctionJdbcRepository
+                .findModifierIds(modifierRows)
+                .mapKeys { (modifier, _) ->
+                    net.jonasmf.auctionengine.mapper.AuctionModifierKey(
+                        type = modifier.type,
+                        value = modifier.value,
+                    )
+                }
+
+        val itemRows = itemVariants.map { it.toUpsertRow() }
+        auctionJdbcRepository.upsertAuctionItems(itemRows)
+        val itemIds = auctionJdbcRepository.findAuctionItemIds(itemVariants.map { it.variantHash })
+
+        val linkRows =
+            itemVariants.flatMap { variant ->
+                variant.toModifierLinkRows(
+                    auctionItemId = itemIds.getValue(variant.variantHash),
+                    modifierIds = modifierIds,
+                )
+            }
+        auctionJdbcRepository.upsertAuctionItemModifierLinks(linkRows)
+
+        val auctionRows =
+            auctions.map { auction ->
+                auction.toUpsertRow(
+                    connectedRealmId = connectedRealmId,
+                    auctionItemId = itemIds.getValue(auction.itemVariant.variantHash),
+                    updateHistoryId = updateHistoryId,
+                    snapshotTime = snapshotTime,
+                )
+            }
+        auctionJdbcRepository.upsertAuctions(auctionRows)
+    }
+
+    private fun streamAuctionBatches(
+        payloadPath: Path,
+        consumer: (List<SnapshotAuction>) -> Unit,
+    ) {
+        val mapper = jacksonObjectMapper()
+        val jsonFactory = JsonFactory(mapper)
+        payloadPath.toFile().inputStream().use { input ->
+            jsonFactory.createParser(input).use { parser ->
+                require(parser.nextToken() == JsonToken.START_OBJECT) {
+                    "Auction payload root must be a JSON object"
+                }
+                while (parser.nextToken() != JsonToken.END_OBJECT) {
+                    val fieldName = parser.currentName
+                    parser.nextToken()
+                    if (fieldName == "auctions") {
+                        require(parser.currentToken == JsonToken.START_ARRAY) {
+                            "Auction payload field 'auctions' must be an array"
+                        }
+                        val batch = mutableListOf<SnapshotAuction>()
+                        while (parser.nextToken() != JsonToken.END_ARRAY) {
+                            batch += mapper.readValue(parser, AuctionDTO::class.java).toSnapshotAuction()
+                            if (batch.size >= snapshotBatchSize) {
+                                consumer(batch.toList())
+                                batch.clear()
+                            }
+                        }
+                        if (batch.isNotEmpty()) {
+                            consumer(batch.toList())
+                        }
+                    } else {
+                        parser.skipChildren()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/net/jonasmf/auctionengine/service/BlizzardAuctionService.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/service/BlizzardAuctionService.kt
@@ -4,50 +4,33 @@ import net.jonasmf.auctionengine.config.BlizzardApiProperties
 import net.jonasmf.auctionengine.constant.Region
 import net.jonasmf.auctionengine.dbo.dynamodb.converters.toKotlin
 import net.jonasmf.auctionengine.dbo.rds.realm.ConnectedRealm
-import net.jonasmf.auctionengine.dbo.rds.realm.ConnectedRealmUpdateHistory
 import net.jonasmf.auctionengine.domain.AuctionHouse
 import net.jonasmf.auctionengine.dto.auction.AuctionDTO
-import net.jonasmf.auctionengine.dto.auction.AuctionData
 import net.jonasmf.auctionengine.dto.auction.AuctionDataResponse
 import net.jonasmf.auctionengine.integration.blizzard.BlizzardApiClientException
 import net.jonasmf.auctionengine.integration.blizzard.BlizzardAuctionApiClient
 import net.jonasmf.auctionengine.integration.blizzard.DownloadedAuctionPayload
-import net.jonasmf.auctionengine.repository.rds.AuctionItemModifierRepository
-import net.jonasmf.auctionengine.repository.rds.AuctionItemRepository
-import net.jonasmf.auctionengine.repository.rds.AuctionRepository
-import net.jonasmf.auctionengine.utility.AuctionVariantKeyUtility
 import net.jonasmf.auctionengine.utility.JvmRuntimeDiagnostics
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 import java.time.ZonedDateTime
 import java.util.Locale
 import java.util.TimeZone
 import kotlin.io.path.deleteIfExists
-import kotlin.math.min
-import net.jonasmf.auctionengine.dbo.rds.auction.Auction as AuctionDBO
-import net.jonasmf.auctionengine.dbo.rds.auction.AuctionItem as AuctionItemDBO
-import net.jonasmf.auctionengine.dbo.rds.auction.AuctionItemModifier as AuctionItemModifierDBO
 
 @Service
 class BlizzardAuctionService(
     private val properties: BlizzardApiProperties,
     private val blizzardAuctionApiClient: BlizzardAuctionApiClient,
-    private val authService: AuthService,
     private val amazonS3: AmazonS3Service,
-    private val auctionRepository: AuctionRepository,
-    private val auctionItemRepository: AuctionItemRepository,
     private val hourlyPriceStatisticsService: HourlyPriceStatisticsService,
     private val realmService: ConnectedRealmService,
-    private val auctionItemModifierRepository: AuctionItemModifierRepository,
-    private val updateHistoryService: ConnectedRealmUpdateHistoryService,
+    private val auctionSnapshotPersistenceService: AuctionSnapshotPersistenceService,
     private val auctionHouseService: AuctionHouseService,
     private val runtimeHealthTracker: RuntimeHealthTracker,
 ) {
-    private val auctionBatchSize = 100_000
-    private val logBatchSize = auctionBatchSize
     val logger: Logger = LoggerFactory.getLogger(BlizzardAuctionService::class.java)
 
     fun updateAuctionHouses(
@@ -246,6 +229,30 @@ class BlizzardAuctionService(
                     JvmRuntimeDiagnostics.snapshot(),
                 )
                 runtimeHealthTracker.markUpdateBatchProgress(
+                    "persist-current-auctions",
+                    region = region,
+                    connectedRealmId = connectedRealmId,
+                )
+                val snapshotPersistenceStartTime = System.currentTimeMillis()
+                val snapshotSummary =
+                    saveAuctionsToDatabase(
+                        connectedRealm = connectedRealm,
+                        auctionCount = hourlyStatsSummary.processedAuctions,
+                        lastModified = lastModified,
+                        payloadPath = downloadedPayload.path,
+                        connectedRealmId = connectedRealmId,
+                    )
+                logger.info(
+                    "Completed current auction persistence for realm {} region {} auctions={} batches={} softDeleted={} in {}ms {}",
+                    connectedRealmId,
+                    region,
+                    snapshotSummary.processedAuctions,
+                    snapshotSummary.batchCount,
+                    snapshotSummary.softDeletedAuctions,
+                    System.currentTimeMillis() - snapshotPersistenceStartTime,
+                    JvmRuntimeDiagnostics.snapshot(),
+                )
+                runtimeHealthTracker.markUpdateBatchProgress(
                     "update-auction-house-times",
                     region = region,
                     connectedRealmId = connectedRealmId,
@@ -372,413 +379,30 @@ class BlizzardAuctionService(
         }
     }
 
-    /**
-     * Saves auctions to the database in batches, along with associated items and modifiers.
-     * Also updates the latest dump timestamp and marks the update as completed.
-     */
     private fun saveAuctionsToDatabase(
         connectedRealm: ConnectedRealm,
         auctionCount: Int,
         lastModified: ZonedDateTime,
-        data: AuctionData?,
+        payloadPath: java.nio.file.Path,
         connectedRealmId: Int,
-        startTime: Long,
-        url: String,
-    ) {
-        if (data == null || data.auctions.isEmpty()) {
-            logger.warn("No auction data to process for realm $connectedRealmId")
-            return
+    ): AuctionSnapshotPersistenceSummary {
+        if (auctionCount <= 0) {
+            logger.warn("No auction data to process for realm {}", connectedRealmId)
+            return AuctionSnapshotPersistenceSummary(processedAuctions = 0, batchCount = 0, softDeletedAuctions = 0)
         }
-        try {
-            val updateHistory = updateHistoryService.startUpdate(connectedRealm, auctionCount, lastModified)
-            processAuctionsInBatches(data.auctions, connectedRealm, connectedRealmId, updateHistory, startTime)
-            realmService.updateLatestDump(connectedRealmId, lastModified.toInstant())
-            updateHistoryService.setUpdateToCompleted(connectedRealmId, lastModified)
-            logger.info(
-                "Successfully processed $auctionCount auctions for $connectedRealmId in ${System.currentTimeMillis() - startTime}ms",
-            )
-        } catch (e: Exception) {
-            logger.error("Failed to process auction data for realm $connectedRealmId", e)
-            authService.getToken().subscribe { token ->
-                logger.error("Processing failed for URL: $url&access_token=$token", e)
-            }
-        }
+        return auctionSnapshotPersistenceService.saveSnapshot(
+            payloadPath = payloadPath,
+            connectedRealm = connectedRealm,
+            auctionCount = auctionCount,
+            lastModified = lastModified,
+        )
     }
 
-    @Transactional
-    fun processAuctionsInBatches(
-        auctions: List<AuctionDTO>,
-        connectedRealm: ConnectedRealm,
-        connectedRealmId: Int,
-        updateHistory: ConnectedRealmUpdateHistory,
-        startTime: Long,
-    ) {
-        val totalAuctions = auctions.size
-        logger.info("Processing $totalAuctions auctions in batches of $auctionBatchSize for realm $connectedRealmId")
-
-        try {
-            val processedItems = mutableMapOf<String, AuctionItemDBO>()
-            val newItems = mutableListOf<AuctionItemDBO>()
-            var duplicateItemCount = 0
-            val totalAuctions = auctions.size
-
-            auctions.forEachIndexed { index, auctionDTO ->
-                val itemKey = createItemKey(auctionDTO.item)
-
-                if (processedItems.containsKey(itemKey)) {
-                    return@forEachIndexed
-                }
-                val existingItems =
-                    auctionItemRepository.findByCompositeKeyWithNullHandlingList(
-                        auctionDTO.item.id,
-                        auctionDTO.item.pet_breed_id,
-                        auctionDTO.item.pet_level,
-                        auctionDTO.item.pet_quality_id,
-                        auctionDTO.item.pet_species_id,
-                        auctionDTO.item.context,
-                        AuctionVariantKeyUtility.canonicalBonusKey(auctionDTO.item.bonus_lists),
-                    )
-
-                val existingItem =
-                    if (existingItems.isNotEmpty()) {
-                        if (existingItems.size > 1) {
-                            duplicateItemCount++
-                            logger.debug(
-                                "Found ${existingItems.size} duplicate items for itemId=${auctionDTO.item.id}, petBreedId=${auctionDTO.item.pet_breed_id}, petLevel=${auctionDTO.item.pet_level}, petQualityId=${auctionDTO.item.pet_quality_id}, petSpeciesId=${auctionDTO.item.pet_species_id}, context=${auctionDTO.item.context}, bonusLists=${auctionDTO.item.bonus_lists}. Using first match.",
-                            )
-                        }
-                        existingItems.first()
-                    } else {
-                        null
-                    }
-
-                if (existingItem != null) {
-                    processedItems[itemKey] = existingItem
-                    logger.debug("Found existing item for key: $itemKey")
-                } else {
-                    val newItem = auctionDTO.item.toDBO()
-                    newItems.add(newItem)
-                    processedItems[itemKey] = newItem
-                    logger.debug("Created new item for key: $itemKey")
-                }
-
-                // logger progress every 10,000 items processed
-                if ((index + 1) % 10000 == 0) {
-                    val progress = ((index + 1) * 100.0 / totalAuctions).toInt()
-                    logger.info(
-                        "Item processing progress: ${index + 1}/$totalAuctions ($progress%) - $duplicateItemCount duplicate items found so far",
-                    )
-                }
-            }
-
-            logger.info(
-                "Found ${processedItems.size} unique items (${newItems.size} new, ${processedItems.size - newItems.size} existing) for realm $connectedRealmId",
-            )
-            if (duplicateItemCount > 0) {
-                logger.warn(
-                    "Found $duplicateItemCount items with duplicate entries in database - this indicates data quality issues that should be investigated",
-                )
-            }
-
-            if (newItems.isNotEmpty()) {
-                val itemsStartTime = System.currentTimeMillis()
-                saveItemsInBatches(newItems, "items")
-                val itemsElapsed = System.currentTimeMillis() - itemsStartTime
-                logger.info(
-                    "Successfully saved ${newItems.size} new items for realm $connectedRealmId in ${itemsElapsed}ms",
-                )
-            }
-
-            val auctionMappingStartTime = System.currentTimeMillis()
-            val auctionDbos =
-                auctions.map { auctionDTO ->
-                    val itemKey = createItemKey(auctionDTO.item)
-                    val item = processedItems[itemKey]
-                    if (item == null) {
-                        throw IllegalStateException("Item not found for key: $itemKey")
-                    }
-
-                    auctionDTO.toDBO(connectedRealm, updateHistory).copy(item = item)
-                }
-            val auctionMappingElapsed = System.currentTimeMillis() - auctionMappingStartTime
-            logger.info("Mapped ${auctionDbos.size} auctions for realm $connectedRealmId in ${auctionMappingElapsed}ms")
-
-            logger.info("Processing ${auctionDbos.size} auctions for realm $connectedRealmId")
-            saveAuctionsInBatches(auctionDbos, connectedRealm, connectedRealmId, updateHistory, startTime)
-
-            val modifiersExtractionStartTime = System.currentTimeMillis()
-            val modifiers =
-                auctionDbos.flatMap { auction ->
-                    auction.item.modifiers ?: emptyList()
-                }
-            val modifiersExtractionElapsed = System.currentTimeMillis() - modifiersExtractionStartTime
-            logger.info(
-                "Extracted ${modifiers.size} item modifiers for realm $connectedRealmId in ${modifiersExtractionElapsed}ms",
-            )
-
-            if (modifiers.isNotEmpty()) {
-                logger.info("Processing ${modifiers.size} item modifiers for realm $connectedRealmId")
-                saveModifiersInBatches(modifiers, "modifiers")
-            }
-
-            logger.info("Successfully completed processing for realm $connectedRealmId")
-        } catch (e: Exception) {
-            logger.error("Failed to process auctions for realm $connectedRealmId", e)
-            throw e
-        }
-    }
-
-    private fun createItemKey(item: net.jonasmf.auctionengine.dto.auction.AuctionItemDTO): String =
-        buildString {
-            append(item.id)
-            append('_')
-            append(item.pet_breed_id ?: "null")
-            append('_')
-            append(item.pet_level ?: "null")
-            append('_')
-            append(item.pet_quality_id ?: "null")
-            append('_')
-            append(item.pet_species_id ?: "null")
-            append('_')
-            append(item.context ?: "null")
-            append('_')
-            append(item.modifiers?.hashCode() ?: "null")
-            append('_')
-            append(AuctionVariantKeyUtility.canonicalBonusKey(item.bonus_lists))
-        }
-
-    private fun saveItemsInBatches(
-        items: List<AuctionItemDBO>,
-        itemType: String,
-    ) {
-        val batches = items.chunked(auctionBatchSize)
-        val totalStartTime = System.currentTimeMillis()
-        logger.debug("Saving ${items.size} $itemType in ${batches.size} batches")
-
-        batches.forEachIndexed { index, batch ->
-            val batchStartTime = System.currentTimeMillis()
-            try {
-                logger.debug("Saving batch ${index + 1}/${batches.size} with ${batch.size} $itemType")
-                val savedItems = auctionItemRepository.saveAll(batch)
-                val batchElapsed = System.currentTimeMillis() - batchStartTime
-                val batchRate = if (batchElapsed > 0) (savedItems.size * 1000.0 / batchElapsed).toInt() else 0
-                logger.debug(
-                    "Successfully saved batch ${index + 1} with ${savedItems.size} $itemType in ${batchElapsed}ms ($batchRate $itemType/sec)",
-                )
-
-                if ((index + 1) % 10 == 0 || index == batches.size - 1) {
-                    val totalElapsed = System.currentTimeMillis() - totalStartTime
-                    val totalRate =
-                        if (totalElapsed >
-                            0
-                        ) {
-                            ((index + 1) * auctionBatchSize * 1000.0 / totalElapsed).toInt()
-                        } else {
-                            0
-                        }
-                    val progress = min((index + 1) * auctionBatchSize, items.size)
-                    logger.info(
-                        "Saved $progress/${items.size} $itemType in ${totalElapsed}ms ($totalRate $itemType/sec)",
-                    )
-                }
-            } catch (e: Exception) {
-                val batchElapsed = System.currentTimeMillis() - batchStartTime
-                logger.error("Failed to save batch ${index + 1} of $itemType after ${batchElapsed}ms", e)
-                throw e
-            }
-        }
-
-        val totalElapsed = System.currentTimeMillis() - totalStartTime
-        val totalRate = if (totalElapsed > 0) (items.size * 1000.0 / totalElapsed).toInt() else 0
-        logger.info("Completed saving ${items.size} $itemType in ${totalElapsed}ms ($totalRate $itemType/sec)")
-    }
-
-    private fun saveAuctionsInBatches(
-        auctionDbos: List<AuctionDBO>,
-        connectedRealm: ConnectedRealm,
-        connectedRealmId: Int,
-        updateHistory: ConnectedRealmUpdateHistory,
-        startTime: Long,
-    ) {
-        val batches = auctionDbos.chunked(auctionBatchSize)
-        logger.debug("Saving ${auctionDbos.size} auctions in ${batches.size} batches for realm $connectedRealmId")
-
-        batches.forEachIndexed { index, batch ->
-            val batchStartTime = System.currentTimeMillis()
-            try {
-                logger.debug(
-                    "Saving auction batch ${index + 1}/${batches.size} with ${batch.size} auctions for realm $connectedRealmId",
-                )
-
-                // Use batch upsert for maximum performance - process in smaller chunks to avoid memory issues
-                val chunkSize = 1000
-                val chunks = batch.chunked(chunkSize)
-                var totalProcessed = 0
-                var totalDuplicates = 0
-
-                chunks.forEach { chunk ->
-                    val chunkStartTime = System.currentTimeMillis()
-                    var chunkProcessed = 0
-                    var chunkDuplicates = 0
-
-                    chunk.forEach { auction ->
-                        try {
-                            val upsertedCount =
-                                auctionRepository.upsertAuction(
-                                    id = auction.id.id,
-                                    connectedRealmId = auction.id.connectedRealm.id,
-                                    itemId =
-                                        auction.item.id
-                                            ?: throw IllegalStateException(
-                                                "Auction item missing identifier for auction ${auction.id.id}",
-                                            ),
-                                    quantity = auction.quantity,
-                                    bid = auction.bid,
-                                    unitPrice = auction.unitPrice,
-                                    timeLeft = auction.timeLeft.ordinal,
-                                    buyout = auction.buyout,
-                                    firstSeen = auction.firstSeen,
-                                    lastSeen = auction.lastSeen,
-                                    updateHistoryId = updateHistory.id,
-                                )
-
-                            if (upsertedCount > 0) {
-                                chunkProcessed++
-                            } else {
-                                chunkDuplicates++
-                            }
-                        } catch (individualException: Exception) {
-                            logger.warn(
-                                "Failed to upsert auction ${auction.id.id} for realm $connectedRealmId: ${individualException.message}",
-                            )
-                            chunkDuplicates++
-                        }
-                    }
-
-                    val chunkElapsed = System.currentTimeMillis() - chunkStartTime
-                    val chunkRate = if (chunkElapsed > 0) (chunk.size * 1000.0 / chunkElapsed).toInt() else 0
-                    logger.debug(
-                        "Processed chunk with ${chunk.size} auctions: $chunkProcessed saved, $chunkDuplicates duplicates for realm $connectedRealmId in ${chunkElapsed}ms ($chunkRate auctions/sec)",
-                    )
-
-                    totalProcessed += chunkProcessed
-                    totalDuplicates += chunkDuplicates
-                }
-
-                val batchElapsed = System.currentTimeMillis() - batchStartTime
-                val batchRate = if (batchElapsed > 0) (batch.size * 1000.0 / batchElapsed).toInt() else 0
-                logger.debug(
-                    "Successfully processed auction batch ${index + 1} with ${batch.size} auctions: $totalProcessed saved, $totalDuplicates duplicates for realm $connectedRealmId in ${batchElapsed}ms ($batchRate auctions/sec)",
-                )
-
-                val processedCount = (index + 1) * auctionBatchSize
-                val progress = min(processedCount, auctionDbos.size)
-
-                if (progress % logBatchSize == 0 || index == batches.size - 1) {
-                    val elapsed = System.currentTimeMillis() - startTime
-                    val rate = (progress * 1000.0 / elapsed).toInt()
-                    logger.info(
-                        "Realm $connectedRealmId: Processed $progress/${auctionDbos.size} auctions ($rate auctions/sec)",
-                    )
-                }
-            } catch (e: Exception) {
-                val batchElapsed = System.currentTimeMillis() - batchStartTime
-                logger.error(
-                    "Failed to save auction batch ${index + 1} for realm $connectedRealmId after ${batchElapsed}ms",
-                    e,
-                )
-                throw e
-            }
-        }
-    }
-
-    private fun saveModifiersInBatches(
-        modifiers: List<AuctionItemModifierDBO>,
-        itemType: String,
-    ) {
-        if (modifiers.isEmpty()) return
-
-        val batches = modifiers.chunked(auctionBatchSize)
-        val totalStartTime = System.currentTimeMillis()
-        logger.debug("Saving ${modifiers.size} $itemType in ${batches.size} batches")
-
-        batches.forEachIndexed { index, batch ->
-            val batchStartTime = System.currentTimeMillis()
-            try {
-                logger.debug("Saving modifier batch ${index + 1}/${batches.size} with ${batch.size} $itemType")
-                val savedModifiers = auctionItemModifierRepository.saveAll(batch)
-                val batchElapsed = System.currentTimeMillis() - batchStartTime
-                val batchRate = if (batchElapsed > 0) (savedModifiers.size * 1000.0 / batchElapsed).toInt() else 0
-                logger.debug(
-                    "Successfully saved modifier batch ${index + 1} with ${savedModifiers.size} $itemType in ${batchElapsed}ms ($batchRate $itemType/sec)",
-                )
-
-                if ((index + 1) % 10 == 0 || index == batches.size - 1) {
-                    val totalElapsed = System.currentTimeMillis() - totalStartTime
-                    val totalRate =
-                        if (totalElapsed >
-                            0
-                        ) {
-                            ((index + 1) * auctionBatchSize * 1000.0 / totalElapsed).toInt()
-                        } else {
-                            0
-                        }
-                    val progress = min((index + 1) * auctionBatchSize, modifiers.size)
-                    logger.info(
-                        "Saved $progress/${modifiers.size} $itemType in ${totalElapsed}ms ($totalRate $itemType/sec)",
-                    )
-                }
-            } catch (e: Exception) {
-                val batchElapsed = System.currentTimeMillis() - batchStartTime
-                logger.error("Failed to save modifier batch ${index + 1} of $itemType after ${batchElapsed}ms", e)
-                throw e
-            }
-        }
-
-        val totalElapsed = System.currentTimeMillis() - totalStartTime
-        val totalRate = if (totalElapsed > 0) (modifiers.size * 1000.0 / totalElapsed).toInt() else 0
-        logger.info("Completed saving ${modifiers.size} $itemType in ${totalElapsed}ms ($totalRate $itemType/sec)")
-    }
-
-    @Transactional
     fun saveAuction(
         auction: AuctionDTO,
         connectedRealm: ConnectedRealm,
     ) {
-        try {
-            val updateHistory = updateHistoryService.startUpdate(connectedRealm, 1, ZonedDateTime.now())
-            val auctionDbo = auction.toDBO(connectedRealm, updateHistory)
-
-            auctionDbo.item.modifiers?.forEach { modifier ->
-                auctionItemModifierRepository.save(modifier)
-            }
-            val savedItem = auctionItemRepository.save(auctionDbo.item)
-
-            auctionRepository.upsertAuction(
-                id = auctionDbo.id.id,
-                connectedRealmId = connectedRealm.id,
-                itemId =
-                    savedItem.id ?: throw IllegalStateException(
-                        "Failed to persist auction item for ${auction.id}",
-                    ),
-                quantity = auctionDbo.quantity,
-                bid = auctionDbo.bid,
-                unitPrice = auctionDbo.unitPrice,
-                timeLeft = auctionDbo.timeLeft.ordinal,
-                buyout = auctionDbo.buyout,
-                firstSeen = auctionDbo.firstSeen,
-                lastSeen = auctionDbo.lastSeen,
-                updateHistoryId = updateHistory.id,
-            )
-
-            logger.debug("Successfully upserted auction ${auctionDbo.id.id} for item ${savedItem.id}")
-        } catch (e: Exception) {
-            if (e.message?.contains("Duplicate entry") == true) {
-                logger.debug("Skipping duplicate auction ${auction.id} for realm ${connectedRealm.id}")
-                return
-            }
-            logger.error("Failed to save auction: ${auction.id}", e)
-            throw e
-        }
+        auctionSnapshotPersistenceService.saveAuction(auction, connectedRealm)
+        logger.debug("Successfully upserted auction {} for realm {}", auction.id, connectedRealm.id)
     }
 }

--- a/src/main/kotlin/net/jonasmf/auctionengine/service/ConnectedRealmUpdateHistoryService.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/service/ConnectedRealmUpdateHistoryService.kt
@@ -34,6 +34,7 @@ class ConnectedRealmUpdateHistoryService(
         return existing ?: repository.save(history)
     }
 
+    @Transactional
     fun setUpdateToCompleted(
         connectedRealmId: Int,
         lastModified: ZonedDateTime,

--- a/src/main/kotlin/net/jonasmf/auctionengine/utility/AuctionVariantKeyUtility.kt
+++ b/src/main/kotlin/net/jonasmf/auctionengine/utility/AuctionVariantKeyUtility.kt
@@ -1,6 +1,7 @@
 package net.jonasmf.auctionengine.utility
 
 import net.jonasmf.auctionengine.dto.auction.ModifierDTO
+import java.security.MessageDigest
 
 object AuctionVariantKeyUtility {
     fun canonicalBonusKey(bonusLists: List<Int>?): String =
@@ -12,6 +13,41 @@ object AuctionVariantKeyUtility {
     fun canonicalModifierKey(modifiers: List<ModifierDTO>?): String =
         modifiers
             .orEmpty()
-            .sortedBy { it.value }
+            .sortedBy(ModifierDTO::value)
             .joinToString(",") { it.value.toString() }
+
+    fun canonicalTypedModifierKey(modifiers: List<ModifierDTO>?): String =
+        modifiers
+            .orEmpty()
+            .sortedWith(compareBy(ModifierDTO::type, ModifierDTO::value))
+            .joinToString(",") { "${it.type}:${it.value}" }
+
+    fun variantHash(
+        itemId: Int,
+        bonusKey: String,
+        modifierKey: String,
+        context: Int?,
+        petBreedId: Int?,
+        petLevel: Int?,
+        petQualityId: Int?,
+        petSpeciesId: Int?,
+    ): String =
+        sha256Hex(
+            listOf(
+                itemId.toString(),
+                bonusKey,
+                modifierKey,
+                context?.toString() ?: "",
+                petBreedId?.toString() ?: "",
+                petLevel?.toString() ?: "",
+                petQualityId?.toString() ?: "",
+                petSpeciesId?.toString() ?: "",
+            ).joinToString("|"),
+        )
+
+    private fun sha256Hex(value: String): String =
+        MessageDigest
+            .getInstance("SHA-256")
+            .digest(value.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,6 +58,8 @@ app:
     profession-recipe-sync-zone: GMT+1
     profession-recipe-sync-startup-delay: PT30S
     profession-recipe-sync-startup-repeat-delay: P3650D
+    deleted-auction-cleanup-cron: "0 0 4 * * *"
+    deleted-auction-cleanup-zone: GMT+1
   health:
     stuck-update-threshold: PT20M
 

--- a/src/main/resources/db/migration/V11__bulk_snapshot_current_auctions.sql
+++ b/src/main/resources/db/migration/V11__bulk_snapshot_current_auctions.sql
@@ -1,0 +1,379 @@
+SET @auction_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'auction'
+);
+
+SET @auction_item_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'auction_item'
+);
+
+SET @auction_item_modifier_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'auction_item_modifier'
+);
+
+SET @legacy_modifier_link_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'auction_item_modifiers'
+);
+
+SET @snapshot_tables_exist = IF(
+    @auction_exists > 0
+    AND @auction_item_exists > 0
+    AND @auction_item_modifier_exists > 0,
+    1,
+    0
+);
+
+SET @add_deleted_at_sql = IF(
+    @snapshot_tables_exist > 0,
+    'ALTER TABLE auction
+        ADD COLUMN IF NOT EXISTS deleted_at DATETIME(6) NULL AFTER last_seen',
+    'SELECT 1'
+);
+PREPARE add_deleted_at_stmt FROM @add_deleted_at_sql;
+EXECUTE add_deleted_at_stmt;
+DEALLOCATE PREPARE add_deleted_at_stmt;
+
+SET @add_variant_hash_sql = IF(
+    @snapshot_tables_exist > 0,
+    'ALTER TABLE auction_item
+        ADD COLUMN IF NOT EXISTS variant_hash CHAR(64) NULL AFTER item_id',
+    'SELECT 1'
+);
+PREPARE add_variant_hash_stmt FROM @add_variant_hash_sql;
+EXECUTE add_variant_hash_stmt;
+DEALLOCATE PREPARE add_variant_hash_stmt;
+
+DROP TEMPORARY TABLE IF EXISTS tmp_auction_modifier_canonical;
+SET @create_tmp_auction_modifier_canonical_sql = IF(
+    @snapshot_tables_exist > 0,
+    'CREATE TEMPORARY TABLE tmp_auction_modifier_canonical AS
+     SELECT MIN(id) AS canonical_id, type, value
+     FROM auction_item_modifier
+     GROUP BY type, value',
+    'SELECT 1'
+);
+PREPARE create_tmp_auction_modifier_canonical_stmt FROM @create_tmp_auction_modifier_canonical_sql;
+EXECUTE create_tmp_auction_modifier_canonical_stmt;
+DEALLOCATE PREPARE create_tmp_auction_modifier_canonical_stmt;
+
+SET @normalize_legacy_modifier_ids_sql = IF(
+    @snapshot_tables_exist > 0 AND @legacy_modifier_link_exists > 0,
+    'UPDATE auction_item_modifiers legacy
+     JOIN auction_item_modifier modifier_row ON modifier_row.id = legacy.modifiers_id
+     JOIN tmp_auction_modifier_canonical canonical
+       ON canonical.type = modifier_row.type
+      AND canonical.value = modifier_row.value
+     SET legacy.modifiers_id = canonical.canonical_id',
+    'SELECT 1'
+);
+PREPARE normalize_legacy_modifier_ids_stmt FROM @normalize_legacy_modifier_ids_sql;
+EXECUTE normalize_legacy_modifier_ids_stmt;
+DEALLOCATE PREPARE normalize_legacy_modifier_ids_stmt;
+
+SET @delete_duplicate_modifiers_sql = IF(
+    @snapshot_tables_exist > 0,
+    'DELETE modifier_row
+     FROM auction_item_modifier modifier_row
+     LEFT JOIN tmp_auction_modifier_canonical canonical
+         ON canonical.canonical_id = modifier_row.id
+     WHERE canonical.canonical_id IS NULL',
+    'SELECT 1'
+);
+PREPARE delete_duplicate_modifiers_stmt FROM @delete_duplicate_modifiers_sql;
+EXECUTE delete_duplicate_modifiers_stmt;
+DEALLOCATE PREPARE delete_duplicate_modifiers_stmt;
+
+SET @drop_modifier_unique_sql = IF(
+    @snapshot_tables_exist > 0 AND EXISTS (
+        SELECT 1
+        FROM information_schema.statistics
+        WHERE table_schema = DATABASE()
+          AND table_name = 'auction_item_modifier'
+          AND index_name = 'uk_auction_item_modifier_type_value'
+    ),
+    'DROP INDEX uk_auction_item_modifier_type_value ON auction_item_modifier',
+    'SELECT 1'
+);
+PREPARE drop_modifier_unique_stmt FROM @drop_modifier_unique_sql;
+EXECUTE drop_modifier_unique_stmt;
+DEALLOCATE PREPARE drop_modifier_unique_stmt;
+
+SET @create_modifier_unique_sql = IF(
+    @snapshot_tables_exist > 0,
+    'CREATE UNIQUE INDEX uk_auction_item_modifier_type_value
+        ON auction_item_modifier (type, value)',
+    'SELECT 1'
+);
+PREPARE create_modifier_unique_stmt FROM @create_modifier_unique_sql;
+EXECUTE create_modifier_unique_stmt;
+DEALLOCATE PREPARE create_modifier_unique_stmt;
+
+SET @create_modifier_link_table_sql = IF(
+    @snapshot_tables_exist > 0,
+    'CREATE TABLE IF NOT EXISTS auction_item_modifier_link (
+        auction_item_id BIGINT NOT NULL,
+        sort_order INT NOT NULL,
+        modifier_id BIGINT NOT NULL,
+        PRIMARY KEY (auction_item_id, sort_order),
+        KEY idx_auction_item_modifier_link_modifier_id (modifier_id),
+        CONSTRAINT fk_auction_item_modifier_link_item
+            FOREIGN KEY (auction_item_id) REFERENCES auction_item (id),
+        CONSTRAINT fk_auction_item_modifier_link_modifier
+            FOREIGN KEY (modifier_id) REFERENCES auction_item_modifier (id)
+    )',
+    'SELECT 1'
+);
+PREPARE create_modifier_link_table_stmt FROM @create_modifier_link_table_sql;
+EXECUTE create_modifier_link_table_stmt;
+DEALLOCATE PREPARE create_modifier_link_table_stmt;
+
+SET @migrate_legacy_modifier_links_sql = IF(
+    @snapshot_tables_exist > 0 AND @legacy_modifier_link_exists > 0,
+    'INSERT INTO auction_item_modifier_link (auction_item_id, sort_order, modifier_id)
+     SELECT
+         legacy.auction_item_id,
+         ROW_NUMBER() OVER (PARTITION BY legacy.auction_item_id ORDER BY legacy.modifiers_id) - 1,
+         legacy.modifiers_id
+     FROM auction_item_modifiers legacy
+     ON DUPLICATE KEY UPDATE
+         modifier_id = VALUES(modifier_id)',
+    'SELECT 1'
+);
+PREPARE migrate_legacy_modifier_links_stmt FROM @migrate_legacy_modifier_links_sql;
+EXECUTE migrate_legacy_modifier_links_stmt;
+DEALLOCATE PREPARE migrate_legacy_modifier_links_stmt;
+
+DROP TABLE IF EXISTS auction_item_modifiers;
+
+SET @populate_variant_hash_sql = IF(
+    @snapshot_tables_exist > 0,
+    'UPDATE auction_item item_row
+     LEFT JOIN (
+         SELECT
+             link.auction_item_id,
+             GROUP_CONCAT(
+                 CONCAT(modifier_row.type, '':'', modifier_row.value)
+                 ORDER BY modifier_row.type, modifier_row.value
+                 SEPARATOR '',''
+             ) AS modifier_key
+         FROM auction_item_modifier_link link
+         JOIN auction_item_modifier modifier_row ON modifier_row.id = link.modifier_id
+         GROUP BY link.auction_item_id
+     ) modifier_keys ON modifier_keys.auction_item_id = item_row.id
+     SET item_row.variant_hash = LOWER(
+         SHA2(
+             CONCAT_WS(
+                 ''|'',
+                 item_row.item_id,
+                 COALESCE(item_row.bonus_lists, ''''),
+                 COALESCE(modifier_keys.modifier_key, ''''),
+                 COALESCE(CAST(item_row.context AS CHAR), ''''),
+                 COALESCE(CAST(item_row.pet_breed_id AS CHAR), ''''),
+                 COALESCE(CAST(item_row.pet_level AS CHAR), ''''),
+                 COALESCE(CAST(item_row.pet_quality_id AS CHAR), ''''),
+                 COALESCE(CAST(item_row.pet_species_id AS CHAR), '''')
+             ),
+             256
+         )
+     )
+     WHERE item_row.variant_hash IS NULL
+        OR item_row.variant_hash = ''''',
+    'SELECT 1'
+);
+PREPARE populate_variant_hash_stmt FROM @populate_variant_hash_sql;
+EXECUTE populate_variant_hash_stmt;
+DEALLOCATE PREPARE populate_variant_hash_stmt;
+
+DROP TEMPORARY TABLE IF EXISTS tmp_auction_item_canonical;
+SET @create_tmp_auction_item_canonical_sql = IF(
+    @snapshot_tables_exist > 0,
+    'CREATE TEMPORARY TABLE tmp_auction_item_canonical AS
+     SELECT MIN(id) AS canonical_id, variant_hash
+     FROM auction_item
+     GROUP BY variant_hash',
+    'SELECT 1'
+);
+PREPARE create_tmp_auction_item_canonical_stmt FROM @create_tmp_auction_item_canonical_sql;
+EXECUTE create_tmp_auction_item_canonical_stmt;
+DEALLOCATE PREPARE create_tmp_auction_item_canonical_stmt;
+
+SET @repoint_auction_items_sql = IF(
+    @snapshot_tables_exist > 0,
+    'UPDATE auction auction_row
+     JOIN auction_item item_row ON item_row.id = auction_row.item_id
+     JOIN tmp_auction_item_canonical canonical ON canonical.variant_hash = item_row.variant_hash
+     SET auction_row.item_id = canonical.canonical_id
+     WHERE auction_row.item_id <> canonical.canonical_id',
+    'SELECT 1'
+);
+PREPARE repoint_auction_items_stmt FROM @repoint_auction_items_sql;
+EXECUTE repoint_auction_items_stmt;
+DEALLOCATE PREPARE repoint_auction_items_stmt;
+
+SET @merge_modifier_links_sql = IF(
+    @snapshot_tables_exist > 0,
+    'INSERT INTO auction_item_modifier_link (auction_item_id, sort_order, modifier_id)
+     SELECT
+         canonical.canonical_id,
+         duplicate_link.sort_order,
+         duplicate_link.modifier_id
+     FROM auction_item_modifier_link duplicate_link
+     JOIN auction_item duplicate_item ON duplicate_item.id = duplicate_link.auction_item_id
+     JOIN tmp_auction_item_canonical canonical ON canonical.variant_hash = duplicate_item.variant_hash
+     WHERE duplicate_link.auction_item_id <> canonical.canonical_id
+     ON DUPLICATE KEY UPDATE
+         modifier_id = VALUES(modifier_id)',
+    'SELECT 1'
+);
+PREPARE merge_modifier_links_stmt FROM @merge_modifier_links_sql;
+EXECUTE merge_modifier_links_stmt;
+DEALLOCATE PREPARE merge_modifier_links_stmt;
+
+SET @delete_duplicate_modifier_links_sql = IF(
+    @snapshot_tables_exist > 0,
+    'DELETE duplicate_link
+     FROM auction_item_modifier_link duplicate_link
+     JOIN auction_item duplicate_item ON duplicate_item.id = duplicate_link.auction_item_id
+     JOIN tmp_auction_item_canonical canonical ON canonical.variant_hash = duplicate_item.variant_hash
+     WHERE duplicate_link.auction_item_id <> canonical.canonical_id',
+    'SELECT 1'
+);
+PREPARE delete_duplicate_modifier_links_stmt FROM @delete_duplicate_modifier_links_sql;
+EXECUTE delete_duplicate_modifier_links_stmt;
+DEALLOCATE PREPARE delete_duplicate_modifier_links_stmt;
+
+SET @delete_duplicate_items_sql = IF(
+    @snapshot_tables_exist > 0,
+    'DELETE duplicate_item
+     FROM auction_item duplicate_item
+     JOIN tmp_auction_item_canonical canonical ON canonical.variant_hash = duplicate_item.variant_hash
+     WHERE duplicate_item.id <> canonical.canonical_id',
+    'SELECT 1'
+);
+PREPARE delete_duplicate_items_stmt FROM @delete_duplicate_items_sql;
+EXECUTE delete_duplicate_items_stmt;
+DEALLOCATE PREPARE delete_duplicate_items_stmt;
+
+SET @set_variant_hash_not_null_sql = IF(
+    @snapshot_tables_exist > 0,
+    'ALTER TABLE auction_item
+        MODIFY COLUMN variant_hash CHAR(64) NOT NULL',
+    'SELECT 1'
+);
+PREPARE set_variant_hash_not_null_stmt FROM @set_variant_hash_not_null_sql;
+EXECUTE set_variant_hash_not_null_stmt;
+DEALLOCATE PREPARE set_variant_hash_not_null_stmt;
+
+SET @drop_auction_item_variant_hash_sql = IF(
+    @snapshot_tables_exist > 0 AND EXISTS (
+        SELECT 1
+        FROM information_schema.statistics
+        WHERE table_schema = DATABASE()
+          AND table_name = 'auction_item'
+          AND index_name = 'uk_auction_item_variant_hash'
+    ),
+    'DROP INDEX uk_auction_item_variant_hash ON auction_item',
+    'SELECT 1'
+);
+PREPARE drop_auction_item_variant_hash_stmt FROM @drop_auction_item_variant_hash_sql;
+EXECUTE drop_auction_item_variant_hash_stmt;
+DEALLOCATE PREPARE drop_auction_item_variant_hash_stmt;
+
+SET @drop_auction_item_item_id_sql = IF(
+    @snapshot_tables_exist > 0 AND EXISTS (
+        SELECT 1
+        FROM information_schema.statistics
+        WHERE table_schema = DATABASE()
+          AND table_name = 'auction_item'
+          AND index_name = 'idx_auction_item_item_id'
+    ),
+    'DROP INDEX idx_auction_item_item_id ON auction_item',
+    'SELECT 1'
+);
+PREPARE drop_auction_item_item_id_stmt FROM @drop_auction_item_item_id_sql;
+EXECUTE drop_auction_item_item_id_stmt;
+DEALLOCATE PREPARE drop_auction_item_item_id_stmt;
+
+SET @create_auction_item_variant_hash_sql = IF(
+    @snapshot_tables_exist > 0,
+    'CREATE UNIQUE INDEX uk_auction_item_variant_hash
+        ON auction_item (variant_hash)',
+    'SELECT 1'
+);
+PREPARE create_auction_item_variant_hash_stmt FROM @create_auction_item_variant_hash_sql;
+EXECUTE create_auction_item_variant_hash_stmt;
+DEALLOCATE PREPARE create_auction_item_variant_hash_stmt;
+
+SET @create_auction_item_item_id_sql = IF(
+    @snapshot_tables_exist > 0,
+    'CREATE INDEX idx_auction_item_item_id
+        ON auction_item (item_id)',
+    'SELECT 1'
+);
+PREPARE create_auction_item_item_id_stmt FROM @create_auction_item_item_id_sql;
+EXECUTE create_auction_item_item_id_stmt;
+DEALLOCATE PREPARE create_auction_item_item_id_stmt;
+
+SET @drop_auction_realm_update_deleted_sql = IF(
+    @snapshot_tables_exist > 0 AND EXISTS (
+        SELECT 1
+        FROM information_schema.statistics
+        WHERE table_schema = DATABASE()
+          AND table_name = 'auction'
+          AND index_name = 'idx_auction_connected_realm_update_deleted'
+    ),
+    'DROP INDEX idx_auction_connected_realm_update_deleted ON auction',
+    'SELECT 1'
+);
+PREPARE drop_auction_realm_update_deleted_stmt FROM @drop_auction_realm_update_deleted_sql;
+EXECUTE drop_auction_realm_update_deleted_stmt;
+DEALLOCATE PREPARE drop_auction_realm_update_deleted_stmt;
+
+SET @drop_auction_deleted_at_sql = IF(
+    @snapshot_tables_exist > 0 AND EXISTS (
+        SELECT 1
+        FROM information_schema.statistics
+        WHERE table_schema = DATABASE()
+          AND table_name = 'auction'
+          AND index_name = 'idx_auction_deleted_at'
+    ),
+    'DROP INDEX idx_auction_deleted_at ON auction',
+    'SELECT 1'
+);
+PREPARE drop_auction_deleted_at_stmt FROM @drop_auction_deleted_at_sql;
+EXECUTE drop_auction_deleted_at_stmt;
+DEALLOCATE PREPARE drop_auction_deleted_at_stmt;
+
+SET @create_auction_realm_update_deleted_sql = IF(
+    @snapshot_tables_exist > 0,
+    'CREATE INDEX idx_auction_connected_realm_update_deleted
+        ON auction (connected_realm_id, update_history_id, deleted_at)',
+    'SELECT 1'
+);
+PREPARE create_auction_realm_update_deleted_stmt FROM @create_auction_realm_update_deleted_sql;
+EXECUTE create_auction_realm_update_deleted_stmt;
+DEALLOCATE PREPARE create_auction_realm_update_deleted_stmt;
+
+SET @create_auction_deleted_at_sql = IF(
+    @snapshot_tables_exist > 0,
+    'CREATE INDEX idx_auction_deleted_at
+        ON auction (deleted_at)',
+    'SELECT 1'
+);
+PREPARE create_auction_deleted_at_stmt FROM @create_auction_deleted_at_sql;
+EXECUTE create_auction_deleted_at_stmt;
+DEALLOCATE PREPARE create_auction_deleted_at_stmt;
+
+DROP TEMPORARY TABLE IF EXISTS tmp_auction_modifier_canonical;
+DROP TEMPORARY TABLE IF EXISTS tmp_auction_item_canonical;

--- a/src/main/resources/db/migration/V12__add_snapshot_read_indexes.sql
+++ b/src/main/resources/db/migration/V12__add_snapshot_read_indexes.sql
@@ -1,0 +1,54 @@
+SET @auction_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'auction'
+);
+
+SET @auction_item_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'auction_item'
+);
+
+SET @drop_auction_item_item_id_sql = IF(
+    @auction_item_exists > 0 AND EXISTS (
+        SELECT 1
+        FROM information_schema.statistics
+        WHERE table_schema = DATABASE()
+          AND table_name = 'auction_item'
+          AND index_name = 'idx_auction_item_item_id'
+    ),
+    'DROP INDEX idx_auction_item_item_id ON auction_item',
+    'SELECT 1'
+);
+PREPARE drop_auction_item_item_id_stmt FROM @drop_auction_item_item_id_sql;
+EXECUTE drop_auction_item_item_id_stmt;
+DEALLOCATE PREPARE drop_auction_item_item_id_stmt;
+
+SET @create_auction_item_item_id_sql = IF(
+    @auction_item_exists > 0,
+    'CREATE INDEX idx_auction_item_item_id
+        ON auction_item (item_id, id)',
+    'SELECT 1'
+);
+PREPARE create_auction_item_item_id_stmt FROM @create_auction_item_item_id_sql;
+EXECUTE create_auction_item_item_id_stmt;
+DEALLOCATE PREPARE create_auction_item_item_id_stmt;
+
+SET @create_auction_realm_item_deleted_last_seen_sql = IF(
+    @auction_exists > 0 AND NOT EXISTS (
+        SELECT 1
+        FROM information_schema.statistics
+        WHERE table_schema = DATABASE()
+          AND table_name = 'auction'
+          AND index_name = 'idx_auction_realm_item_deleted_last_seen'
+    ),
+    'CREATE INDEX idx_auction_realm_item_deleted_last_seen
+        ON auction (connected_realm_id, item_id, deleted_at, last_seen)',
+    'SELECT 1'
+);
+PREPARE create_auction_realm_item_deleted_last_seen_stmt FROM @create_auction_realm_item_deleted_last_seen_sql;
+EXECUTE create_auction_realm_item_deleted_last_seen_stmt;
+DEALLOCATE PREPARE create_auction_realm_item_deleted_last_seen_stmt;

--- a/src/main/resources/db/migration/V12__add_snapshot_read_indexes.sql
+++ b/src/main/resources/db/migration/V12__add_snapshot_read_indexes.sql
@@ -37,18 +37,18 @@ PREPARE create_auction_item_item_id_stmt FROM @create_auction_item_item_id_sql;
 EXECUTE create_auction_item_item_id_stmt;
 DEALLOCATE PREPARE create_auction_item_item_id_stmt;
 
-SET @create_auction_realm_item_deleted_last_seen_sql = IF(
+SET @create_auction_item_realm_deleted_last_seen_sql = IF(
     @auction_exists > 0 AND NOT EXISTS (
         SELECT 1
         FROM information_schema.statistics
         WHERE table_schema = DATABASE()
           AND table_name = 'auction'
-          AND index_name = 'idx_auction_realm_item_deleted_last_seen'
+          AND index_name = 'idx_auction_item_realm_deleted_last_seen'
     ),
-    'CREATE INDEX idx_auction_realm_item_deleted_last_seen
-        ON auction (connected_realm_id, item_id, deleted_at, last_seen)',
+    'CREATE INDEX idx_auction_item_realm_deleted_last_seen
+        ON auction (item_id, connected_realm_id, deleted_at, last_seen)',
     'SELECT 1'
 );
-PREPARE create_auction_realm_item_deleted_last_seen_stmt FROM @create_auction_realm_item_deleted_last_seen_sql;
-EXECUTE create_auction_realm_item_deleted_last_seen_stmt;
-DEALLOCATE PREPARE create_auction_realm_item_deleted_last_seen_stmt;
+PREPARE create_auction_item_realm_deleted_last_seen_stmt FROM @create_auction_item_realm_deleted_last_seen_sql;
+EXECUTE create_auction_item_realm_deleted_last_seen_stmt;
+DEALLOCATE PREPARE create_auction_item_realm_deleted_last_seen_stmt;

--- a/src/main/resources/db/migration/V13__drop_accidental_auction_item_unique_constraint.sql
+++ b/src/main/resources/db/migration/V13__drop_accidental_auction_item_unique_constraint.sql
@@ -1,0 +1,114 @@
+SET @auction_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'auction'
+);
+
+SET @auction_item_fk_name = (
+    SELECT MIN(constraint_name)
+    FROM information_schema.key_column_usage
+    WHERE table_schema = DATABASE()
+      AND table_name = 'auction'
+      AND column_name = 'item_id'
+      AND referenced_table_name = 'auction_item'
+      AND referenced_column_name = 'id'
+);
+
+SET @accidental_auction_item_unique_index = (
+    SELECT MIN(index_name)
+    FROM (
+        SELECT index_name
+        FROM information_schema.statistics
+        WHERE table_schema = DATABASE()
+          AND table_name = 'auction'
+          AND non_unique = 0
+          AND index_name <> 'PRIMARY'
+        GROUP BY index_name
+        HAVING COUNT(*) = 1
+           AND MIN(column_name) = 'item_id'
+           AND MAX(column_name) = 'item_id'
+    ) accidental_indexes
+);
+
+SET @drop_auction_item_fk_sql = IF(
+    @auction_exists > 0
+    AND @auction_item_fk_name IS NOT NULL
+    AND @accidental_auction_item_unique_index IS NOT NULL,
+    CONCAT(
+        'ALTER TABLE auction DROP FOREIGN KEY `',
+        REPLACE(@auction_item_fk_name, '`', '``'),
+        '`'
+    ),
+    'SELECT 1'
+);
+PREPARE drop_auction_item_fk_stmt FROM @drop_auction_item_fk_sql;
+EXECUTE drop_auction_item_fk_stmt;
+DEALLOCATE PREPARE drop_auction_item_fk_stmt;
+
+SET @drop_accidental_auction_item_unique_index_sql = IF(
+    @auction_exists > 0 AND @accidental_auction_item_unique_index IS NOT NULL,
+    CONCAT(
+        'DROP INDEX `',
+        REPLACE(@accidental_auction_item_unique_index, '`', '``'),
+        '` ON auction'
+    ),
+    'SELECT 1'
+);
+PREPARE drop_accidental_auction_item_unique_index_stmt FROM @drop_accidental_auction_item_unique_index_sql;
+EXECUTE drop_accidental_auction_item_unique_index_stmt;
+DEALLOCATE PREPARE drop_accidental_auction_item_unique_index_stmt;
+
+SET @drop_old_snapshot_read_index_sql = IF(
+    @auction_exists > 0 AND EXISTS (
+        SELECT 1
+        FROM information_schema.statistics
+        WHERE table_schema = DATABASE()
+          AND table_name = 'auction'
+          AND index_name = 'idx_auction_realm_item_deleted_last_seen'
+    ),
+    'DROP INDEX idx_auction_realm_item_deleted_last_seen ON auction',
+    'SELECT 1'
+);
+PREPARE drop_old_snapshot_read_index_stmt FROM @drop_old_snapshot_read_index_sql;
+EXECUTE drop_old_snapshot_read_index_stmt;
+DEALLOCATE PREPARE drop_old_snapshot_read_index_stmt;
+
+SET @create_target_snapshot_read_index_sql = IF(
+    @auction_exists > 0 AND NOT EXISTS (
+        SELECT 1
+        FROM information_schema.statistics
+        WHERE table_schema = DATABASE()
+          AND table_name = 'auction'
+          AND index_name = 'idx_auction_item_realm_deleted_last_seen'
+    ),
+    'CREATE INDEX idx_auction_item_realm_deleted_last_seen
+        ON auction (item_id, connected_realm_id, deleted_at, last_seen)',
+    'SELECT 1'
+);
+PREPARE create_target_snapshot_read_index_stmt FROM @create_target_snapshot_read_index_sql;
+EXECUTE create_target_snapshot_read_index_stmt;
+DEALLOCATE PREPARE create_target_snapshot_read_index_stmt;
+
+SET @recreate_auction_item_fk_sql = IF(
+    @auction_exists > 0
+    AND @auction_item_fk_name IS NOT NULL
+    AND NOT EXISTS (
+        SELECT 1
+        FROM information_schema.key_column_usage
+        WHERE table_schema = DATABASE()
+          AND table_name = 'auction'
+          AND column_name = 'item_id'
+          AND referenced_table_name = 'auction_item'
+          AND referenced_column_name = 'id'
+    ),
+    CONCAT(
+        'ALTER TABLE auction ADD CONSTRAINT `',
+        REPLACE(@auction_item_fk_name, '`', '``'),
+        '` FOREIGN KEY (item_id) REFERENCES auction_item (id)'
+    ),
+    'SELECT 1'
+);
+PREPARE recreate_auction_item_fk_stmt FROM @recreate_auction_item_fk_sql;
+EXECUTE recreate_auction_item_fk_stmt;
+DEALLOCATE PREPARE recreate_auction_item_fk_stmt;

--- a/src/test/kotlin/db/migration/V11BulkSnapshotCurrentAuctionsTest.kt
+++ b/src/test/kotlin/db/migration/V11BulkSnapshotCurrentAuctionsTest.kt
@@ -1,0 +1,288 @@
+package db.migration
+
+import net.jonasmf.auctionengine.testsupport.container.SharedTestContainers
+import org.flywaydb.core.Flyway
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.sql.Connection
+import java.sql.DriverManager
+
+class V11BulkSnapshotCurrentAuctionsTest {
+    @Test
+    fun `should add bulk snapshot schema and normalize legacy auction data`() {
+        SharedTestContainers.startMariaDb()
+
+        databaseConnection().use { connection ->
+            try {
+                dropTables(connection)
+                createLegacySchema(connection)
+                seedLegacyRows(connection)
+
+                Flyway
+                    .configure()
+                    .dataSource(
+                        SharedTestContainers.mariaDbContainer.jdbcUrl,
+                        SharedTestContainers.mariaDbContainer.username,
+                        SharedTestContainers.mariaDbContainer.password,
+                    ).baselineOnMigrate(true)
+                    .baselineVersion("10")
+                    .locations("classpath:db/migration")
+                    .load()
+                    .migrate()
+
+                assertEquals(1, countColumns(connection, "auction", "deleted_at"))
+                assertEquals(1, countColumns(connection, "auction_item", "variant_hash"))
+                assertTrue(countIndexes(connection, "auction_item", "uk_auction_item_variant_hash") >= 1)
+                assertTrue(countIndexes(connection, "auction_item", "idx_auction_item_item_id") >= 1)
+                assertTrue(countIndexes(connection, "auction", "idx_auction_connected_realm_update_deleted") >= 1)
+                assertTrue(countIndexes(connection, "auction", "idx_auction_deleted_at") >= 1)
+                assertTrue(
+                    countIndexes(connection, "auction_item_modifier", "uk_auction_item_modifier_type_value") >= 1,
+                )
+                assertTrue(tableExists(connection, "auction_item_modifier_link"))
+                assertEquals(0, countTables(connection, "auction_item_modifiers"))
+
+                assertEquals(1, queryInt(connection, "SELECT COUNT(*) FROM auction_item_modifier"))
+                assertEquals(1, queryInt(connection, "SELECT COUNT(*) FROM auction_item"))
+                assertEquals(1, queryInt(connection, "SELECT COUNT(*) FROM auction_item_modifier_link"))
+                assertEquals(1, queryInt(connection, "SELECT COUNT(*) FROM auction WHERE item_id = 1"))
+            } finally {
+                dropTables(connection)
+            }
+        }
+    }
+
+    private fun databaseConnection(): Connection =
+        DriverManager.getConnection(
+            SharedTestContainers.mariaDbContainer.jdbcUrl,
+            SharedTestContainers.mariaDbContainer.username,
+            SharedTestContainers.mariaDbContainer.password,
+        )
+
+    private fun dropTables(connection: Connection) {
+        execute(connection, "SET FOREIGN_KEY_CHECKS = 0")
+        try {
+            listOf(
+                "flyway_schema_history",
+                "auction",
+                "auction_item_modifier_link",
+                "auction_item_modifiers",
+                "auction_item",
+                "auction_item_modifier",
+                "connected_realm_update_history",
+                "connected_realm",
+            ).forEach { execute(connection, "DROP TABLE IF EXISTS $it") }
+        } finally {
+            execute(connection, "SET FOREIGN_KEY_CHECKS = 1")
+        }
+    }
+
+    private fun createLegacySchema(connection: Connection) {
+        execute(
+            connection,
+            """
+            CREATE TABLE connected_realm (
+                id INT NOT NULL,
+                PRIMARY KEY (id)
+            )
+            """.trimIndent(),
+        )
+        execute(
+            connection,
+            """
+            CREATE TABLE connected_realm_update_history (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                auction_count INT NOT NULL,
+                last_modified DATETIME(6) NULL,
+                update_timestamp DATETIME(6) NULL,
+                completed_timestamp DATETIME(6) NULL,
+                connected_realm_id INT NOT NULL,
+                PRIMARY KEY (id),
+                CONSTRAINT fk_cruh_connected_realm
+                    FOREIGN KEY (connected_realm_id) REFERENCES connected_realm (id)
+            )
+            """.trimIndent(),
+        )
+        execute(
+            connection,
+            """
+            CREATE TABLE auction_item_modifier (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                type VARCHAR(255) NOT NULL,
+                value INT NOT NULL,
+                PRIMARY KEY (id)
+            )
+            """.trimIndent(),
+        )
+        execute(
+            connection,
+            """
+            CREATE TABLE auction_item (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                item_id INT NOT NULL,
+                bonus_lists VARCHAR(255) NOT NULL DEFAULT '',
+                context INT NULL,
+                pet_breed_id INT NULL,
+                pet_level INT NULL,
+                pet_quality_id INT NULL,
+                pet_species_id INT NULL,
+                PRIMARY KEY (id)
+            )
+            """.trimIndent(),
+        )
+        execute(
+            connection,
+            """
+            CREATE TABLE auction_item_modifiers (
+                auction_item_id BIGINT NOT NULL,
+                modifiers_id BIGINT NOT NULL
+            )
+            """.trimIndent(),
+        )
+        execute(
+            connection,
+            """
+            CREATE TABLE auction (
+                id BIGINT NOT NULL,
+                connected_realm_id INT NOT NULL,
+                item_id BIGINT NOT NULL,
+                quantity BIGINT NOT NULL,
+                bid BIGINT NULL,
+                unit_price BIGINT NULL,
+                time_left INT NOT NULL,
+                buyout BIGINT NULL,
+                first_seen DATETIME(6) NULL,
+                last_seen DATETIME(6) NULL,
+                update_history_id BIGINT NOT NULL,
+                PRIMARY KEY (id, connected_realm_id),
+                CONSTRAINT fk_auction_connected_realm
+                    FOREIGN KEY (connected_realm_id) REFERENCES connected_realm (id),
+                CONSTRAINT fk_auction_item
+                    FOREIGN KEY (item_id) REFERENCES auction_item (id),
+                CONSTRAINT fk_auction_update_history
+                    FOREIGN KEY (update_history_id) REFERENCES connected_realm_update_history (id)
+            )
+            """.trimIndent(),
+        )
+    }
+
+    private fun seedLegacyRows(connection: Connection) {
+        execute(connection, "INSERT INTO connected_realm (id) VALUES (1)")
+        execute(
+            connection,
+            """
+            INSERT INTO connected_realm_update_history (
+                id, auction_count, last_modified, update_timestamp, completed_timestamp, connected_realm_id
+            ) VALUES (
+                1, 1, '2026-04-10 10:00:00.000000', '2026-04-10 10:00:00.000000', '2026-04-10 10:00:00.000000', 1
+            )
+            """.trimIndent(),
+        )
+        execute(
+            connection,
+            """
+            INSERT INTO auction_item_modifier (id, type, value) VALUES
+                (1, 'ITEM_LEVEL', 489),
+                (2, 'ITEM_LEVEL', 489)
+            """.trimIndent(),
+        )
+        execute(
+            connection,
+            """
+            INSERT INTO auction_item (id, item_id, bonus_lists, context) VALUES
+                (1, 211297, '12251,12252,12499', 52),
+                (2, 211297, '12251,12252,12499', 52)
+            """.trimIndent(),
+        )
+        execute(
+            connection,
+            """
+            INSERT INTO auction_item_modifiers (auction_item_id, modifiers_id) VALUES
+                (1, 1),
+                (2, 2)
+            """.trimIndent(),
+        )
+        execute(
+            connection,
+            """
+            INSERT INTO auction (
+                id, connected_realm_id, item_id, quantity, bid, unit_price, time_left, buyout, first_seen, last_seen, update_history_id
+            ) VALUES (
+                101, 1, 2, 1, NULL, 1599900, 3, 1599900, '2026-04-10 10:00:00.000000', '2026-04-10 10:00:00.000000', 1
+            )
+            """.trimIndent(),
+        )
+    }
+
+    private fun execute(
+        connection: Connection,
+        sql: String,
+    ) {
+        connection.createStatement().use { statement ->
+            statement.execute(sql)
+        }
+    }
+
+    private fun queryInt(
+        connection: Connection,
+        sql: String,
+    ): Int =
+        connection.createStatement().use { statement ->
+            statement.executeQuery(sql).use { rs ->
+                rs.next()
+                rs.getInt(1)
+            }
+        }
+
+    private fun countColumns(
+        connection: Connection,
+        tableName: String,
+        columnName: String,
+    ): Int =
+        queryInt(
+            connection,
+            """
+            SELECT COUNT(*)
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = '$tableName'
+              AND column_name = '$columnName'
+            """.trimIndent(),
+        )
+
+    private fun countIndexes(
+        connection: Connection,
+        tableName: String,
+        indexName: String,
+    ): Int =
+        queryInt(
+            connection,
+            """
+            SELECT COUNT(*)
+            FROM information_schema.statistics
+            WHERE table_schema = DATABASE()
+              AND table_name = '$tableName'
+              AND index_name = '$indexName'
+            """.trimIndent(),
+        )
+
+    private fun countTables(
+        connection: Connection,
+        tableName: String,
+    ): Int =
+        queryInt(
+            connection,
+            """
+            SELECT COUNT(*)
+            FROM information_schema.tables
+            WHERE table_schema = DATABASE()
+              AND table_name = '$tableName'
+            """.trimIndent(),
+        )
+
+    private fun tableExists(
+        connection: Connection,
+        tableName: String,
+    ): Boolean = countTables(connection, tableName) == 1
+}

--- a/src/test/kotlin/net/jonasmf/auctionengine/dto/auction/AuctionDTODeserializationTest.kt
+++ b/src/test/kotlin/net/jonasmf/auctionengine/dto/auction/AuctionDTODeserializationTest.kt
@@ -2,6 +2,7 @@ package net.jonasmf.auctionengine.dto.auction
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import net.jonasmf.auctionengine.mapper.toDBO
 import net.jonasmf.auctionengine.testsupport.loadFixture
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionItemRepositoryTest.kt
+++ b/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionItemRepositoryTest.kt
@@ -2,6 +2,7 @@ package net.jonasmf.auctionengine.repository.rds
 
 import net.jonasmf.auctionengine.config.IntegrationTestBase
 import net.jonasmf.auctionengine.dbo.rds.auction.AuctionItem
+import net.jonasmf.auctionengine.utility.AuctionVariantKeyUtility
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
@@ -16,6 +17,17 @@ class AuctionItemRepositoryTest : IntegrationTestBase() {
         repository.save(
             AuctionItem(
                 itemId = 19019,
+                variantHash =
+                    AuctionVariantKeyUtility.variantHash(
+                        itemId = 19019,
+                        bonusKey = "12251,12252,12499",
+                        modifierKey = "",
+                        context = 52,
+                        petBreedId = null,
+                        petLevel = null,
+                        petQualityId = null,
+                        petSpeciesId = null,
+                    ),
                 bonusLists = "12251,12252,12499",
                 context = 52,
                 petBreedId = null,
@@ -27,6 +39,17 @@ class AuctionItemRepositoryTest : IntegrationTestBase() {
         repository.save(
             AuctionItem(
                 itemId = 19019,
+                variantHash =
+                    AuctionVariantKeyUtility.variantHash(
+                        itemId = 19019,
+                        bonusKey = "12251,12253,12499",
+                        modifierKey = "",
+                        context = 52,
+                        petBreedId = null,
+                        petLevel = null,
+                        petQualityId = null,
+                        petSpeciesId = null,
+                    ),
                 bonusLists = "12251,12253,12499",
                 context = 52,
                 petBreedId = null,
@@ -37,31 +60,37 @@ class AuctionItemRepositoryTest : IntegrationTestBase() {
         )
 
         val first =
-            repository.findByCompositeKeyWithNullHandlingList(
-                itemId = 19019,
-                petBreedId = null,
-                petLevel = null,
-                petQualityId = null,
-                petSpeciesId = null,
-                context = 52,
-                bonusLists = "12251,12252,12499",
+            repository.findByVariantHash(
+                AuctionVariantKeyUtility.variantHash(
+                    itemId = 19019,
+                    bonusKey = "12251,12252,12499",
+                    modifierKey = "",
+                    context = 52,
+                    petBreedId = null,
+                    petLevel = null,
+                    petQualityId = null,
+                    petSpeciesId = null,
+                ),
             )
         val second =
-            repository.findByCompositeKeyWithNullHandlingList(
-                itemId = 19019,
-                petBreedId = null,
-                petLevel = null,
-                petQualityId = null,
-                petSpeciesId = null,
-                context = 52,
-                bonusLists = "12251,12253,12499",
+            repository.findByVariantHash(
+                AuctionVariantKeyUtility.variantHash(
+                    itemId = 19019,
+                    bonusKey = "12251,12253,12499",
+                    modifierKey = "",
+                    context = 52,
+                    petBreedId = null,
+                    petLevel = null,
+                    petQualityId = null,
+                    petSpeciesId = null,
+                ),
             )
 
-        assertEquals(1, first.size)
-        assertEquals(1, second.size)
-        assertNotNull(first.single().id)
-        assertNotNull(second.single().id)
-        assertEquals("12251,12252,12499", first.single().bonusLists)
-        assertEquals("12251,12253,12499", second.single().bonusLists)
+        assertNotNull(first)
+        assertNotNull(second)
+        assertNotNull(first!!.id)
+        assertNotNull(second!!.id)
+        assertEquals("12251,12252,12499", first.bonusLists)
+        assertEquals("12251,12253,12499", second.bonusLists)
     }
 }

--- a/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionJDBCRepositoryTest.kt
+++ b/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionJDBCRepositoryTest.kt
@@ -1,0 +1,326 @@
+package net.jonasmf.auctionengine.repository.rds
+
+import net.jonasmf.auctionengine.config.IntegrationTestBase
+import net.jonasmf.auctionengine.constant.Region
+import net.jonasmf.auctionengine.dbo.rds.auction.AuctionId
+import net.jonasmf.auctionengine.dbo.rds.realm.AuctionHouse
+import net.jonasmf.auctionengine.dbo.rds.realm.ConnectedRealm
+import net.jonasmf.auctionengine.dbo.rds.realm.ConnectedRealmUpdateHistory
+import net.jonasmf.auctionengine.utility.AuctionVariantKeyUtility
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.jdbc.core.JdbcTemplate
+import java.sql.Timestamp
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+class AuctionJDBCRepositoryTest : IntegrationTestBase() {
+    @Autowired
+    lateinit var auctionJdbcRepository: AuctionJDBCRepository
+
+    @Autowired
+    lateinit var auctionRepository: AuctionRepository
+
+    @Autowired
+    lateinit var auctionItemRepository: AuctionItemRepository
+
+    @Autowired
+    lateinit var auctionItemModifierRepository: AuctionItemModifierRepository
+
+    @Autowired
+    lateinit var connectedRealmRepository: ConnectedRealmRepository
+
+    @Autowired
+    lateinit var connectedRealmUpdateHistoryRepository: ConnectedRealmUpdateHistoryRepository
+
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    @Test
+    fun `bulk upsert reuses variant keys soft deletes missing auctions and undeletes reappearing rows`() {
+        val connectedRealm = createConnectedRealm(1)
+        val modifierRows =
+            listOf(
+                AuctionModifierUpsertRow(type = "ITEM_LEVEL", value = 489),
+                AuctionModifierUpsertRow(type = "PLAYER_LEVEL", value = 70),
+                AuctionModifierUpsertRow(type = "ITEM_LEVEL", value = 489),
+            )
+
+        auctionJdbcRepository.upsertModifiers(modifierRows)
+        val modifierIds = auctionJdbcRepository.findModifierIds(modifierRows)
+        assertEquals(2, modifierIds.size)
+        assertEquals(2L, auctionItemModifierRepository.count())
+
+        val variantHash =
+            AuctionVariantKeyUtility.variantHash(
+                itemId = 211297,
+                bonusKey = "12251,12252,12499",
+                modifierKey = "ITEM_LEVEL:489,PLAYER_LEVEL:70",
+                context = 52,
+                petBreedId = null,
+                petLevel = null,
+                petQualityId = null,
+                petSpeciesId = null,
+            )
+        val itemRow =
+            AuctionItemUpsertRow(
+                variantHash = variantHash,
+                itemId = 211297,
+                bonusLists = "12251,12252,12499",
+                context = 52,
+                petBreedId = null,
+                petLevel = null,
+                petQualityId = null,
+                petSpeciesId = null,
+            )
+
+        auctionJdbcRepository.upsertAuctionItems(listOf(itemRow, itemRow))
+        val itemIds = auctionJdbcRepository.findAuctionItemIds(listOf(variantHash))
+        val auctionItemId = itemIds.getValue(variantHash)
+        assertEquals(1L, auctionItemRepository.count())
+
+        auctionJdbcRepository.upsertAuctionItemModifierLinks(
+            listOf(
+                AuctionItemModifierLinkUpsertRow(
+                    auctionItemId = auctionItemId,
+                    sortOrder = 0,
+                    modifierId = modifierIds.getValue(AuctionModifierUpsertRow("ITEM_LEVEL", 489)),
+                ),
+                AuctionItemModifierLinkUpsertRow(
+                    auctionItemId = auctionItemId,
+                    sortOrder = 1,
+                    modifierId = modifierIds.getValue(AuctionModifierUpsertRow("PLAYER_LEVEL", 70)),
+                ),
+            ),
+        )
+
+        val firstSnapshot = OffsetDateTime.ofInstant(Instant.parse("2026-04-10T10:00:00Z"), ZoneOffset.UTC)
+        val firstHistory = createUpdateHistory(connectedRealm, firstSnapshot, 2)
+        auctionJdbcRepository.upsertAuctions(
+            listOf(
+                AuctionUpsertRow(
+                    id = 101,
+                    connectedRealmId = connectedRealm.id,
+                    itemId = auctionItemId,
+                    quantity = 3,
+                    bid = null,
+                    unitPrice = 1599900,
+                    timeLeft = 3,
+                    buyout = 1599900,
+                    firstSeen = firstSnapshot,
+                    lastSeen = firstSnapshot,
+                    updateHistoryId = firstHistory.id,
+                ),
+                AuctionUpsertRow(
+                    id = 102,
+                    connectedRealmId = connectedRealm.id,
+                    itemId = auctionItemId,
+                    quantity = 1,
+                    bid = 125000000,
+                    unitPrice = null,
+                    timeLeft = 2,
+                    buyout = 250000000,
+                    firstSeen = firstSnapshot,
+                    lastSeen = firstSnapshot,
+                    updateHistoryId = firstHistory.id,
+                ),
+            ),
+        )
+
+        val secondSnapshot = firstSnapshot.plusHours(1)
+        val secondHistory = createUpdateHistory(connectedRealm, secondSnapshot, 1)
+        auctionJdbcRepository.upsertAuctions(
+            listOf(
+                AuctionUpsertRow(
+                    id = 101,
+                    connectedRealmId = connectedRealm.id,
+                    itemId = auctionItemId,
+                    quantity = 5,
+                    bid = null,
+                    unitPrice = 1699900,
+                    timeLeft = 1,
+                    buyout = 1699900,
+                    firstSeen = secondSnapshot,
+                    lastSeen = secondSnapshot,
+                    updateHistoryId = secondHistory.id,
+                ),
+            ),
+        )
+        auctionJdbcRepository.markMissingAuctionsDeleted(connectedRealm.id, secondHistory.id, secondSnapshot)
+
+        assertEquals(firstSnapshot, auctionTimestamp(101, connectedRealm.id, "first_seen"))
+        assertEquals(secondSnapshot, auctionTimestamp(101, connectedRealm.id, "last_seen"))
+        assertNull(auctionTimestamp(101, connectedRealm.id, "deleted_at"))
+        assertEquals(secondHistory.id, auctionLong(101, connectedRealm.id, "update_history_id"))
+        assertNotNull(auctionTimestamp(102, connectedRealm.id, "deleted_at"))
+        assertEquals(secondSnapshot, auctionTimestamp(102, connectedRealm.id, "deleted_at"))
+
+        val thirdSnapshot = secondSnapshot.plusHours(1)
+        val thirdHistory = createUpdateHistory(connectedRealm, thirdSnapshot, 1)
+        auctionJdbcRepository.upsertAuctions(
+            listOf(
+                AuctionUpsertRow(
+                    id = 102,
+                    connectedRealmId = connectedRealm.id,
+                    itemId = auctionItemId,
+                    quantity = 2,
+                    bid = 126000000,
+                    unitPrice = null,
+                    timeLeft = 0,
+                    buyout = 251000000,
+                    firstSeen = thirdSnapshot,
+                    lastSeen = thirdSnapshot,
+                    updateHistoryId = thirdHistory.id,
+                ),
+            ),
+        )
+        auctionJdbcRepository.markMissingAuctionsDeleted(connectedRealm.id, thirdHistory.id, thirdSnapshot)
+
+        assertEquals(firstSnapshot, auctionTimestamp(102, connectedRealm.id, "first_seen"))
+        assertEquals(thirdSnapshot, auctionTimestamp(102, connectedRealm.id, "last_seen"))
+        assertNull(auctionTimestamp(102, connectedRealm.id, "deleted_at"))
+        assertNotNull(auctionTimestamp(101, connectedRealm.id, "deleted_at"))
+        assertEquals(thirdSnapshot, auctionTimestamp(101, connectedRealm.id, "deleted_at"))
+    }
+
+    @Test
+    fun `purge deletes only aged soft deleted auctions and keeps reusable key tables`() {
+        val connectedRealm = createConnectedRealm(2)
+        val modifier = AuctionModifierUpsertRow(type = "ITEM_LEVEL", value = 525)
+        auctionJdbcRepository.upsertModifiers(listOf(modifier))
+        val modifierId = auctionJdbcRepository.findModifierIds(listOf(modifier)).getValue(modifier)
+        val variantHash =
+            AuctionVariantKeyUtility.variantHash(
+                itemId = 19019,
+                bonusKey = "",
+                modifierKey = "ITEM_LEVEL:525",
+                context = null,
+                petBreedId = null,
+                petLevel = null,
+                petQualityId = null,
+                petSpeciesId = null,
+            )
+        auctionJdbcRepository.upsertAuctionItems(
+            listOf(
+                AuctionItemUpsertRow(
+                    variantHash = variantHash,
+                    itemId = 19019,
+                    bonusLists = "",
+                    context = null,
+                    petBreedId = null,
+                    petLevel = null,
+                    petQualityId = null,
+                    petSpeciesId = null,
+                ),
+            ),
+        )
+        val itemId = auctionJdbcRepository.findAuctionItemIds(listOf(variantHash)).getValue(variantHash)
+        auctionJdbcRepository.upsertAuctionItemModifierLinks(
+            listOf(
+                AuctionItemModifierLinkUpsertRow(auctionItemId = itemId, sortOrder = 0, modifierId = modifierId),
+            ),
+        )
+
+        val historyTime = OffsetDateTime.ofInstant(Instant.parse("2026-04-01T00:00:00Z"), ZoneOffset.UTC)
+        val history = createUpdateHistory(connectedRealm, historyTime, 1)
+        auctionJdbcRepository.upsertAuctions(
+            listOf(
+                AuctionUpsertRow(
+                    id = 201,
+                    connectedRealmId = connectedRealm.id,
+                    itemId = itemId,
+                    quantity = 1,
+                    bid = null,
+                    unitPrice = 1,
+                    timeLeft = 0,
+                    buyout = 1,
+                    firstSeen = historyTime,
+                    lastSeen = historyTime,
+                    updateHistoryId = history.id,
+                ),
+            ),
+        )
+
+        jdbcTemplate.update(
+            "UPDATE auction SET deleted_at = ? WHERE id = ? AND connected_realm_id = ?",
+            Timestamp.from(historyTime.minusDays(8).toInstant()),
+            201L,
+            connectedRealm.id,
+        )
+
+        val deletedRows = auctionJdbcRepository.deleteSoftDeletedAuctionsOlderThan(historyTime.minusDays(1))
+        assertEquals(1, deletedRows)
+        assertFalse(auctionRepository.findById(AuctionId(201, connectedRealm.id)).isPresent)
+        assertEquals(1L, auctionItemRepository.count())
+        assertEquals(1L, auctionItemModifierRepository.count())
+        assertEquals(1, jdbcTemplate.queryForObject("SELECT COUNT(*) FROM auction_item_modifier_link", Int::class.java))
+    }
+
+    private fun createConnectedRealm(id: Int): ConnectedRealm =
+        connectedRealmRepository.save(
+            ConnectedRealm(
+                id = id,
+                auctionHouse =
+                    AuctionHouse(
+                        connectedId = id,
+                        region = Region.Europe,
+                        lastModified = null,
+                        lastRequested = null,
+                        nextUpdate = Instant.EPOCH,
+                        lowestDelay = 60,
+                        avgDelay = 60,
+                        highestDelay = 60,
+                        tsmFile = null,
+                        statsFile = null,
+                        auctionFile = null,
+                        updateAttempts = 0,
+                    ),
+                realms = mutableListOf(),
+            ),
+        )
+
+    private fun createUpdateHistory(
+        connectedRealm: ConnectedRealm,
+        snapshotTime: OffsetDateTime,
+        auctionCount: Int,
+    ): ConnectedRealmUpdateHistory =
+        connectedRealmUpdateHistoryRepository.save(
+            ConnectedRealmUpdateHistory(
+                auctionCount = auctionCount,
+                lastModified = snapshotTime,
+                updateTimestamp = snapshotTime,
+                connectedRealm = connectedRealm,
+            ),
+        )
+
+    private fun auctionTimestamp(
+        auctionId: Long,
+        connectedRealmId: Int,
+        columnName: String,
+    ): OffsetDateTime? =
+        jdbcTemplate.queryForObject(
+            "SELECT $columnName FROM auction WHERE id = ? AND connected_realm_id = ?",
+            { rs, _ ->
+                rs.getTimestamp(1)?.toInstant()?.atOffset(ZoneOffset.UTC)
+            },
+            auctionId,
+            connectedRealmId,
+        )
+
+    private fun auctionLong(
+        auctionId: Long,
+        connectedRealmId: Int,
+        columnName: String,
+    ): Long =
+        jdbcTemplate.queryForObject(
+            "SELECT $columnName FROM auction WHERE id = ? AND connected_realm_id = ?",
+            Long::class.java,
+            auctionId,
+            connectedRealmId,
+        )!!
+}

--- a/src/test/kotlin/net/jonasmf/auctionengine/service/BlizzardAuctionServiceTest.kt
+++ b/src/test/kotlin/net/jonasmf/auctionengine/service/BlizzardAuctionServiceTest.kt
@@ -16,9 +16,6 @@ import net.jonasmf.auctionengine.dto.auction.AuctionDataResponse
 import net.jonasmf.auctionengine.integration.blizzard.BlizzardApiClientException
 import net.jonasmf.auctionengine.integration.blizzard.BlizzardAuctionApiClient
 import net.jonasmf.auctionengine.integration.blizzard.DownloadedAuctionPayload
-import net.jonasmf.auctionengine.repository.rds.AuctionItemModifierRepository
-import net.jonasmf.auctionengine.repository.rds.AuctionItemRepository
-import net.jonasmf.auctionengine.repository.rds.AuctionRepository
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -41,14 +38,10 @@ class BlizzardAuctionServiceTest {
         )
 
     private val blizzardAuctionApiClient = mockk<BlizzardAuctionApiClient>()
-    private val authService = mockk<AuthService>(relaxed = true)
     private val amazonS3 = mockk<AmazonS3Service>()
-    private val auctionRepository = mockk<AuctionRepository>(relaxed = true)
-    private val auctionItemRepository = mockk<AuctionItemRepository>(relaxed = true)
     private val hourlyPriceStatisticsService = mockk<HourlyPriceStatisticsService>()
     private val realmService = mockk<ConnectedRealmService>()
-    private val auctionItemModifierRepository = mockk<AuctionItemModifierRepository>(relaxed = true)
-    private val updateHistoryService = mockk<ConnectedRealmUpdateHistoryService>(relaxed = true)
+    private val auctionSnapshotPersistenceService = mockk<AuctionSnapshotPersistenceService>(relaxed = true)
     private val auctionHouseService = mockk<AuctionHouseService>()
     private val runtimeHealthTracker = RuntimeHealthTracker(Duration.ofMinutes(20))
 
@@ -56,14 +49,10 @@ class BlizzardAuctionServiceTest {
         BlizzardAuctionService(
             properties = properties,
             blizzardAuctionApiClient = blizzardAuctionApiClient,
-            authService = authService,
             amazonS3 = amazonS3,
-            auctionRepository = auctionRepository,
-            auctionItemRepository = auctionItemRepository,
             hourlyPriceStatisticsService = hourlyPriceStatisticsService,
             realmService = realmService,
-            auctionItemModifierRepository = auctionItemModifierRepository,
-            updateHistoryService = updateHistoryService,
+            auctionSnapshotPersistenceService = auctionSnapshotPersistenceService,
             auctionHouseService = auctionHouseService,
             runtimeHealthTracker = runtimeHealthTracker,
         )
@@ -131,6 +120,18 @@ class BlizzardAuctionServiceTest {
             events += "stats-2"
             HourlyPriceStatisticsSummary(insertedRows = 1, groupedRows = 1, processedAuctions = 1)
         }
+        every {
+            auctionSnapshotPersistenceService.saveSnapshot(eq(firstData.path), eq(firstRealm), eq(1), any())
+        } answers {
+            events += "db-1"
+            AuctionSnapshotPersistenceSummary(processedAuctions = 1, batchCount = 1, softDeletedAuctions = 0)
+        }
+        every {
+            auctionSnapshotPersistenceService.saveSnapshot(eq(secondData.path), eq(secondRealm), eq(1), any())
+        } answers {
+            events += "db-2"
+            AuctionSnapshotPersistenceSummary(processedAuctions = 1, batchCount = 1, softDeletedAuctions = 0)
+        }
         every { auctionHouseService.updateTimes(eq(1), any(), eq(true), any()) } answers {
             events += "update-1"
         }
@@ -153,12 +154,14 @@ class BlizzardAuctionServiceTest {
                 "download-1",
                 "s3-1",
                 "stats-1",
+                "db-1",
                 "update-1",
                 "dump-2",
                 "dump-s3-2",
                 "download-2",
                 "s3-2",
                 "stats-2",
+                "db-2",
                 "update-2",
             ),
             events,
@@ -212,6 +215,12 @@ class BlizzardAuctionServiceTest {
             events += "stats-2"
             HourlyPriceStatisticsSummary(insertedRows = 1, groupedRows = 1, processedAuctions = 1)
         }
+        every {
+            auctionSnapshotPersistenceService.saveSnapshot(eq(secondData.path), eq(secondRealm), eq(1), any())
+        } answers {
+            events += "db-2"
+            AuctionSnapshotPersistenceSummary(processedAuctions = 1, batchCount = 1, softDeletedAuctions = 0)
+        }
         every { auctionHouseService.updateTimes(eq(2), any(), eq(true), any()) } answers {
             events += "update-2"
         }
@@ -224,7 +233,7 @@ class BlizzardAuctionServiceTest {
             ),
         )
 
-        assertEquals(listOf("failure-1", "dump-2", "download-2", "s3-2", "stats-2", "update-2"), events)
+        assertEquals(listOf("failure-1", "dump-2", "download-2", "s3-2", "stats-2", "db-2", "update-2"), events)
     }
 
     @Test
@@ -253,6 +262,12 @@ class BlizzardAuctionServiceTest {
                 events += "stats"
                 HourlyPriceStatisticsSummary(insertedRows = 1, groupedRows = 1, processedAuctions = 1)
             }
+        every {
+            auctionSnapshotPersistenceService.saveSnapshot(eq(data.path), eq(realm), eq(1), any())
+        } answers {
+            events += "db"
+            AuctionSnapshotPersistenceSummary(processedAuctions = 1, batchCount = 1, softDeletedAuctions = 0)
+        }
         every { auctionHouseService.updateTimes(eq(1), any(), eq(true), capture(completionMarker)) } answers {
             events += "complete"
         }
@@ -262,8 +277,38 @@ class BlizzardAuctionServiceTest {
             listOf(AuctionHouseDomain(id = 1, connectedId = 1, region = Region.Europe)),
         )
 
-        assertEquals(listOf("stats", "complete"), events)
+        assertEquals(listOf("stats", "db", "complete"), events)
         assertEquals("s3://first", completionMarker.captured)
+    }
+
+    @Test
+    fun `updateAuctionHouses marks update as failed when current auction persistence fails`() {
+        val service = createService()
+        val lastModified = ZonedDateTime.now().minusMinutes(5)
+        val realm = createRealm(1, lastModified.minusMinutes(1))
+        val data = createDownloadedPayload()
+
+        every { blizzardAuctionApiClient.getLatestAuctionDump(1, Region.Europe, any()) } returns
+            Mono.just(AuctionDataResponse(lastModified.toInstant().toEpochMilli(), "url-1", GameBuildVersion.RETAIL))
+        every { realmService.getById(1) } returns realm
+        every { amazonS3.uploadFile(eq(Region.Europe), any(), any<AuctionDataResponse>()) } returns "s3://dump"
+        every { blizzardAuctionApiClient.downloadAuctionData("url-1") } returns Mono.just(data)
+        every { amazonS3.uploadCompressedFile(eq(Region.Europe), any(), any()) } returns "s3://first"
+        every {
+            hourlyPriceStatisticsService.processHourlyPriceStatisticsFromFile(eq(realm), eq(data.path), any())
+        } returns HourlyPriceStatisticsSummary(insertedRows = 1, groupedRows = 1, processedAuctions = 1)
+        every {
+            auctionSnapshotPersistenceService.saveSnapshot(eq(data.path), eq(realm), eq(1), any())
+        } throws IllegalStateException("db failure")
+        every { auctionHouseService.updateTimes(eq(1), any(), eq(false), any()) } returns Unit
+
+        service.updateAuctionHouses(
+            Region.Europe,
+            listOf(AuctionHouseDomain(id = 1, connectedId = 1, region = Region.Europe)),
+        )
+
+        io.mockk.verify(exactly = 1) { auctionHouseService.updateTimes(eq(1), any(), eq(false), any()) }
+        io.mockk.verify(exactly = 0) { auctionHouseService.updateTimes(eq(1), any(), eq(true), any()) }
     }
 
     @Test

--- a/src/test/kotlin/net/jonasmf/auctionengine/service/ConnectedRealmUpdateHistoryServiceTest.kt
+++ b/src/test/kotlin/net/jonasmf/auctionengine/service/ConnectedRealmUpdateHistoryServiceTest.kt
@@ -1,0 +1,23 @@
+package net.jonasmf.auctionengine.service
+
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.springframework.core.annotation.AnnotatedElementUtils
+import org.springframework.transaction.annotation.Transactional
+import java.time.ZonedDateTime
+
+class ConnectedRealmUpdateHistoryServiceTest {
+    @Test
+    fun `setUpdateToCompleted is transactional because it executes a modifying query`() {
+        val method =
+            ConnectedRealmUpdateHistoryService::class.java.getMethod(
+                "setUpdateToCompleted",
+                Int::class.javaPrimitiveType,
+                ZonedDateTime::class.java,
+            )
+
+        val transactional = AnnotatedElementUtils.findMergedAnnotation(method, Transactional::class.java)
+
+        assertNotNull(transactional)
+    }
+}

--- a/src/test/kotlin/net/jonasmf/auctionengine/service/ConnectedRealmUpdateHistoryServiceTest.kt
+++ b/src/test/kotlin/net/jonasmf/auctionengine/service/ConnectedRealmUpdateHistoryServiceTest.kt
@@ -1,23 +1,73 @@
 package net.jonasmf.auctionengine.service
 
+import net.jonasmf.auctionengine.config.IntegrationTestBase
+import net.jonasmf.auctionengine.constant.Region
+import net.jonasmf.auctionengine.dbo.rds.realm.AuctionHouse
+import net.jonasmf.auctionengine.dbo.rds.realm.ConnectedRealm
+import net.jonasmf.auctionengine.repository.rds.ConnectedRealmRepository
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import org.springframework.core.annotation.AnnotatedElementUtils
-import org.springframework.transaction.annotation.Transactional
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.jdbc.core.JdbcTemplate
+import java.time.Instant
+import java.time.ZoneOffset
 import java.time.ZonedDateTime
 
-class ConnectedRealmUpdateHistoryServiceTest {
+class ConnectedRealmUpdateHistoryServiceTest : IntegrationTestBase() {
+    @Autowired
+    lateinit var connectedRealmRepository: ConnectedRealmRepository
+
+    @Autowired
+    lateinit var connectedRealmUpdateHistoryService: ConnectedRealmUpdateHistoryService
+
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
     @Test
-    fun `setUpdateToCompleted is transactional because it executes a modifying query`() {
-        val method =
-            ConnectedRealmUpdateHistoryService::class.java.getMethod(
-                "setUpdateToCompleted",
-                Int::class.javaPrimitiveType,
-                ZonedDateTime::class.java,
+    fun `setUpdateToCompleted updates completed timestamp via modifying query`() {
+        val connectedRealm = createConnectedRealm(1401)
+        val lastModified = ZonedDateTime.ofInstant(Instant.parse("2026-04-15T06:44:17Z"), ZoneOffset.UTC)
+        val history =
+            connectedRealmUpdateHistoryService.startUpdate(
+                connectedRealm = connectedRealm,
+                auctionCount = 34944,
+                lastModified = lastModified,
             )
 
-        val transactional = AnnotatedElementUtils.findMergedAnnotation(method, Transactional::class.java)
+        val updated = connectedRealmUpdateHistoryService.setUpdateToCompleted(connectedRealm.id, lastModified)
 
-        assertNotNull(transactional)
+        assertTrue(updated)
+        val completedTimestamp =
+            jdbcTemplate.queryForObject(
+                "SELECT completed_timestamp FROM connected_realm_update_history WHERE id = ?",
+                { rs, _ -> rs.getTimestamp(1) },
+                history.id,
+            )
+
+        assertNotNull(completedTimestamp)
     }
+
+    private fun createConnectedRealm(id: Int): ConnectedRealm =
+        connectedRealmRepository.save(
+            ConnectedRealm(
+                id = id,
+                auctionHouse =
+                    AuctionHouse(
+                        connectedId = id,
+                        region = Region.Europe,
+                        lastModified = null,
+                        lastRequested = null,
+                        nextUpdate = Instant.EPOCH,
+                        lowestDelay = 60,
+                        avgDelay = 60,
+                        highestDelay = 60,
+                        tsmFile = null,
+                        statsFile = null,
+                        auctionFile = null,
+                        updateAttempts = 0,
+                    ),
+                realms = mutableListOf(),
+            ),
+        )
 }


### PR DESCRIPTION
## Summary
- Move current auction persistence to a DB-focused bulk snapshot pipeline with `INSERT ... ON DUPLICATE KEY UPDATE`
- Normalize reusable auction item modifiers and variant identities while keeping FK-friendly relationships
- Track missing auctions with `deleted_at` soft deletes and add scheduled cleanup for rows older than 7 days

## Task Reference
- GitHub issue: Resolves #27
- Local task doc:
- Task slug:

## Context For Reviewers
- `saveAuctionsToDatabase` is now focused on snapshot persistence only; non-DB side effects were removed from that path
- Snapshot variant hashing uses typed modifier keys, while hourly stats keep their prior canonical modifier behavior
- The Flyway migration is guarded so older schemas without auction snapshot tables migrate cleanly

## Changes
- Move auction mapping logic out of DTOs into `mapper/AuctionMapper.kt`
- Rework auction snapshot persistence into bulk JDBC upserts for modifiers, item variants, modifier links, and auctions
- Update auction schema/entities for reusable modifier keys, variant hashes, explicit link table usage, and soft-delete tracking
- Add indexes and migration coverage for the new bulk snapshot model
- Add a dedicated schedule for pruning soft-deleted auctions after 7 days
- Add integration and service tests for duplicate handling, undelete behavior, and cleanup

## Testing
- [x] Tests added or updated where needed
- [x] Verified locally

### Checks run
```text
./mvnw -q test
```

## Screenshots
- N/A

## Checklist
- [x] This PR references the GitHub issue it resolves or fixes
- [ ] This PR references the local task doc or slug when one exists
- [x] Scope stays aligned with the linked task
- [ ] Documentation updated if behavior or workflow changed