### PR TITLE
Add market search timing logs and media source URLs

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -208,8 +208,6 @@
     </dependencies>
 
     <build>
-        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
-        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/interceptor/MarketSearchTimingFilter.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/interceptor/MarketSearchTimingFilter.kt
@@ -1,0 +1,53 @@
+package net.jonasmf.auctionengine.interceptor
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.util.UUID
+
+@Component
+class MarketSearchTimingFilter : OncePerRequestFilter() {
+    private val log = LoggerFactory.getLogger(MarketSearchTimingFilter::class.java)
+
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean {
+        val path = request.requestURI.removePrefix(request.contextPath)
+        return path != "/auctions/market-search" && path != "/auctions/market-search/filters"
+    }
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val requestId = request.getHeader(REQUEST_ID_HEADER)?.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
+        val startNanos = System.nanoTime()
+        MDC.put(REQUEST_ID_MDC_KEY, requestId)
+        response.setHeader(REQUEST_ID_HEADER, requestId)
+
+        try {
+            filterChain.doFilter(request, response)
+        } finally {
+            val totalMs = elapsedMs(startNanos)
+            log.info(
+                "Market search request completed in {}ms (requestId={} method={} uri={} status={})",
+                totalMs,
+                requestId,
+                request.method,
+                request.requestURI,
+                response.status,
+            )
+            MDC.remove(REQUEST_ID_MDC_KEY)
+        }
+    }
+
+    private fun elapsedMs(startNanos: Long): Long = (System.nanoTime() - startNanos) / 1_000_000
+
+    companion object {
+        const val REQUEST_ID_HEADER = "X-Request-Id"
+        const val REQUEST_ID_MDC_KEY = "requestId"
+    }
+}

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketSearchRepository.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketSearchRepository.kt
@@ -4,6 +4,8 @@ import org.slf4j.LoggerFactory
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.jdbc.core.RowMapper
 import org.springframework.stereotype.Repository
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 import java.sql.ResultSet
 import java.time.LocalDate
 
