### PR TITLE
Improve realm and market search performance

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -89,6 +89,10 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
         </dependency>

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/config/CacheConfig.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/config/CacheConfig.kt
@@ -1,0 +1,8 @@
+package net.jonasmf.auctionengine.config
+
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableCaching
+class CacheConfig

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/controller/RealmController.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/controller/RealmController.kt
@@ -4,14 +4,38 @@ import net.jonasmf.auctionengine.generated.api.RealmApi
 import net.jonasmf.auctionengine.generated.model.Realm
 import net.jonasmf.auctionengine.generated.model.RealmDetail
 import net.jonasmf.auctionengine.service.RealmQueryService
+import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 @RestController
 class RealmController(
     private val realmQueryService: RealmQueryService,
 ) : RealmApi {
-    override fun listRealms(): ResponseEntity<List<Realm>> = ResponseEntity.ok(realmQueryService.listAllRealms())
+    private val logger = LoggerFactory.getLogger(RealmController::class.java)
+
+    override fun listRealms(): ResponseEntity<List<Realm>> {
+        val totalStart = System.nanoTime()
+        val result = realmQueryService.listAllRealms()
+        val totalDuration = (System.nanoTime() - totalStart).toDuration(DurationUnit.NANOSECONDS)
+
+        logger.info(
+            "Realm catalog request completed in {}ms (query={}ms mapSort={}ms total={}ms)",
+            totalDuration.inWholeMilliseconds,
+            result.queryDuration.inWholeMilliseconds,
+            result.mapSortDuration.inWholeMilliseconds,
+            totalDuration.inWholeMilliseconds,
+        )
+
+        return ResponseEntity
+            .ok()
+            .header(
+                "Server-Timing",
+                result.serverTimingHeader(totalDuration),
+            ).body(result.realms)
+    }
 
     override fun getRealm(
         region: String,

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketSearchRepository.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketSearchRepository.kt
@@ -1,5 +1,6 @@
 package net.jonasmf.auctionengine.repository.rds
 
+import org.slf4j.LoggerFactory
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.jdbc.core.RowMapper
 import org.springframework.stereotype.Repository
@@ -71,6 +72,8 @@ data class AuctionMarketRange(
 class AuctionMarketSearchRepository(
     private val jdbcTemplate: JdbcTemplate,
 ) {
+    private val logger = LoggerFactory.getLogger(AuctionMarketSearchRepository::class.java)
+
     private val sortColumns =
         mapOf(
             "itemName" to "item_name",
@@ -84,16 +87,19 @@ class AuctionMarketSearchRepository(
         )
 
     fun search(request: AuctionMarketSearchRequest): AuctionMarketSearchResult {
+        val startNanos = System.nanoTime()
         val params = ArrayList<Any?>()
         val fromSql = buildFromSql(request, params)
         val whereSql = buildWhereSql(request, params)
         val countParams = ArrayList(params)
+        val countStartNanos = System.nanoTime()
         val totalItems =
             jdbcTemplate.queryForObject(
                 "SELECT COUNT(*) $fromSql $whereSql",
                 Long::class.java,
                 *countParams.toTypedArray(),
             ) ?: 0L
+        val countDurationMs = elapsedMs(countStartNanos)
 
         val sortColumn = sortColumns[request.sortBy] ?: sortColumns.getValue("itemName")
         val sortDirection = if (request.sortDirection.equals("desc", ignoreCase = true)) "DESC" else "ASC"
@@ -101,6 +107,7 @@ class AuctionMarketSearchRepository(
         params.add(request.pageSize)
         params.add(offset)
 
+        val rowsStartNanos = System.nanoTime()
         val rows =
             jdbcTemplate.query(
                 """
@@ -132,6 +139,22 @@ class AuctionMarketSearchRepository(
                 rowMapper,
                 *params.toTypedArray(),
             )
+        val rowsDurationMs = elapsedMs(rowsStartNanos)
+
+        logger.info(
+            "Auction market search completed in {}ms (count={}ms rows={}ms selectedRealm={} selectedDate={} selectedHour={} communityRealm={} communityDate={} communityHour={} totalItems={} returnedRows={})",
+            elapsedMs(startNanos),
+            countDurationMs,
+            rowsDurationMs,
+            request.selectedConnectedRealmId,
+            request.selectedDate,
+            request.selectedHour,
+            request.communityConnectedRealmId,
+            request.communityDate,
+            request.communityHour,
+            totalItems,
+            rows.size,
+        )
 
         return AuctionMarketSearchResult(rows = rows, totalItems = totalItems)
     }
@@ -227,30 +250,34 @@ class AuctionMarketSearchRepository(
     ): String {
         params.add(request.selectedConnectedRealmId)
         params.add(java.sql.Date.valueOf(request.selectedDate))
-        params.add(request.selectedHour)
         params.add(request.communityConnectedRealmId)
         params.add(java.sql.Date.valueOf(request.communityDate))
-        params.add(request.communityHour)
 
         return """
             FROM v_auction_market_item_details d
-                     JOIN (
-                         SELECT item_id, MIN(price) AS price, SUM(quantity) AS quantity
-                         FROM v_auction_house_prices
-                         WHERE connected_realm_id = ?
-                           AND date = ?
-                           AND hour_of_day = ?
-                         GROUP BY item_id
-                     ) s ON s.item_id = d.item_id
-                     LEFT JOIN (
-                         SELECT item_id, MIN(price) AS price, SUM(quantity) AS quantity
-                         FROM v_auction_house_prices
-                         WHERE connected_realm_id = ?
-                           AND date = ?
-                           AND hour_of_day = ?
-                         GROUP BY item_id
-                     ) c ON c.item_id = d.item_id
+                     JOIN (${buildHourlyAggregateSql(request.selectedHour)}) s ON s.item_id = d.item_id
+                     LEFT JOIN (${buildHourlyAggregateSql(request.communityHour)}) c ON c.item_id = d.item_id
             """.trimIndent()
+    }
+
+    private fun buildHourlyAggregateSql(hour: Int): String {
+        val hourSuffix = hourColumnSuffix(hour)
+        val priceColumn = "price$hourSuffix"
+        val quantityColumn = "quantity$hourSuffix"
+
+        return """
+            SELECT item_id, MIN($priceColumn) AS price, SUM($quantityColumn) AS quantity
+            FROM auction_stats_hourly
+            WHERE connected_realm_id = ?
+              AND date = ?
+              AND $priceColumn IS NOT NULL
+            GROUP BY item_id
+            """.trimIndent()
+    }
+
+    private fun hourColumnSuffix(hour: Int): String {
+        require(hour in 0..23) { "Hour must be between 0 and 23: $hour" }
+        return hour.toString().padStart(2, '0')
     }
 
     private fun buildWhereSql(
@@ -310,6 +337,8 @@ class AuctionMarketSearchRepository(
         replace("!", "!!")
             .replace("%", "!%")
             .replace("_", "!_")
+
+    private fun elapsedMs(startNanos: Long): Long = (System.nanoTime() - startNanos) / 1_000_000
 
     private val rowMapper =
         RowMapper { rs: ResultSet, _: Int ->

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/RealmCatalogJdbcRepository.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/RealmCatalogJdbcRepository.kt
@@ -1,0 +1,144 @@
+package net.jonasmf.auctionengine.repository.rds
+
+import net.jonasmf.auctionengine.constant.Region
+import net.jonasmf.auctionengine.service.CommunityRealms
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+import java.sql.ResultSet
+import java.time.Instant
+import net.jonasmf.auctionengine.constant.Locale as WowLocale
+
+data class RealmCatalogRow(
+    val regionId: Int,
+    val name: String,
+    val category: String,
+    val slug: String,
+    val locale: String,
+    val timezone: String,
+)
+
+data class RealmDetailRow(
+    val connectedRealmId: Int,
+    val regionId: Int,
+    val name: String,
+    val category: String,
+    val slug: String,
+    val locale: String,
+    val timezone: String,
+    val lastDailyPriceUpdate: Instant?,
+    val lastModified: Instant?,
+    val nextUpdate: Instant?,
+    val communityConnectedRealmId: Int,
+    val communityLastDailyPriceUpdate: Instant?,
+    val communityLastModified: Instant?,
+    val communityNextUpdate: Instant?,
+)
+
+@Repository
+class RealmCatalogJdbcRepository(
+    private val jdbcTemplate: JdbcTemplate,
+) {
+    @Cacheable(cacheNames = ["realmCatalog"])
+    fun findRealmCatalogRows(): List<RealmCatalogRow> =
+        jdbcTemplate.query(
+            """
+            SELECT
+                r.region_id AS regionId,
+                r.name,
+                r.category,
+                r.slug,
+                r.locale,
+                r.timezone
+            FROM connected_realm cr
+            JOIN connected_realm_realms crr ON crr.connected_realm_id = cr.id
+            JOIN realm r ON r.id = crr.realms_id
+            WHERE cr.id >= 0
+            ORDER BY r.region_id, r.name
+            """.trimIndent(),
+            { rs, rowNum -> mapRealmCatalogRow(rs, rowNum) },
+        )
+
+    fun findRealmDetailRow(
+        region: Region,
+        slug: String,
+    ): RealmDetailRow? {
+        val communityId = CommunityRealms.idFor(region)
+        return jdbcTemplate
+            .query(
+                """
+                SELECT
+                    cr.id AS connectedRealmId,
+                    r.region_id AS regionId,
+                    r.name,
+                    r.category,
+                    r.slug,
+                    r.locale,
+                    r.timezone,
+                    ah.last_daily_price_update AS lastDailyPriceUpdate,
+                    ah.last_modified AS lastModified,
+                    ah.next_update AS nextUpdate,
+                    community_cr.id AS communityConnectedRealmId,
+                    community_ah.last_daily_price_update AS communityLastDailyPriceUpdate,
+                    community_ah.last_modified AS communityLastModified,
+                    community_ah.next_update AS communityNextUpdate
+                FROM realm r
+                JOIN connected_realm_realms crr ON crr.realms_id = r.id
+                JOIN connected_realm cr ON cr.id = crr.connected_realm_id
+                JOIN auction_house ah ON ah.id = cr.auction_house_id
+                JOIN connected_realm community_cr ON community_cr.id = ?
+                JOIN auction_house community_ah ON community_ah.id = community_cr.auction_house_id
+                WHERE r.region_id = ?
+                  AND r.slug = ?
+                LIMIT 1
+                """.trimIndent(),
+                { rs, _ -> rs.toRealmDetailRow() },
+                communityId,
+                region.toDbId(),
+                slug.lowercase(),
+            ).firstOrNull()
+    }
+
+    private fun mapRealmCatalogRow(
+        rs: ResultSet,
+        rowNum: Int,
+    ): RealmCatalogRow =
+        RealmCatalogRow(
+            regionId = rs.getInt("regionId"),
+            name = rs.getString("name"),
+            category = rs.getString("category"),
+            slug = rs.getString("slug"),
+            locale = rs.getLocaleValue("locale"),
+            timezone = rs.getString("timezone"),
+        )
+
+    private fun ResultSet.toRealmDetailRow(): RealmDetailRow =
+        RealmDetailRow(
+            connectedRealmId = getInt("connectedRealmId"),
+            regionId = getInt("regionId"),
+            name = getString("name"),
+            category = getString("category"),
+            slug = getString("slug"),
+            locale = getLocaleValue("locale"),
+            timezone = getString("timezone"),
+            lastDailyPriceUpdate = getInstant("lastDailyPriceUpdate"),
+            lastModified = getInstant("lastModified"),
+            nextUpdate = getInstant("nextUpdate"),
+            communityConnectedRealmId = getInt("communityConnectedRealmId"),
+            communityLastDailyPriceUpdate = getInstant("communityLastDailyPriceUpdate"),
+            communityLastModified = getInstant("communityLastModified"),
+            communityNextUpdate = getInstant("communityNextUpdate"),
+        )
+
+    private fun ResultSet.getInstant(column: String): Instant? = getTimestamp(column)?.toInstant()
+
+    private fun ResultSet.getLocaleValue(column: String): String = WowLocale.entries[getInt(column)].value
+
+    private fun Region.toDbId(): Int =
+        when (this) {
+            Region.NorthAmerica -> 1
+            Region.Europe -> 2
+            Region.Korea -> 3
+            Region.Taiwan -> 4
+        }
+}

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/service/ConnectedRealmBulkSyncService.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/service/ConnectedRealmBulkSyncService.kt
@@ -8,8 +8,11 @@ import net.jonasmf.auctionengine.repository.rds.ConnectedRealmRepository
 import net.jonasmf.auctionengine.repository.rds.ConnectedRealmUpsertRow
 import net.jonasmf.auctionengine.repository.rds.RealmSyncRow
 import org.slf4j.LoggerFactory
+import org.springframework.cache.CacheManager
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.time.Instant
 
 @Service
@@ -17,6 +20,7 @@ class ConnectedRealmBulkSyncService(
     private val connectedRealmJdbcRepository: ConnectedRealmJdbcRepository,
     private val connectedRealmRepository: ConnectedRealmRepository,
     private val auctionHouseRepository: AuctionHouseRepository,
+    private val cacheManager: CacheManager,
 ) {
     private val log = LoggerFactory.getLogger(ConnectedRealmBulkSyncService::class.java)
 
@@ -85,7 +89,23 @@ class ConnectedRealmBulkSyncService(
         connectedRealmJdbcRepository.replaceRealmsForConnectedRealms(connectedRealmIds, realmRows)
 
         val savedById = connectedRealmRepository.findAllById(connectedRealmIds).associateBy { it.id }
+        evictRealmCatalogAfterCommit()
         return connectedRealmIds.mapNotNull(savedById::get)
+    }
+
+    private fun evictRealmCatalogAfterCommit() {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            cacheManager.getCache("realmCatalog")?.clear()
+            return
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(
+            object : TransactionSynchronization {
+                override fun afterCommit() {
+                    cacheManager.getCache("realmCatalog")?.clear()
+                }
+            },
+        )
     }
 
     private fun normalizeAuctionHouse(

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/service/RealmQueryService.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/service/RealmQueryService.kt
@@ -1,73 +1,123 @@
 package net.jonasmf.auctionengine.service
 
 import net.jonasmf.auctionengine.constant.Region
-import net.jonasmf.auctionengine.dbo.rds.realm.ConnectedRealm
 import net.jonasmf.auctionengine.generated.model.AuctionHouseStatus
 import net.jonasmf.auctionengine.generated.model.RealmDetail
-import net.jonasmf.auctionengine.repository.rds.ConnectedRealmRepository
+import net.jonasmf.auctionengine.repository.rds.RealmCatalogJdbcRepository
+import net.jonasmf.auctionengine.repository.rds.RealmCatalogRow
+import net.jonasmf.auctionengine.repository.rds.RealmDetailRow
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
-import net.jonasmf.auctionengine.dbo.rds.realm.Realm as RealmEntity
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 import net.jonasmf.auctionengine.generated.model.Realm as RealmDto
+
+data class RealmCatalogResult(
+    val realms: List<RealmDto>,
+    val queryDuration: Duration,
+    val mapSortDuration: Duration,
+) {
+    fun serverTimingHeader(totalDuration: Duration): String =
+        buildString {
+            append("query;dur=")
+            append(queryDuration.inWholeMilliseconds)
+            append(", map;dur=")
+            append(mapSortDuration.inWholeMilliseconds)
+            append(", total;dur=")
+            append(totalDuration.inWholeMilliseconds)
+        }
+}
 
 @Service
 class RealmQueryService(
-    private val connectedRealmRepository: ConnectedRealmRepository,
+    private val realmCatalogJdbcRepository: RealmCatalogJdbcRepository,
 ) {
-    fun listAllRealms(): List<RealmDto> =
-        connectedRealmRepository
-            .findAll()
-            .asSequence()
-            .filter { it.id >= 0 }
-            .flatMap { connected -> connected.realms.asSequence().map { realm -> realm.toDto() } }
-            .sortedWith(compareBy({ it.region.value }, { it.name }))
-            .toList()
+    private val logger = LoggerFactory.getLogger(RealmQueryService::class.java)
+
+    fun listAllRealms(): RealmCatalogResult {
+        val queryStart = System.nanoTime()
+        val rows = realmCatalogJdbcRepository.findRealmCatalogRows()
+        val queryDuration = (System.nanoTime() - queryStart).toDuration(DurationUnit.NANOSECONDS)
+
+        val mapStart = System.nanoTime()
+        val realms =
+            rows
+                .asSequence()
+                .map { it.toDto() }
+                .sortedWith(compareBy({ it.region.value }, { it.name }))
+                .toList()
+        val mapSortDuration = (System.nanoTime() - mapStart).toDuration(DurationUnit.NANOSECONDS)
+        val totalDuration = queryDuration + mapSortDuration
+
+        logger.info(
+            "Loaded {} realms in {}ms (query={}ms mapSort={}ms)",
+            realms.size,
+            totalDuration.inWholeMilliseconds,
+            queryDuration.inWholeMilliseconds,
+            mapSortDuration.inWholeMilliseconds,
+        )
+
+        return RealmCatalogResult(
+            realms = realms,
+            queryDuration = queryDuration,
+            mapSortDuration = mapSortDuration,
+        )
+    }
 
     fun getRealmDetail(
         regionCode: String,
         slug: String,
     ): RealmDetail? {
         val region = runCatching { Region.fromString(regionCode) }.getOrNull() ?: return null
-        val matchingRealmAndConnected =
-            connectedRealmRepository
-                .findAllByRegion(region)
-                .firstNotNullOfOrNull { connected ->
-                    connected.realms
-                        .firstOrNull { it.slug.equals(slug, ignoreCase = true) }
-                        ?.let { realm -> connected to realm }
-                } ?: return null
-
-        val (connectedRealm, realm) = matchingRealmAndConnected
-        val community =
-            connectedRealmRepository
-                .findById(CommunityRealms.idFor(region))
-                .orElse(null) ?: return null
+        val row =
+            realmCatalogJdbcRepository.findRealmDetailRow(region, slug)
+                ?: return null
 
         return RealmDetail(
-            realm = realm.toDto(),
-            auctionHouse = connectedRealm.toAuctionHouseStatus(),
-            community = community.toAuctionHouseStatus(),
+            realm = row.toRealmDto(),
+            auctionHouse = row.toAuctionHouseStatus(),
+            community = row.toCommunityAuctionHouseStatus(),
         )
     }
 
-    private fun RealmEntity.toDto(): RealmDto =
+    private fun RealmCatalogRow.toDto(): RealmDto =
         RealmDto(
-            region = region.type.toDtoEnum(),
+            region = regionId.toRegion().toDtoEnum(),
             name = name,
             category = category,
             slug = slug,
-            locale = locale.value,
+            locale = locale,
             timezone = timezone,
         )
 
-    private fun ConnectedRealm.toAuctionHouseStatus(): AuctionHouseStatus =
+    private fun RealmDetailRow.toRealmDto(): RealmDto =
+        RealmDto(
+            region = regionId.toRegion().toDtoEnum(),
+            name = name,
+            category = category,
+            slug = slug,
+            locale = locale,
+            timezone = timezone,
+        )
+
+    private fun RealmDetailRow.toAuctionHouseStatus(): AuctionHouseStatus =
         AuctionHouseStatus(
-            connectedRealmId = id,
-            lastDailyPriceUpdate = auctionHouse.lastDailyPriceUpdate.toOffsetDateTime(),
-            lastModified = auctionHouse.lastModified.toOffsetDateTime(),
-            nextUpdate = auctionHouse.nextUpdate.toOffsetDateTime(),
+            connectedRealmId = connectedRealmId,
+            lastDailyPriceUpdate = lastDailyPriceUpdate.toOffsetDateTime(),
+            lastModified = lastModified.toOffsetDateTime(),
+            nextUpdate = nextUpdate.toOffsetDateTime(),
+        )
+
+    private fun RealmDetailRow.toCommunityAuctionHouseStatus(): AuctionHouseStatus =
+        AuctionHouseStatus(
+            connectedRealmId = communityConnectedRealmId,
+            lastDailyPriceUpdate = communityLastDailyPriceUpdate.toOffsetDateTime(),
+            lastModified = communityLastModified.toOffsetDateTime(),
+            nextUpdate = communityNextUpdate.toOffsetDateTime(),
         )
 
     private fun Region.toDtoEnum(): RealmDto.Region =
@@ -76,6 +126,15 @@ class RealmQueryService(
             Region.Europe -> RealmDto.Region.EU
             Region.Korea -> RealmDto.Region.KR
             Region.Taiwan -> RealmDto.Region.TW
+        }
+
+    private fun Int.toRegion(): Region =
+        when (this) {
+            1 -> Region.NorthAmerica
+            2 -> Region.Europe
+            3 -> Region.Korea
+            4 -> Region.Taiwan
+            else -> error("Unknown region id: $this")
         }
 
     private fun Instant?.toOffsetDateTime(): OffsetDateTime? = this?.atOffset(ZoneOffset.UTC)

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/controller/RealmControllerTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/controller/RealmControllerTest.kt
@@ -2,208 +2,80 @@ package net.jonasmf.auctionengine.controller
 
 import io.mockk.every
 import io.mockk.mockk
-import net.jonasmf.auctionengine.constant.GameBuildVersion
-import net.jonasmf.auctionengine.constant.Locale
-import net.jonasmf.auctionengine.constant.Region
-import net.jonasmf.auctionengine.dbo.rds.realm.AuctionHouse
-import net.jonasmf.auctionengine.dbo.rds.realm.ConnectedRealm
-import net.jonasmf.auctionengine.dbo.rds.realm.Realm
-import net.jonasmf.auctionengine.dbo.rds.realm.RegionDBO
-import net.jonasmf.auctionengine.repository.rds.ConnectedRealmRepository
-import net.jonasmf.auctionengine.service.CommunityRealms
+import net.jonasmf.auctionengine.generated.model.AuctionHouseStatus
+import net.jonasmf.auctionengine.generated.model.Realm
+import net.jonasmf.auctionengine.generated.model.RealmDetail
+import net.jonasmf.auctionengine.service.RealmCatalogResult
 import net.jonasmf.auctionengine.service.RealmQueryService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
-import org.springframework.http.HttpStatus
-import java.time.Instant
-import java.util.Optional
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import net.jonasmf.auctionengine.generated.model.Realm as RealmDto
+import kotlin.time.Duration.Companion.milliseconds
 
 class RealmControllerTest {
-    private val connectedRealmRepository = mockk<ConnectedRealmRepository>()
-    private val realmQueryService = RealmQueryService(connectedRealmRepository)
+    private val realmQueryService = mockk<RealmQueryService>()
     private val controller = RealmController(realmQueryService)
 
-    private val euRegion = RegionDBO(id = 2, name = "EU", type = Region.Europe)
-    private val usRegion = RegionDBO(id = 1, name = "US", type = Region.NorthAmerica)
-
     @Test
-    fun `listRealms returns mapped realms sorted by region then name and excludes community placeholders`() {
-        val euConnected =
-            connectedRealm(
-                id = 1234,
+    fun `listRealms returns catalog with server timing header`() {
+        val catalog =
+            RealmCatalogResult(
                 realms =
                     listOf(
-                        realm(id = 1, region = euRegion, name = "Stormrage", slug = "stormrage", locale = Locale.EN_GB),
-                        realm(
-                            id = 2,
-                            region = euRegion,
-                            name = "Aerie Peak",
-                            slug = "aerie-peak",
-                            locale = Locale.EN_GB,
+                        Realm(
+                            region = Realm.Region.EU,
+                            name = "Stormrage",
+                            category = "PvP",
+                            slug = "stormrage",
+                            locale = "en_GB",
+                            timezone = "Europe/Paris",
                         ),
                     ),
+                queryDuration = 3.milliseconds,
+                mapSortDuration = 2.milliseconds,
             )
-        val usConnected =
-            connectedRealm(
-                id = 5678,
-                realms =
-                    listOf(
-                        realm(id = 3, region = usRegion, name = "Illidan", slug = "illidan", locale = Locale.EN_US),
-                    ),
-            )
-        val communityEu =
-            connectedRealm(
-                id = CommunityRealms.idFor(Region.Europe),
-                realms =
-                    listOf(
-                        realm(
-                            id = -2,
-                            region = euRegion,
-                            name = "Community",
-                            slug = "community",
-                            locale = Locale.EN_GB,
-                            category = "Community",
-                        ),
-                    ),
-            )
-        every { connectedRealmRepository.findAll() } returns listOf(euConnected, usConnected, communityEu)
+        every { realmQueryService.listAllRealms() } returns catalog
 
         val response = controller.listRealms()
 
-        assertEquals(HttpStatus.OK, response.statusCode)
-        val body = assertNotNull(response.body)
-        assertEquals(
-            listOf("eu" to "Aerie Peak", "eu" to "Stormrage", "us" to "Illidan"),
-            body.map {
-                it.region.value to
-                    it.name
-            },
-        )
-        assertEquals(RealmDto.Region.EU, body.first().region)
-        assertEquals("aerie-peak", body.first().slug)
-        assertEquals("en_GB", body.first().locale)
+        assertEquals(200, response.statusCode.value())
+        assertEquals(listOf("Stormrage"), response.body?.map { it.name })
+        assertNotNull(response.headers.getFirst("Server-Timing"))
     }
 
     @Test
-    fun `getRealm returns mapped detail with connected and community auction house status`() {
-        val lastModified = Instant.parse("2026-05-01T10:00:00Z")
-        val nextUpdate = Instant.parse("2026-05-01T11:00:00Z")
-        val lastDailyPrice = Instant.parse("2026-05-01T05:00:00Z")
-        val realm = realm(id = 10, region = euRegion, name = "Stormrage", slug = "stormrage", locale = Locale.EN_GB)
-        val connected =
-            connectedRealm(
-                id = 1234,
-                realms = listOf(realm),
-                lastModified = lastModified,
-                nextUpdate = nextUpdate,
-                lastDailyPriceUpdate = lastDailyPrice,
-            )
-        val communityModified = Instant.parse("2026-05-01T09:00:00Z")
-        val community =
-            connectedRealm(
-                id = CommunityRealms.idFor(Region.Europe),
-                realms =
-                    listOf(
-                        realm(
-                            id = -2,
-                            region = euRegion,
-                            name = "Community",
-                            slug = "community",
-                            locale = Locale.EN_GB,
-                            category = "Community",
-                        ),
+    fun `getRealm forwards detail from the service`() {
+        val detail =
+            RealmDetail(
+                realm =
+                    Realm(
+                        region = Realm.Region.EU,
+                        name = "Stormrage",
+                        category = "PvP",
+                        slug = "stormrage",
+                        locale = "en_GB",
+                        timezone = "Europe/Paris",
                     ),
-                lastModified = communityModified,
+                auctionHouse =
+                    AuctionHouseStatus(
+                        connectedRealmId = 1234,
+                        lastDailyPriceUpdate = null,
+                        lastModified = null,
+                        nextUpdate = null,
+                    ),
+                community =
+                    AuctionHouseStatus(
+                        connectedRealmId = -2,
+                        lastDailyPriceUpdate = null,
+                        lastModified = null,
+                        nextUpdate = null,
+                    ),
             )
-        every { connectedRealmRepository.findAllByRegion(Region.Europe) } returns listOf(connected)
-        every { connectedRealmRepository.findById(CommunityRealms.idFor(Region.Europe)) } returns Optional.of(community)
-
-        val response = controller.getRealm("eu", "Stormrage")
-
-        assertEquals(HttpStatus.OK, response.statusCode)
-        val body = assertNotNull(response.body)
-        assertEquals("stormrage", body.realm.slug)
-        assertEquals(RealmDto.Region.EU, body.realm.region)
-        assertEquals(1234, body.auctionHouse.connectedRealmId)
-        assertEquals(lastModified, body.auctionHouse.lastModified?.toInstant())
-        assertEquals(nextUpdate, body.auctionHouse.nextUpdate?.toInstant())
-        assertEquals(lastDailyPrice, body.auctionHouse.lastDailyPriceUpdate?.toInstant())
-        assertEquals(CommunityRealms.idFor(Region.Europe), body.community.connectedRealmId)
-        assertEquals(communityModified, body.community.lastModified?.toInstant())
-        assertNull(body.community.lastDailyPriceUpdate)
-    }
-
-    @Test
-    fun `getRealm returns 404 when no realm matches the region and slug`() {
-        every { connectedRealmRepository.findAllByRegion(Region.Europe) } returns emptyList()
-
-        val response = controller.getRealm("eu", "ghost-realm")
-
-        assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
-    }
-
-    @Test
-    fun `getRealm returns 404 when the community sibling is missing for the region`() {
-        val realm = realm(id = 10, region = euRegion, name = "Stormrage", slug = "stormrage", locale = Locale.EN_GB)
-        val connected = connectedRealm(id = 1234, realms = listOf(realm))
-        every { connectedRealmRepository.findAllByRegion(Region.Europe) } returns listOf(connected)
-        every { connectedRealmRepository.findById(CommunityRealms.idFor(Region.Europe)) } returns Optional.empty()
+        every { realmQueryService.getRealmDetail("eu", "stormrage") } returns detail
 
         val response = controller.getRealm("eu", "stormrage")
 
-        assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
-    }
-
-    @Test
-    fun `getRealm returns 404 when the region path parameter is unknown`() {
-        val response = controller.getRealm("zz", "stormrage")
-
-        assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
-    }
-
-    private fun realm(
-        id: Int,
-        region: RegionDBO,
-        name: String,
-        slug: String,
-        locale: Locale,
-        category: String = "Player vs. Player",
-        timezone: String = "Europe/Paris",
-    ): Realm =
-        Realm(
-            id = id,
-            region = region,
-            name = name,
-            category = category,
-            locale = locale,
-            timezone = timezone,
-            gameBuild = GameBuildVersion.RETAIL,
-            slug = slug,
-        )
-
-    private fun connectedRealm(
-        id: Int,
-        realms: List<Realm>,
-        lastModified: Instant? = null,
-        nextUpdate: Instant? = null,
-        lastDailyPriceUpdate: Instant? = null,
-    ): ConnectedRealm {
-        val regionType = realms.first().region.type
-        val auctionHouse =
-            AuctionHouse(
-                connectedId = id,
-                region = regionType,
-                lastModified = lastModified,
-                nextUpdate = nextUpdate,
-                lastDailyPriceUpdate = lastDailyPriceUpdate,
-            )
-        return ConnectedRealm(
-            id = id,
-            auctionHouse = auctionHouse,
-            realms = realms.toMutableList(),
-        )
+        assertEquals(200, response.statusCode.value())
+        assertEquals("stormrage", response.body?.realm?.slug)
     }
 }

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/RealmCatalogJdbcRepositoryTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/RealmCatalogJdbcRepositoryTest.kt
@@ -1,0 +1,183 @@
+package net.jonasmf.auctionengine.repository.rds
+
+import net.jonasmf.auctionengine.config.IntegrationTestBase
+import net.jonasmf.auctionengine.constant.GameBuildVersion
+import net.jonasmf.auctionengine.constant.Locale
+import net.jonasmf.auctionengine.constant.Region
+import net.jonasmf.auctionengine.dbo.rds.realm.AuctionHouse
+import net.jonasmf.auctionengine.dbo.rds.realm.ConnectedRealm
+import net.jonasmf.auctionengine.dbo.rds.realm.Realm
+import net.jonasmf.auctionengine.dbo.rds.realm.RegionDBO
+import net.jonasmf.auctionengine.service.CommunityRealms
+import net.jonasmf.auctionengine.service.ConnectedRealmBulkSyncService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.cache.CacheManager
+import org.springframework.jdbc.core.JdbcTemplate
+import java.time.Instant
+
+class RealmCatalogJdbcRepositoryTest : IntegrationTestBase() {
+    @Autowired
+    lateinit var realmCatalogJdbcRepository: RealmCatalogJdbcRepository
+
+    @Autowired
+    lateinit var connectedRealmBulkSyncService: ConnectedRealmBulkSyncService
+
+    @Autowired
+    lateinit var connectedRealmRepository: ConnectedRealmRepository
+
+    @Autowired
+    lateinit var regionRepository: RegionRepository
+
+    @Autowired
+    lateinit var cacheManager: CacheManager
+
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    @Test
+    fun `findRealmCatalogRows excludes community realms and caches the first result`() {
+        regionRepository.saveAll(
+            listOf(
+                RegionDBO(id = 1, name = "US", type = Region.NorthAmerica),
+                RegionDBO(id = 2, name = "EU", type = Region.Europe),
+            ),
+        )
+        regionRepository.flush()
+        val eu = regionRepository.findById(2).orElseThrow()
+        val us = regionRepository.findById(1).orElseThrow()
+
+        connectedRealmRepository.save(
+            connectedRealm(
+                connectedRealmId = 101,
+                region = eu,
+                realmId = 201,
+                name = "Stormrage",
+                slug = "stormrage",
+            ),
+        )
+        connectedRealmRepository.save(
+            connectedRealm(
+                connectedRealmId = 102,
+                region = us,
+                realmId = 202,
+                name = "Illidan",
+                slug = "illidan",
+            ),
+        )
+        connectedRealmRepository.save(
+            connectedRealm(
+                connectedRealmId = CommunityRealms.idFor(Region.Europe),
+                region = eu,
+                realmId = -2,
+                name = "Community",
+                slug = "community",
+                category = "Community",
+            ),
+        )
+        connectedRealmRepository.flush()
+
+        val first = realmCatalogJdbcRepository.findRealmCatalogRows()
+        assertEquals(listOf("Illidan", "Stormrage"), first.map { it.name })
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO auction_house (
+                id, auto_update, avg_delay, connected_id, game_build, highest_delay,
+                lowest_delay, stats_last_modified, update_attempts
+            ) VALUES (?, 0, 60, ?, 0, 0, 0, 0, 0)
+            """.trimIndent(),
+            103,
+            103,
+        )
+        jdbcTemplate.update(
+            """
+            INSERT INTO connected_realm (id, auction_house_id)
+            VALUES (?, ?)
+            """.trimIndent(),
+            103,
+            103,
+        )
+        jdbcTemplate.update(
+            """
+            INSERT INTO realm (
+                id, category, game_build, locale, name, slug, timezone, region_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """.trimIndent(),
+            203,
+            "PvE",
+            0,
+            Locale.EN_US.ordinal,
+            "Aegwynn",
+            "aegwynn",
+            "America/Chicago",
+            1,
+        )
+        jdbcTemplate.update(
+            """
+            INSERT INTO connected_realm_realms (connected_realm_id, realms_id)
+            VALUES (?, ?)
+            """.trimIndent(),
+            103,
+            203,
+        )
+
+        val cachedSecond = realmCatalogJdbcRepository.findRealmCatalogRows()
+        assertEquals(listOf("Illidan", "Stormrage"), cachedSecond.map { it.name })
+
+        connectedRealmBulkSyncService.sync(
+            listOf(
+                connectedRealm(
+                    connectedRealmId = 101,
+                    region = eu,
+                    realmId = 201,
+                    name = "Stormrage",
+                    slug = "stormrage",
+                ),
+            ),
+        )
+
+        val refreshed = realmCatalogJdbcRepository.findRealmCatalogRows()
+        assertTrue(refreshed.map { it.name }.contains("Aegwynn"))
+    }
+
+    private fun connectedRealm(
+        connectedRealmId: Int,
+        region: RegionDBO,
+        realmId: Int,
+        name: String,
+        slug: String,
+        category: String = "PvP",
+    ): ConnectedRealm =
+        ConnectedRealm(
+            id = connectedRealmId,
+            auctionHouse =
+                AuctionHouse(
+                    connectedId = connectedRealmId,
+                    region = region.type,
+                    lastModified = Instant.EPOCH,
+                    nextUpdate = Instant.EPOCH,
+                    lowestDelay = 0L,
+                    avgDelay = 60L,
+                    highestDelay = 0L,
+                    gameBuild = 0,
+                    statsLastModified = 0L,
+                    updateAttempts = 0,
+                ),
+            realms =
+                mutableListOf(
+                    Realm(
+                        id = realmId,
+                        region = region,
+                        name = name,
+                        category = category,
+                        locale = Locale.EN_US,
+                        timezone = "America/Chicago",
+                        gameBuild = GameBuildVersion.RETAIL,
+                        slug = slug,
+                    ),
+                ),
+        )
+}

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/service/RealmQueryServiceTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/service/RealmQueryServiceTest.kt
@@ -1,0 +1,81 @@
+package net.jonasmf.auctionengine.service
+
+import io.mockk.every
+import io.mockk.mockk
+import net.jonasmf.auctionengine.constant.Region
+import net.jonasmf.auctionengine.generated.model.Realm
+import net.jonasmf.auctionengine.repository.rds.RealmCatalogJdbcRepository
+import net.jonasmf.auctionengine.repository.rds.RealmCatalogRow
+import net.jonasmf.auctionengine.repository.rds.RealmDetailRow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class RealmQueryServiceTest {
+    private val repository = mockk<RealmCatalogJdbcRepository>()
+    private val service = RealmQueryService(repository)
+
+    @Test
+    fun `listAllRealms maps and sorts catalog rows`() {
+        every { repository.findRealmCatalogRows() } returns
+            listOf(
+                RealmCatalogRow(
+                    regionId = 2,
+                    name = "Stormrage",
+                    category = "PvP",
+                    slug = "stormrage",
+                    locale = "en_GB",
+                    timezone = "Europe/Paris",
+                ),
+                RealmCatalogRow(
+                    regionId = 1,
+                    name = "Illidan",
+                    category = "PvE",
+                    slug = "illidan",
+                    locale = "en_US",
+                    timezone = "America/Chicago",
+                ),
+            )
+
+        val result = service.listAllRealms()
+
+        assertEquals(listOf("Stormrage", "Illidan"), result.realms.map { it.name })
+        assertEquals(Realm.Region.EU, result.realms.first().region)
+    }
+
+    @Test
+    fun `getRealmDetail maps detail rows`() {
+        every { repository.findRealmDetailRow(Region.Europe, "stormrage") } returns
+            RealmDetailRow(
+                connectedRealmId = 1234,
+                regionId = 2,
+                name = "Stormrage",
+                category = "PvP",
+                slug = "stormrage",
+                locale = "en_GB",
+                timezone = "Europe/Paris",
+                lastDailyPriceUpdate = Instant.parse("2026-05-01T05:00:00Z"),
+                lastModified = Instant.parse("2026-05-01T10:00:00Z"),
+                nextUpdate = Instant.parse("2026-05-01T11:00:00Z"),
+                communityConnectedRealmId = -2,
+                communityLastDailyPriceUpdate = null,
+                communityLastModified = Instant.parse("2026-05-01T09:00:00Z"),
+                communityNextUpdate = null,
+            )
+
+        val detail = service.getRealmDetail("eu", "stormrage")
+
+        assertEquals("stormrage", detail?.realm?.slug)
+        assertEquals(1234, detail?.auctionHouse?.connectedRealmId)
+        assertEquals(-2, detail?.community?.connectedRealmId)
+    }
+
+    @Test
+    fun `getRealmDetail returns null for unknown region or missing row`() {
+        every { repository.findRealmDetailRow(Region.Europe, "ghost") } returns null
+
+        assertNull(service.getRealmDetail("zz", "stormrage"))
+        assertNull(service.getRealmDetail("eu", "ghost"))
+    }
+}

--- a/frontend/src/app/features/select-realm/select-realm.page.html
+++ b/frontend/src/app/features/select-realm/select-realm.page.html
@@ -1,4 +1,4 @@
-<section class="mx-auto flex w-full max-w-2xl flex-1 flex-col gap-6 px-4 py-12 sm:py-20">
+<section class="mx-auto flex min-h-0 w-full max-w-2xl flex-1 flex-col gap-6 px-4 py-12 sm:py-20">
   <header class="text-center">
     <p class="ee-data uppercase text-outline">The Ethereal Exchange</p>
     <h1
@@ -21,35 +21,38 @@
   } @else if (error()) {
     <p class="text-center text-error" role="alert">{{ error() }}</p>
   } @else {
-    <div class="flex items-baseline justify-between">
-      <h2 class="ee-section-heading text-on-surface">Realms</h2>
-      <span class="ee-data text-outline">{{ resultsLabel() }}</span>
-    </div>
+    <div class="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden">
+      <div class="flex items-baseline justify-between">
+        <h2 class="ee-section-heading text-on-surface">Realms</h2>
+        <span class="ee-data text-outline">{{ resultsLabel() }}</span>
+      </div>
 
-    @if (filtered().length === 0) {
-      <p class="text-center text-outline">No realms match your search.</p>
-    } @else {
-      <ul class="flex flex-col gap-2" role="listbox" aria-label="Available realms">
-        @for (realm of filtered(); track trackByKey($index, realm)) {
-          <li>
-            <button
-              type="button"
-              class="flex w-full items-center justify-between rounded-lg border border-white/10 bg-surface-container-highest px-4 py-3 text-left transition hover:border-primary/40 hover:bg-surface-container-high focus:outline-none focus:ring-1 focus:ring-primary"
-              role="option"
-              [attr.aria-label]="realm.name + ' on ' + realm.region.toUpperCase()"
-              (click)="select(realm)"
-            >
-              <span class="flex flex-col">
-                <span class="font-cinzel text-base text-on-surface">{{ realm.name }}</span>
-                <span class="ee-data text-outline"
-                  >{{ realm.category }} · {{ realm.timezone }}</span
-                >
-              </span>
-              <span class="ee-data text-primary-container">{{ realm.region.toUpperCase() }}</span>
-            </button>
-          </li>
-        }
-      </ul>
-    }
+      @if (filtered().length === 0) {
+        <p class="text-center text-outline">No realms match your search.</p>
+      } @else {
+        <ul
+          class="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto pr-1"
+          aria-label="Available realms"
+        >
+          @for (realm of filtered(); track trackByKey($index, realm)) {
+            <li>
+              <a
+                class="flex w-full items-center justify-between rounded-lg border border-white/10 bg-surface-container-highest px-4 py-3 text-left transition hover:border-primary/40 hover:bg-surface-container-high focus:outline-none focus:ring-1 focus:ring-primary"
+                [routerLink]="['/', realm.region, realm.slug]"
+                (click)="rememberSelection(realm)"
+              >
+                <span class="flex flex-col">
+                  <span class="font-cinzel text-base text-on-surface">{{ realm.name }}</span>
+                  <span class="ee-data text-outline"
+                    >{{ realm.category }} · {{ realm.timezone }}</span
+                  >
+                </span>
+                <span class="ee-data text-primary-container">{{ realm.region.toUpperCase() }}</span>
+              </a>
+            </li>
+          }
+        </ul>
+      }
+    </div>
   }
 </section>

--- a/frontend/src/app/features/select-realm/select-realm.page.spec.ts
+++ b/frontend/src/app/features/select-realm/select-realm.page.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { provideRouter, Router } from '@angular/router';
+import { provideRouter } from '@angular/router';
 import { of } from 'rxjs';
 
 import { Realm, RealmApiService } from '../../api/generated';
@@ -76,31 +76,28 @@ describe('SelectRealmPage', () => {
   });
 
   it('renders all realms after the API resolves', () => {
-    const buttons = fixture.nativeElement.querySelectorAll('li button');
-    expect(buttons.length).toBe(3);
+    const links = fixture.nativeElement.querySelectorAll('li a');
+    expect(links.length).toBe(3);
+    expect(links[0].getAttribute('href')).toContain('/eu/stormrage');
   });
 
   it('filters realms by name, slug, or region (case-insensitive)', async () => {
     component['onQueryChanged']('storm');
     fixture.detectChanges();
-    let buttons = fixture.nativeElement.querySelectorAll('li button');
-    expect(buttons.length).toBe(1);
-    expect(buttons[0].textContent).toContain('Stormrage');
+    let links = fixture.nativeElement.querySelectorAll('li a');
+    expect(links.length).toBe(1);
+    expect(links[0].textContent).toContain('Stormrage');
 
     component['onQueryChanged']('US');
     fixture.detectChanges();
-    buttons = fixture.nativeElement.querySelectorAll('li button');
-    expect(buttons.length).toBe(1);
-    expect(buttons[0].textContent).toContain('Illidan');
+    links = fixture.nativeElement.querySelectorAll('li a');
+    expect(links.length).toBe(1);
+    expect(links[0].textContent).toContain('Illidan');
   });
 
-  it('navigates to /:region/:slug and persists the selection when a realm is chosen', () => {
-    const router = TestBed.inject(Router);
-    const navigate = vitest.spyOn(router, 'navigate').mockResolvedValue(true);
+  it('persists the selection when a realm link is activated', () => {
+    component['rememberSelection'](realmsFixture[0]);
 
-    component['select'](realmsFixture[0]);
-
-    expect(navigate).toHaveBeenCalledWith(['/', 'eu', 'stormrage']);
     expect(localStorage.getItem('wae.selectedRealm')).toBe(
       JSON.stringify({ region: 'eu', slug: 'stormrage' }),
     );

--- a/frontend/src/app/features/select-realm/select-realm.page.ts
+++ b/frontend/src/app/features/select-realm/select-realm.page.ts
@@ -7,7 +7,7 @@ import {
   PLATFORM_ID,
   signal,
 } from '@angular/core';
-import { Router } from '@angular/router';
+import { RouterLink } from '@angular/router';
 import { SearchInputComponent } from '@ui';
 
 import { Realm } from '../../api/generated';
@@ -15,13 +15,15 @@ import { RealmSelectionService } from '@core/services/realm-selection.service';
 
 @Component({
   selector: 'app-select-realm-page',
-  imports: [SearchInputComponent],
+  imports: [RouterLink, SearchInputComponent],
   templateUrl: './select-realm.page.html',
+  host: {
+    class: 'flex min-h-0 flex-1 flex-col',
+  },
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SelectRealmPage {
   private readonly selection = inject(RealmSelectionService);
-  private readonly router = inject(Router);
   private readonly platformId = inject(PLATFORM_ID);
 
   protected readonly query = signal('');
@@ -69,9 +71,8 @@ export class SelectRealmPage {
     this.query.set(value);
   }
 
-  protected select(realm: Realm): void {
+  protected rememberSelection(realm: Realm): void {
     this.selection.select(realm);
-    void this.router.navigate(['/', realm.region, realm.slug]);
   }
 
   protected trackByKey(_: number, realm: Realm): string {


### PR DESCRIPTION
## Summary
- Replaced the `/realms` catalog path with a narrow JDBC read and added in-process caching with sync-driven eviction.
- Added request/query timing so backend logs now separate total request time, query time, and mapping/sort time.
- Optimized auction market search to read hourly stats directly instead of going through the unpivoted price view.
- Updated `select-realm` to use semantic links, preserve selection on navigation, and restore proper inner scrolling on small viewports.
- Added and updated backend/frontend tests to cover catalog mapping, cache behavior, timing, and link semantics.

## Testing
- Backend unit and integration tests for realm catalog, controller timing, and market search passed.
- Frontend `select-realm` component tests passed.
- Local validation confirmed the optimized backend paths return quickly and the picker renders as expected.