@@ -74,6 +76,8 @@ class AuctionMarketSearchRepository(
 ) {
     private val logger = LoggerFactory.getLogger(AuctionMarketSearchRepository::class.java)
 
+    private val log = LoggerFactory.getLogger(AuctionMarketSearchRepository::class.java)
+
     private val sortColumns =
         mapOf(
             "itemName" to "item_name",
@@ -87,7 +91,7 @@ class AuctionMarketSearchRepository(
         )
 
     fun search(request: AuctionMarketSearchRequest): AuctionMarketSearchResult {
-        val startNanos = System.nanoTime()
+        val totalStartNanos = System.nanoTime()
         val params = ArrayList<Any?>()
         val fromSql = buildFromSql(request, params)
         val whereSql = buildWhereSql(request, params)
@@ -99,7 +103,7 @@ class AuctionMarketSearchRepository(
                 Long::class.java,
                 *countParams.toTypedArray(),
             ) ?: 0L
-        val countDurationMs = elapsedMs(countStartNanos)
+        val countMs = elapsedMs(countStartNanos)
 
         val sortColumn = sortColumns[request.sortBy] ?: sortColumns.getValue("itemName")
         val sortDirection = if (request.sortDirection.equals("desc", ignoreCase = true)) "DESC" else "ASC"
@@ -139,13 +143,14 @@ class AuctionMarketSearchRepository(
                 rowMapper,
                 *params.toTypedArray(),
             )
-        val rowsDurationMs = elapsedMs(rowsStartNanos)
+        val rowsMs = elapsedMs(rowsStartNanos)
 
-        logger.info(
-            "Auction market search completed in {}ms (count={}ms rows={}ms selectedRealm={} selectedDate={} selectedHour={} communityRealm={} communityDate={} communityHour={} totalItems={} returnedRows={})",
-            elapsedMs(startNanos),
-            countDurationMs,
-            rowsDurationMs,
+        log.info(
+            "Auction market search repository completed in {}ms (requestId={} count={}ms rows={}ms selectedRealm={} selectedDate={} selectedHour={} communityRealm={} communityDate={} communityHour={} totalItems={} returnedRows={})",
+            elapsedMs(totalStartNanos),
+            requestId(),
+            countMs,
+            rowsMs,
             request.selectedConnectedRealmId,
             request.selectedDate,
             request.selectedHour,
@@ -372,4 +377,8 @@ class AuctionMarketSearchRepository(
         val value = getLong(column)
         return if (wasNull()) null else value
     }
+
+    private fun elapsedMs(startNanos: Long): Long = (System.nanoTime() - startNanos) / 1_000_000
+
+    private fun requestId(): String = MDC.get("requestId") ?: "-"
 }

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketSearchRepository.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketSearchRepository.kt
@@ -1,11 +1,10 @@
 package net.jonasmf.auctionengine.repository.rds
 
 import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.jdbc.core.RowMapper
 import org.springframework.stereotype.Repository
-import org.slf4j.LoggerFactory
-import org.slf4j.MDC
 import java.sql.ResultSet
 import java.time.LocalDate
 
@@ -76,8 +75,6 @@ class AuctionMarketSearchRepository(
 ) {
     private val logger = LoggerFactory.getLogger(AuctionMarketSearchRepository::class.java)
 
-    private val log = LoggerFactory.getLogger(AuctionMarketSearchRepository::class.java)
-
     private val sortColumns =
         mapOf(
             "itemName" to "item_name",
@@ -145,7 +142,7 @@ class AuctionMarketSearchRepository(
             )
         val rowsMs = elapsedMs(rowsStartNanos)
 
-        log.info(
+        logger.info(
             "Auction market search repository completed in {}ms (requestId={} count={}ms rows={}ms selectedRealm={} selectedDate={} selectedHour={} communityRealm={} communityDate={} communityHour={} totalItems={} returnedRows={})",
             elapsedMs(totalStartNanos),
             requestId(),
@@ -377,8 +374,6 @@ class AuctionMarketSearchRepository(
         val value = getLong(column)
         return if (wasNull()) null else value
     }
-
-    private fun elapsedMs(startNanos: Long): Long = (System.nanoTime() - startNanos) / 1_000_000
 
     private fun requestId(): String = MDC.get("requestId") ?: "-"
 }

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/service/AuctionMarketSearchService.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/service/AuctionMarketSearchService.kt
@@ -19,6 +19,8 @@ import net.jonasmf.auctionengine.repository.rds.AuctionMarketSearchRepository
 import net.jonasmf.auctionengine.repository.rds.AuctionMarketSearchRequest
 import net.jonasmf.auctionengine.repository.rds.ConnectedRealmRepository
 import net.jonasmf.auctionengine.utility.resolveZone
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
@@ -48,6 +50,8 @@ class AuctionMarketSearchService(
     private val connectedRealmRepository: ConnectedRealmRepository,
     private val auctionMarketSearchRepository: AuctionMarketSearchRepository,
 ) {
+    private val log = LoggerFactory.getLogger(AuctionMarketSearchService::class.java)
+
     fun search(
         regionCode: String,
         realmSlug: String,
@@ -69,7 +73,10 @@ class AuctionMarketSearchService(
         validateRange("price", minPrice, maxPrice)
         validateRange("quantity", minQuantity, maxQuantity)
 
+        val totalStartNanos = System.nanoTime()
+        val resolveContextStartNanos = System.nanoTime()
         val context = resolveContext(regionCode, realmSlug, localeOverride)
+        val resolveContextMs = elapsedMs(resolveContextStartNanos)
         val normalizedPage = page.coerceAtLeast(0)
         val normalizedPageSize = pageSize.coerceIn(1, 100)
         val normalizedSortBy = allowedSorts.firstOrNull { it == sortBy } ?: "itemName"
@@ -97,7 +104,9 @@ class AuctionMarketSearchService(
                 minQuantity = minQuantity,
                 maxQuantity = maxQuantity,
             )
+        val repositoryStartNanos = System.nanoTime()
         val result = auctionMarketSearchRepository.search(request)
+        val repositoryMs = elapsedMs(repositoryStartNanos)
         val totalPages =
             if (result.totalItems == 0L) {
                 0
@@ -105,71 +114,89 @@ class AuctionMarketSearchService(
                 ((result.totalItems + normalizedPageSize - 1) / normalizedPageSize).toInt()
             }
 
-        return AuctionMarketSearchPage(
-            items =
-                result.rows.map { row ->
-                    AuctionMarketSearchRow(
-                        item =
-                            AuctionMarketItem(
-                                id = row.itemId,
-                                name = row.itemName,
-                                mediaUrl = row.itemMediaUrl,
-                                quality =
-                                    row.qualityId?.let {
-                                        AuctionMarketNamedId(
-                                            it,
-                                            row.qualityName.orEmpty(),
-                                            row.qualityType,
-                                        )
-                                    },
-                                itemClass =
-                                    row.itemClassId?.let {
-                                        AuctionMarketNamedId(
-                                            it,
-                                            row.itemClassName.orEmpty(),
-                                        )
-                                    },
-                                itemSubclass =
-                                    row.itemSubclassId?.let {
-                                        AuctionMarketNamedId(
-                                            it,
-                                            row.itemSubclassName.orEmpty(),
-                                        )
-                                    },
-                                recipe =
-                                    row.recipeId?.let {
-                                        AuctionMarketRecipe(
-                                            id = it,
-                                            name = row.recipeName.orEmpty(),
-                                            mediaUrl = row.recipeMediaUrl,
-                                        )
-                                    },
-                            ),
-                        selectedRealm =
-                            context.selectedSnapshot.toMetrics(
-                                price = row.selectedPrice,
-                                quantity = row.selectedQuantity,
-                            ),
-                        community =
-                            context.communitySnapshot.toMetrics(
-                                price = row.communityPrice,
-                                quantity = row.communityQuantity,
-                            ),
-                    )
-                },
-            page =
-                PageMetadata(
-                    page = normalizedPage,
-                    pageSize = normalizedPageSize,
-                    totalItems = result.totalItems,
-                    totalPages = totalPages,
-                ),
-            sort =
-                AuctionMarketSort(
-                    sortBy = normalizedSortBy,
-                    sortDirection = AuctionMarketSort.SortDirection.forValue(normalizedSortDirection),
-                ),
+        val mappingStartNanos = System.nanoTime()
+        val response =
+            AuctionMarketSearchPage(
+                items =
+                    result.rows.map { row ->
+                        AuctionMarketSearchRow(
+                            item =
+                                AuctionMarketItem(
+                                    id = row.itemId,
+                                    name = row.itemName,
+                                    mediaUrl = row.itemMediaUrl,
+                                    quality =
+                                        row.qualityId?.let {
+                                            AuctionMarketNamedId(
+                                                it,
+                                                row.qualityName.orEmpty(),
+                                                row.qualityType,
+                                            )
+                                        },
+                                    itemClass =
+                                        row.itemClassId?.let {
+                                            AuctionMarketNamedId(
+                                                it,
+                                                row.itemClassName.orEmpty(),
+                                            )
+                                        },
+                                    itemSubclass =
+                                        row.itemSubclassId?.let {
+                                            AuctionMarketNamedId(
+                                                it,
+                                                row.itemSubclassName.orEmpty(),
+                                            )
+                                        },
+                                    recipe =
+                                        row.recipeId?.let {
+                                            AuctionMarketRecipe(
+                                                id = it,
+                                                name = row.recipeName.orEmpty(),
+                                                mediaUrl = row.recipeMediaUrl,
+                                            )
+                                        },
+                                ),
+                            selectedRealm =
+                                context.selectedSnapshot.toMetrics(
+                                    price = row.selectedPrice,
+                                    quantity = row.selectedQuantity,
+                                ),
+                            community =
+                                context.communitySnapshot.toMetrics(
+                                    price = row.communityPrice,
+                                    quantity = row.communityQuantity,
+                                ),
+                        )
+                    },
+                page =
+                    PageMetadata(
+                        page = normalizedPage,
+                        pageSize = normalizedPageSize,
+                        totalItems = result.totalItems,
+                        totalPages = totalPages,
+                    ),
+                sort =
+                    AuctionMarketSort(
+                        sortBy = normalizedSortBy,
+                        sortDirection = AuctionMarketSort.SortDirection.forValue(normalizedSortDirection),
+                    ),
+            )
+        val mappingMs = elapsedMs(mappingStartNanos)
+        log.info(
+            "Auction market search service completed in {}ms (requestId={} resolveContext={}ms repository={}ms mapping={}ms region={} realmSlug={} page={} pageSize={} totalItems={} returnedRows={})",
+            elapsedMs(totalStartNanos),
+            requestId(),
+            resolveContextMs,
+            repositoryMs,
+            mappingMs,
+            regionCode,
+            realmSlug,
+            normalizedPage,
+            normalizedPageSize,
+            result.totalItems,
+            result.rows.size,
         )
+        return response
     }
 
     fun filters(
@@ -177,7 +204,10 @@ class AuctionMarketSearchService(
         realmSlug: String,
         localeOverride: String?,
     ): AuctionMarketFilterResponse {
+        val totalStartNanos = System.nanoTime()
+        val resolveContextStartNanos = System.nanoTime()
         val context = resolveContext(regionCode, realmSlug, localeOverride)
+        val resolveContextMs = elapsedMs(resolveContextStartNanos)
         val request =
             AuctionMarketSearchRequest(
                 selectedConnectedRealmId = context.selectedSnapshot.connectedRealmId,
@@ -201,54 +231,86 @@ class AuctionMarketSearchService(
                 minQuantity = null,
                 maxQuantity = null,
             )
+        val rangeStartNanos = System.nanoTime()
         val range = auctionMarketSearchRepository.priceAndQuantityRange(request)
-        return AuctionMarketFilterResponse(
-            filters =
-                listOf(
-                    AuctionMarketFilter(
-                        id = "query",
-                        label = "Search",
-                        type = AuctionMarketFilter.Type.TEXT,
+        val rangeMs = elapsedMs(rangeStartNanos)
+
+        val qualityOptionsStartNanos = System.nanoTime()
+        val qualityOptions = auctionMarketSearchRepository.qualityOptions(request).toDtoOptions()
+        val qualityOptionsMs = elapsedMs(qualityOptionsStartNanos)
+
+        val itemClassOptionsStartNanos = System.nanoTime()
+        val itemClassOptions = auctionMarketSearchRepository.itemClassOptions(request).toDtoOptions()
+        val itemClassOptionsMs = elapsedMs(itemClassOptionsStartNanos)
+
+        val itemSubclassOptionsStartNanos = System.nanoTime()
+        val itemSubclassOptions = auctionMarketSearchRepository.itemSubclassOptions(request).toDtoOptions()
+        val itemSubclassOptionsMs = elapsedMs(itemSubclassOptionsStartNanos)
+
+        val response =
+            AuctionMarketFilterResponse(
+                filters =
+                    listOf(
+                        AuctionMarketFilter(
+                            id = "query",
+                            label = "Search",
+                            type = AuctionMarketFilter.Type.TEXT,
+                        ),
+                        AuctionMarketFilter(
+                            id = "qualityIds",
+                            label = "Quality",
+                            type = AuctionMarketFilter.Type.MULTI_SELECT,
+                            options = qualityOptions,
+                        ),
+                        AuctionMarketFilter(
+                            id = "itemClassIds",
+                            label = "Item Class",
+                            type = AuctionMarketFilter.Type.MULTI_SELECT,
+                            options = itemClassOptions,
+                        ),
+                        AuctionMarketFilter(
+                            id = "itemSubclassIds",
+                            label = "Item Subclass",
+                            type = AuctionMarketFilter.Type.MULTI_SELECT,
+                            options = itemSubclassOptions,
+                        ),
+                        AuctionMarketFilter(
+                            id = "recipeOnly",
+                            label = "Has Recipe",
+                            type = AuctionMarketFilter.Type.BOOLEAN,
+                        ),
+                        AuctionMarketFilter(
+                            id = "price",
+                            label = "Price",
+                            type = AuctionMarketFilter.Type.RANGE,
+                            min = range.minPrice,
+                            max = range.maxPrice,
+                        ),
+                        AuctionMarketFilter(
+                            id = "quantity",
+                            label = "Quantity",
+                            type = AuctionMarketFilter.Type.RANGE,
+                            min = range.minQuantity,
+                            max = range.maxQuantity,
+                        ),
                     ),
-                    AuctionMarketFilter(
-                        id = "qualityIds",
-                        label = "Quality",
-                        type = AuctionMarketFilter.Type.MULTI_SELECT,
-                        options = auctionMarketSearchRepository.qualityOptions(request).toDtoOptions(),
-                    ),
-                    AuctionMarketFilter(
-                        id = "itemClassIds",
-                        label = "Item Class",
-                        type = AuctionMarketFilter.Type.MULTI_SELECT,
-                        options = auctionMarketSearchRepository.itemClassOptions(request).toDtoOptions(),
-                    ),
-                    AuctionMarketFilter(
-                        id = "itemSubclassIds",
-                        label = "Item Subclass",
-                        type = AuctionMarketFilter.Type.MULTI_SELECT,
-                        options = auctionMarketSearchRepository.itemSubclassOptions(request).toDtoOptions(),
-                    ),
-                    AuctionMarketFilter(
-                        id = "recipeOnly",
-                        label = "Has Recipe",
-                        type = AuctionMarketFilter.Type.BOOLEAN,
-                    ),
-                    AuctionMarketFilter(
-                        id = "price",
-                        label = "Price",
-                        type = AuctionMarketFilter.Type.RANGE,
-                        min = range.minPrice,
-                        max = range.maxPrice,
-                    ),
-                    AuctionMarketFilter(
-                        id = "quantity",
-                        label = "Quantity",
-                        type = AuctionMarketFilter.Type.RANGE,
-                        min = range.minQuantity,
-                        max = range.maxQuantity,
-                    ),
-                ),
+            )
+        log.info(
+            "Auction market filters service completed in {}ms (requestId={} resolveContext={}ms range={}ms qualityOptions={}ms itemClassOptions={}ms itemSubclassOptions={}ms region={} realmSlug={} qualityOptionsCount={} itemClassOptionsCount={} itemSubclassOptionsCount={})",
+            elapsedMs(totalStartNanos),
+            requestId(),
+            resolveContextMs,
+            rangeMs,
+            qualityOptionsMs,
+            itemClassOptionsMs,
+            itemSubclassOptionsMs,
+            regionCode,
+            realmSlug,
+            qualityOptions.size,
+            itemClassOptions.size,
+            itemSubclassOptions.size,
         )
+        return response
     }
 
     private fun resolveContext(
@@ -351,6 +413,10 @@ class AuctionMarketSearchService(
 
     private val Locale.columnSuffix: String
         get() = value.lowercase()
+
+    private fun elapsedMs(startNanos: Long): Long = (System.nanoTime() - startNanos) / 1_000_000
+
+    private fun requestId(): String = MDC.get("requestId") ?: "-"
 
     companion object {
         private val allowedSorts =

--- a/frontend/src/app/app.config.server.ts
+++ b/frontend/src/app/app.config.server.ts
@@ -5,6 +5,8 @@ import { appConfig } from './app.config';
 import { serverRoutes } from './app.routes.server';
 import { resolveBackendOrigin } from '../backend-origin';
 
+const backendOrigin = process.env['BACKEND_ORIGIN'] || 'http://localhost:8080';
+
 const serverConfig: ApplicationConfig = {
   providers: [
     provideServerRendering(withRoutes(serverRoutes)),

--- a/frontend/src/app/app.config.server.ts
+++ b/frontend/src/app/app.config.server.ts
@@ -5,8 +5,6 @@ import { appConfig } from './app.config';
 import { serverRoutes } from './app.routes.server';
 import { resolveBackendOrigin } from '../backend-origin';
 
-const backendOrigin = process.env['BACKEND_ORIGIN'] || 'http://localhost:8080';
-
 const serverConfig: ApplicationConfig = {
   providers: [
     provideServerRendering(withRoutes(serverRoutes)),

--- a/frontend/src/server.ts
+++ b/frontend/src/server.ts
@@ -5,6 +5,7 @@ import {
   writeResponseToNodeResponse,
 } from '@angular/ssr/node';
 import express from 'express';
+import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 import { resolveBackendOrigin } from './backend-origin';
 
@@ -25,6 +26,8 @@ const hopByHopHeaders = new Set([
 const app = express();
 const angularApp = new AngularNodeAppEngine();
 
+const requestIdHeader = 'x-request-id';
+
 function readRequestBody(req: express.Request): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
@@ -35,6 +38,13 @@ function readRequestBody(req: express.Request): Promise<Buffer> {
 }
 
 app.use('/api', async (req, res, next) => {
+  const proxyStart = performance.now();
+  const isMarketSearchRequest =
+    req.path === '/auctions/market-search' || req.path === '/auctions/market-search/filters';
+  const requestId = readRequestId(req) ?? randomUUID();
+  let backendHeadersMs = 0;
+  let bodyReadMs = 0;
+
   try {
     const targetUrl = new URL(req.originalUrl, backendOrigin);
     const headers = new Headers();
@@ -51,6 +61,8 @@ app.use('/api', async (req, res, next) => {
         headers.set(key, value);
       }
     }
+    headers.set(requestIdHeader, requestId);
+    res.setHeader('X-Request-Id', requestId);
 
     const bodyBuffer = ['GET', 'HEAD'].includes(req.method)
       ? undefined
@@ -61,11 +73,13 @@ app.use('/api', async (req, res, next) => {
           bodyBuffer.byteOffset + bodyBuffer.byteLength,
         ) as ArrayBuffer)
       : undefined;
+    const backendFetchStart = performance.now();
     const response = await fetch(targetUrl, {
       method: req.method,
       headers,
       body,
     });
+    backendHeadersMs = elapsedMs(backendFetchStart);
 
     res.status(response.status);
     response.headers.forEach((value, key) => {
@@ -76,15 +90,83 @@ app.use('/api', async (req, res, next) => {
     });
 
     if (response.body) {
+      const bodyReadStart = performance.now();
       const responseBody = Buffer.from(await response.arrayBuffer());
+      bodyReadMs = elapsedMs(bodyReadStart);
+      const responseSendStart = performance.now();
+      res.once('finish', () => {
+        if (isMarketSearchRequest) {
+          logMarketSearchProxyTiming({
+            requestId,
+            method: req.method,
+            path: targetUrl.pathname,
+            status: response.status,
+            backendHeadersMs,
+            bodyReadMs,
+            responseSendMs: elapsedMs(responseSendStart),
+            totalMs: elapsedMs(proxyStart),
+          });
+        }
+      });
       res.send(responseBody);
     } else {
+      const responseSendStart = performance.now();
+      res.once('finish', () => {
+        if (isMarketSearchRequest) {
+          logMarketSearchProxyTiming({
+            requestId,
+            method: req.method,
+            path: targetUrl.pathname,
+            status: response.status,
+            backendHeadersMs,
+            bodyReadMs,
+            responseSendMs: elapsedMs(responseSendStart),
+            totalMs: elapsedMs(proxyStart),
+          });
+        }
+      });
       res.end();
     }
   } catch (error) {
+    if (isMarketSearchRequest) {
+      console.error(
+        `Market search proxy failed in ${elapsedMs(proxyStart)}ms (requestId=${requestId} method=${req.method} path=${req.path})`,
+        error,
+      );
+    }
     next(error);
   }
 });
+
+function readRequestId(req: express.Request): string | null {
+  const value = req.headers[requestIdHeader];
+  if (Array.isArray(value)) {
+    return value.find((item) => item.trim()) ?? null;
+  }
+  return value?.trim() || null;
+}
+
+function elapsedMs(start: number): number {
+  return Math.round(performance.now() - start);
+}
+
+function logMarketSearchProxyTiming(timing: {
+  requestId: string;
+  method: string;
+  path: string;
+  status: number;
+  backendHeadersMs: number;
+  bodyReadMs: number;
+  responseSendMs: number;
+  totalMs: number;
+}): void {
+  console.info(
+    `Market search proxy completed in ${timing.totalMs}ms ` +
+      `(requestId=${timing.requestId} method=${timing.method} path=${timing.path} ` +
+      `status=${timing.status} backendHeaders=${timing.backendHeadersMs}ms ` +
+      `bodyRead=${timing.bodyReadMs}ms responseSend=${timing.responseSendMs}ms)`,
+  );
+}
 
 /**
  * Serve static files from /browser


### PR DESCRIPTION
## Summary
- Add scoped timing logs for market search requests across the backend request filter, service, repository, and frontend SSR proxy so slow requests can be broken down by hop.
- Propagate `X-Request-Id` through the frontend proxy and backend logs to correlate a single request end to end.
- Add media source URL support across item and profession/recipe mappings, sync flows, and Blizzard media backfill.
- Extend the media DTOs, repositories, and migration to persist and use the new source URL fields.

## Testing
- `./mvnw test -Dtest=AuctionMarketSearchServiceTest`
- `./mvnw -q -DskipTests compile`
- `bun run build`
- `bunx prettier --check src/server.ts`