### PR TITLE
Adds Admin User Management and Reactive API

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -139,6 +139,16 @@
             <artifactId>kotlinx-coroutines-core-jvm</artifactId>
             <version>${kotlinx.coroutines.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-reactor</artifactId>
+            <version>${kotlinx.coroutines.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-reactor</artifactId>
+            <version>${kotlinx.coroutines.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
@@ -155,6 +165,11 @@
         <dependency>
             <groupId>aws.sdk.kotlin</groupId>
             <artifactId>s3-jvm</artifactId>
+            <version>${aws.sdk.kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>aws.sdk.kotlin</groupId>
+            <artifactId>cognitoidentityprovider-jvm</artifactId>
             <version>${aws.sdk.kotlin.version}</version>
         </dependency>
         <dependency>
@@ -301,8 +316,8 @@
                             <modelPackage>net.jonasmf.auctionengine.generated.model</modelPackage>
                             <generateApiTests>false</generateApiTests>
                             <generateModelTests>false</generateModelTests>
-                            <generateApiDocumentation>false</generateApiDocumentation>
-                            <generateModelDocumentation>false</generateModelDocumentation>
+                            <generateApiDocumentation>true</generateApiDocumentation>
+                            <generateModelDocumentation>true</generateModelDocumentation>
                             <nameMappings>
                                 <nameMapping>isCommodity=commodityOnly</nameMapping>
                             </nameMappings>
@@ -313,6 +328,8 @@
                                 <interfaceOnly>true</interfaceOnly>
                                 <sourceFolder>src/main/kotlin</sourceFolder>
                                 <useSpringBoot3>true</useSpringBoot3>
+                                <reactive>true</reactive>
+                                <useFlowForArrayReturnType>false</useFlowForArrayReturnType>
                                 <useTags>true</useTags>
                             </configOptions>
                         </configuration>

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/config/SecurityConfig.kt
@@ -3,17 +3,43 @@ package net.jonasmf.auctionengine.config
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.convert.converter.Converter
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter
 import org.springframework.security.web.SecurityFilterChain
 
 @Configuration
+@EnableMethodSecurity
 class SecurityConfig(
     @Value("\${spring.security.oauth2.resourceserver.jwt.issuer-uri:}")
     private val issuerUri: String,
 ) {
     @Bean
-    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+    fun cognitoGroupsGrantedAuthoritiesConverter(): Converter<Jwt, Collection<GrantedAuthority>> {
+        val defaultAuthoritiesConverter = JwtGrantedAuthoritiesConverter()
+
+        return Converter { jwt ->
+            val scopeAuthorities = defaultAuthoritiesConverter.convert(jwt) ?: emptyList()
+            val groupAuthorities =
+                jwt.getClaimAsStringList("cognito:groups")
+                    ?.map { group -> SimpleGrantedAuthority(group) }
+                    ?: emptyList()
+
+            scopeAuthorities + groupAuthorities
+        }
+    }
+
+    @Bean
+    fun securityFilterChain(
+        http: HttpSecurity,
+        cognitoGroupsGrantedAuthoritiesConverter: Converter<Jwt, Collection<GrantedAuthority>>,
+    ): SecurityFilterChain {
         http
             .csrf { csrf -> csrf.disable() }
             .sessionManagement { sessions ->
@@ -27,8 +53,15 @@ class SecurityConfig(
             }
 
         if (issuerUri.isNotBlank()) {
+            val jwtAuthenticationConverter =
+                JwtAuthenticationConverter().also { converter ->
+                    converter.setJwtGrantedAuthoritiesConverter(cognitoGroupsGrantedAuthoritiesConverter)
+                }
+
             http.oauth2ResourceServer { resourceServer ->
-                resourceServer.jwt { }
+                resourceServer.jwt { jwt ->
+                    jwt.jwtAuthenticationConverter(jwtAuthenticationConverter)
+                }
             }
         }
 

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/controller/AdminController.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/controller/AdminController.kt
@@ -1,23 +1,17 @@
 package net.jonasmf.auctionengine.controller
 
-import io.netty.util.concurrent.CompleteFuture
 import net.jonasmf.auctionengine.generated.api.AdminApi
 import net.jonasmf.auctionengine.generated.model.User
-import net.jonasmf.auctionengine.generated.model.Users
 import net.jonasmf.auctionengine.service.admin.UserService
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.security.core.Authentication
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.util.concurrent.CompletableFuture
 
 @RestController
 class AdminController(
     val userService: UserService,
 ) : AdminApi {
     // TODO: Need a paginated response - Update openApi as well
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasAuthority('Admin')")
     override suspend fun listUsers(): ResponseEntity<List<User>> = ResponseEntity.ok(userService.getUsers())
 }

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/controller/AdminController.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/controller/AdminController.kt
@@ -1,19 +1,23 @@
 package net.jonasmf.auctionengine.controller
 
+import io.netty.util.concurrent.CompleteFuture
+import net.jonasmf.auctionengine.generated.api.AdminApi
+import net.jonasmf.auctionengine.generated.model.User
+import net.jonasmf.auctionengine.generated.model.Users
+import net.jonasmf.auctionengine.service.admin.UserService
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.util.concurrent.CompletableFuture
 
 @RestController
-@RequestMapping("/admin")
-class AdminController {
-    @GetMapping("/session-check")
-    fun sessionCheck(authentication: Authentication): ResponseEntity<Unit> =
-        if (authentication.isAuthenticated) {
-            ResponseEntity.noContent().build()
-        } else {
-            ResponseEntity.status(401).build()
-        }
+class AdminController(
+    val userService: UserService,
+) : AdminApi {
+    // TODO: Need a paginated response - Update openApi as well
+    @PreAuthorize("hasRole('ADMIN')")
+    override suspend fun listUsers(): ResponseEntity<List<User>> = ResponseEntity.ok(userService.getUsers())
 }

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/controller/AuctionMarketController.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/controller/AuctionMarketController.kt
@@ -17,7 +17,7 @@ class AuctionMarketController(
     private val auctionMarketItemDetailService: AuctionMarketItemDetailService,
     private val craftingMarketSearchService: CraftingMarketSearchService,
 ) : AuctionMarketApi {
-    override fun filters(
+    override suspend fun filters(
         region: String,
         realmSlug: String,
         locale: String?,
@@ -30,7 +30,7 @@ class AuctionMarketController(
             ),
         )
 
-    override fun search(
+    override suspend fun search(
         region: String,
         realmSlug: String,
         locale: String?,
@@ -69,7 +69,7 @@ class AuctionMarketController(
             ),
         )
 
-    override fun getAuctionMarketItemDetail(
+    override suspend fun getAuctionMarketItemDetail(
         region: String,
         realmSlug: String,
         itemId: Int,
@@ -94,7 +94,7 @@ class AuctionMarketController(
             ),
         )
 
-    override fun getAuctionMarketItemCraftingAnalytics(
+    override suspend fun getAuctionMarketItemCraftingAnalytics(
         region: String,
         realmSlug: String,
         itemId: Int,

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/controller/CraftingController.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/controller/CraftingController.kt
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController
 class CraftingController(
     private val craftingMarketSearchService: CraftingMarketSearchService,
 ) : CraftingMarketApi {
-    override fun filters(
+    override suspend fun filters(
         region: String,
         realmSlug: String,
         locale: String?,
@@ -24,7 +24,7 @@ class CraftingController(
             ),
         )
 
-    override fun search(
+    override suspend fun search(
         region: String,
         realmSlug: String,
         locale: String?,

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/controller/HealthController.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/controller/HealthController.kt
@@ -12,7 +12,7 @@ class HealthController(
 ) : HealthApi {
     private val logger = LoggerFactory.getLogger(HealthController::class.java)
 
-    override fun health(): ResponseEntity<Unit> {
+    override suspend fun health(): ResponseEntity<Unit> {
         val snapshot = runtimeHealthTracker.snapshot()
         return if (snapshot.healthy) {
             ResponseEntity.noContent().build()

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/controller/RealmController.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/controller/RealmController.kt
@@ -16,7 +16,7 @@ class RealmController(
 ) : RealmApi {
     private val logger = LoggerFactory.getLogger(RealmController::class.java)
 
-    override fun listRealms(): ResponseEntity<List<Realm>> {
+    override suspend fun listRealms(): ResponseEntity<List<Realm>> {
         val totalStart = System.nanoTime()
         val result = realmQueryService.listAllRealms()
         val totalDuration = (System.nanoTime() - totalStart).toDuration(DurationUnit.NANOSECONDS)
@@ -37,7 +37,7 @@ class RealmController(
             ).body(result.realms)
     }
 
-    override fun getRealm(
+    override suspend fun getRealm(
         region: String,
         slug: String,
     ): ResponseEntity<RealmDetail> {

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/mapper/admin/UserMapper.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/mapper/admin/UserMapper.kt
@@ -3,7 +3,6 @@ package net.jonasmf.auctionengine.mapper.admin
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.UserType
 import aws.smithy.kotlin.runtime.time.toJvmInstant
 import net.jonasmf.auctionengine.generated.model.User
-import net.jonasmf.auctionengine.generated.model.Users
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/mapper/admin/UserMapper.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/mapper/admin/UserMapper.kt
@@ -1,0 +1,35 @@
+package net.jonasmf.auctionengine.mapper.admin
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.UserType
+import aws.smithy.kotlin.runtime.time.toJvmInstant
+import net.jonasmf.auctionengine.generated.model.User
+import net.jonasmf.auctionengine.generated.model.Users
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+fun UserType.toUser(): User =
+    User(
+        sub = getAttributeByKey(UserAttributeName.Sub),
+        username = username,
+        email = getAttributeByKey(UserAttributeName.Email),
+        emailVerified =
+            getAttributeByKey(UserAttributeName.EmailVerified)?.equals("true"),
+        status = userStatus?.value,
+        created = OffsetDateTime.ofInstant(userCreateDate?.toJvmInstant(), ZoneOffset.UTC),
+        lastModified = OffsetDateTime.ofInstant(userLastModifiedDate?.toJvmInstant(), ZoneOffset.UTC),
+    )
+
+// It is here, as it's the only context I imagine that I will use it
+enum class UserAttributeName(
+    val attributeName: String,
+) {
+    Email("email"),
+    EmailVerified("email_verified"),
+    Sub("sub"),
+}
+
+fun UserType.getAttributeByKey(key: UserAttributeName): String? =
+    attributes
+        ?.find {
+            it.name == key.attributeName
+        }?.value

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/service/admin/UserService.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/service/admin/UserService.kt
@@ -2,9 +2,7 @@ package net.jonasmf.auctionengine.service.admin
 
 import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.ListUsersRequest
-import aws.smithy.kotlin.runtime.collections.push
 import net.jonasmf.auctionengine.generated.model.User
-import net.jonasmf.auctionengine.generated.model.Users
 import net.jonasmf.auctionengine.mapper.admin.toUser
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/service/admin/UserService.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/service/admin/UserService.kt
@@ -2,26 +2,47 @@ package net.jonasmf.auctionengine.service.admin
 
 import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.ListUsersRequest
+import aws.smithy.kotlin.runtime.collections.push
+import net.jonasmf.auctionengine.generated.model.User
 import net.jonasmf.auctionengine.generated.model.Users
+import net.jonasmf.auctionengine.mapper.admin.toUser
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
 @Component
 class UserService(
-    @Value("\${aws.cognito.identity-provider.url}")
-    private val cognitoPoolId: String,
+    // @Value("\${spring.cloud.aws.cognito.pool_id}")
+    // We can derive the pool ID from here
+    @Value("\${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
+    private val issuerUri: String,
+    private val cognitoRegion: String = "eu-north-1",
 ) {
-    suspend fun getUsers(): List<Users> {
+    private val logger = LoggerFactory.getLogger(UserService::class.java)
+
+    fun getCognitoPoolId(): String? {
+        if (issuerUri == null) return null
+        val parts = issuerUri.split("amazonaws.com/")
+        val poolId = parts[parts.size - 1] // The last part is the pool id
+        return poolId ?: null
+    }
+
+    suspend fun getUsers(): List<User> {
+        val poolId = getCognitoPoolId()
         val request =
             ListUsersRequest {
-                this.userPoolId = userPoolId
+                this.userPoolId = poolId
             }
-        CognitoIdentityProviderClient.fromEnvironment { region = "us-east-1" }.use { cognitoClient ->
+        var users: List<User> = mutableListOf<User>()
+
+        logger.info("Fetching users for pool $poolId...")
+        CognitoIdentityProviderClient.fromEnvironment { region = cognitoRegion }.use { cognitoClient ->
             val response = cognitoClient.listUsers(request)
-            response.users?.forEach { user ->
-                println("The user name is ${user.username}")
-            }
+            users =
+                response.users?.map {
+                    it.toUser()
+                }!!
         }
-        return emptyList<Users>()
+        return users
     }
 }

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/service/admin/UserService.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/service/admin/UserService.kt
@@ -1,0 +1,27 @@
+package net.jonasmf.auctionengine.service.admin
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.CognitoIdentityProviderClient
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.ListUsersRequest
+import net.jonasmf.auctionengine.generated.model.Users
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class UserService(
+    @Value("\${aws.cognito.identity-provider.url}")
+    private val cognitoPoolId: String,
+) {
+    suspend fun getUsers(): List<Users> {
+        val request =
+            ListUsersRequest {
+                this.userPoolId = userPoolId
+            }
+        CognitoIdentityProviderClient.fromEnvironment { region = "us-east-1" }.use { cognitoClient ->
+            val response = cognitoClient.listUsers(request)
+            response.users?.forEach { user ->
+                println("The user name is ${user.username}")
+            }
+        }
+        return emptyList<Users>()
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -8,6 +8,8 @@ spring:
       credentials:
         access-key: ${AWS_ACCESS_KEY:local-dev-key}
         secret-key: ${AWS_SECRET_KEY:local-dev-secret}
+      cognito:
+        pool_id: ${WAE_COGNITO_USER_POOL_ID}
       dynamodb:
         endpoint: "http://localhost:4566"
       s3:

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/config/SecurityConfigTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/config/SecurityConfigTest.kt
@@ -4,6 +4,7 @@ import net.jonasmf.auctionengine.controller.AdminController
 import net.jonasmf.auctionengine.controller.HealthController
 import net.jonasmf.auctionengine.service.RuntimeHealthSnapshot
 import net.jonasmf.auctionengine.service.RuntimeHealthTracker
+import net.jonasmf.auctionengine.service.admin.UserService
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mockito.`when`
@@ -19,6 +20,8 @@ import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @WebMvcTest(
     controllers = [
@@ -44,18 +47,26 @@ class SecurityConfigTest {
     private lateinit var runtimeHealthTracker: RuntimeHealthTracker
 
     @MockitoBean
+    private lateinit var userService: UserService
+
+    @MockitoBean
     private lateinit var jwtDecoder: JwtDecoder
 
     @Test
     fun `health remains public`() {
         `when`(runtimeHealthTracker.snapshot(anyLong())).thenReturn(RuntimeHealthSnapshot(healthy = true))
 
-        mockMvc.get("/health")
-            .andExpect {
-                status { isNoContent() }
-            }
+        val result =
+            mockMvc
+                .get("/health")
+                .andReturn()
+
+        mockMvc
+            .perform(asyncDispatch(result))
+            .andExpect(status().isNoContent)
     }
 
+    /*
     @Test
     fun `admin session check rejects anonymous requests`() {
         mockMvc.get("/admin/session-check")
@@ -72,5 +83,5 @@ class SecurityConfigTest {
             }.andExpect {
                 status { isNoContent() }
             }
-    }
+    }*/
 }

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/controller/AdminControllerTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/controller/AdminControllerTest.kt
@@ -1,44 +1,56 @@
 package net.jonasmf.auctionengine.controller
 
-import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import net.jonasmf.auctionengine.generated.model.User
 import net.jonasmf.auctionengine.service.admin.UserService
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
-import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.core.convert.converter.Converter
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.MvcResult
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.request
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.request
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @SpringBootTest
 @AutoConfigureMockMvc
 class AdminControllerTest {
-    private val userService: UserService = mockk<UserService>()
-    private val controller = AdminController(userService)
+    @MockitoBean
+    private lateinit var userService: UserService
+
+    @Autowired
+    private lateinit var cognitoGroupsGrantedAuthoritiesConverter: Converter<Jwt, Collection<GrantedAuthority>>
 
     @Nested
     inner class ListUsers {
         @Autowired
         private lateinit var mockMvc: MockMvc
 
-        private fun performAsync(result: MvcResult) = mockMvc.perform(asyncDispatch(result))
-
         @Test
-        fun `should return a list of users is admin`() {
+        fun `should return list of users if Cognito Admin group`() {
+            runBlocking {
+                `when`(userService.getUsers()).thenReturn(emptyList<User>())
+            }
+
             val result =
                 mockMvc
                     .perform(
                         get("/api/admin/users")
                             .contextPath("/api")
-                            .with(jwt().authorities(SimpleGrantedAuthority("ADMIN"))),
+                            .with(
+                                jwt()
+                                    .jwt { token ->
+                                        token.claim("cognito:groups", listOf("Admin"))
+                                    }.authorities(cognitoGroupsGrantedAuthoritiesConverter),
+                            ),
                     ).andExpect(request().asyncStarted())
                     .andReturn()
 
@@ -48,7 +60,14 @@ class AdminControllerTest {
         }
 
         @Test
-        fun `should return 401 if not admin`() {
+        fun `should return 401 if unauthenticated`() {
+            mockMvc
+                .perform(get("/api/admin/users").contextPath("/api"))
+                .andExpect(status().isUnauthorized)
+        }
+
+        @Test
+        fun `should return 403 if authenticated but not admin`() {
             val result =
                 mockMvc
                     .perform(
@@ -60,7 +79,7 @@ class AdminControllerTest {
 
             mockMvc
                 .perform(asyncDispatch(result))
-                .andExpect(status().isUnauthorized)
+                .andExpect(status().isForbidden)
         }
     }
 }

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/controller/AdminControllerTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/controller/AdminControllerTest.kt
@@ -1,18 +1,24 @@
 package net.jonasmf.auctionengine.controller
 
 import kotlinx.coroutines.runBlocking
+import net.jonasmf.auctionengine.config.SecurityConfig
 import net.jonasmf.auctionengine.generated.model.User
 import net.jonasmf.auctionengine.service.admin.UserService
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration
+import org.springframework.boot.security.autoconfigure.web.servlet.SecurityFilterAutoConfiguration
+import org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
 import org.springframework.core.convert.converter.Converter
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
+import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch
@@ -20,11 +26,23 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.request
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@SpringBootTest
-@AutoConfigureMockMvc
+@WebMvcTest(AdminController::class)
+@ImportAutoConfiguration(
+    ServletWebSecurityAutoConfiguration::class,
+    SecurityFilterAutoConfiguration::class,
+)
+@Import(SecurityConfig::class)
+@TestPropertySource(
+    properties = [
+        "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://issuer.example.test",
+    ],
+)
 class AdminControllerTest {
     @MockitoBean
     private lateinit var userService: UserService
+
+    @MockitoBean
+    private lateinit var jwtDecoder: JwtDecoder
 
     @Autowired
     private lateinit var cognitoGroupsGrantedAuthoritiesConverter: Converter<Jwt, Collection<GrantedAuthority>>

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/controller/AdminControllerTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/controller/AdminControllerTest.kt
@@ -1,0 +1,66 @@
+package net.jonasmf.auctionengine.controller
+
+import io.mockk.mockk
+import net.jonasmf.auctionengine.service.admin.UserService
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.MvcResult
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.request
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.request
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AdminControllerTest {
+    private val userService: UserService = mockk<UserService>()
+    private val controller = AdminController(userService)
+
+    @Nested
+    inner class ListUsers {
+        @Autowired
+        private lateinit var mockMvc: MockMvc
+
+        private fun performAsync(result: MvcResult) = mockMvc.perform(asyncDispatch(result))
+
+        @Test
+        fun `should return a list of users is admin`() {
+            val result =
+                mockMvc
+                    .perform(
+                        get("/api/admin/users")
+                            .contextPath("/api")
+                            .with(jwt().authorities(SimpleGrantedAuthority("ADMIN"))),
+                    ).andExpect(request().asyncStarted())
+                    .andReturn()
+
+            mockMvc
+                .perform(asyncDispatch(result))
+                .andExpect(status().isOk)
+        }
+
+        @Test
+        fun `should return 401 if not admin`() {
+            val result =
+                mockMvc
+                    .perform(
+                        get("/api/admin/users")
+                            .contextPath("/api")
+                            .with(jwt()),
+                    ).andExpect(request().asyncStarted())
+                    .andReturn()
+
+            mockMvc
+                .perform(asyncDispatch(result))
+                .andExpect(status().isUnauthorized)
+        }
+    }
+}

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/controller/AuctionMarketSearchRequestCorrelationIntegrationTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/controller/AuctionMarketSearchRequestCorrelationIntegrationTest.kt
@@ -8,6 +8,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.MvcResult
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
@@ -21,20 +23,24 @@ class AuctionMarketSearchRequestCorrelationIntegrationTest : IntegrationTestBase
     @Autowired
     private lateinit var jdbcTemplate: JdbcTemplate
 
+    private fun performAsync(result: MvcResult) = mockMvc.perform(asyncDispatch(result))
+
     @Test
     fun `market search echoes x-request-id for log correlation`() {
         MarketSearchTestFixtures.seedMarketSearchData(jdbcTemplate)
 
-        mockMvc
-            .perform(
-                get("/api/auctions/search")
-                    .contextPath("/api")
-                    .param("region", "eu")
-                    .param("realmSlug", "argent-dawn")
-                    .param("page", "0")
-                    .param("pageSize", "10")
-                    .header("X-Request-Id", "corr-integration-test-1"),
-            ).andExpect(status().isOk)
+        performAsync(
+            mockMvc
+                .perform(
+                    get("/api/auctions/search")
+                        .contextPath("/api")
+                        .param("region", "eu")
+                        .param("realmSlug", "argent-dawn")
+                        .param("page", "0")
+                        .param("pageSize", "10")
+                        .header("X-Request-Id", "corr-integration-test-1"),
+                ).andReturn(),
+        ).andExpect(status().isOk)
             .andExpect(header().string("X-Request-Id", "corr-integration-test-1"))
     }
 
@@ -42,14 +48,16 @@ class AuctionMarketSearchRequestCorrelationIntegrationTest : IntegrationTestBase
     fun `market search filters echoes x-request-id for log correlation`() {
         MarketSearchTestFixtures.seedMarketSearchData(jdbcTemplate)
 
-        mockMvc
-            .perform(
-                get("/api/auctions/search/filters")
-                    .contextPath("/api")
-                    .param("region", "eu")
-                    .param("realmSlug", "argent-dawn")
-                    .header("X-Request-Id", "corr-integration-test-2"),
-            ).andExpect(status().isOk)
+        performAsync(
+            mockMvc
+                .perform(
+                    get("/api/auctions/search/filters")
+                        .contextPath("/api")
+                        .param("region", "eu")
+                        .param("realmSlug", "argent-dawn")
+                        .header("X-Request-Id", "corr-integration-test-2"),
+                ).andReturn(),
+        ).andExpect(status().isOk)
             .andExpect(header().string("X-Request-Id", "corr-integration-test-2"))
     }
 
@@ -58,15 +66,17 @@ class AuctionMarketSearchRequestCorrelationIntegrationTest : IntegrationTestBase
         MarketSearchTestFixtures.seedMarketSearchData(jdbcTemplate)
         MarketSearchTestFixtures.seedCommodityOnlyItem(jdbcTemplate)
 
-        mockMvc
-            .perform(
-                get("/api/auctions/search")
-                    .contextPath("/api")
-                    .param("region", "eu")
-                    .param("realmSlug", "argent-dawn")
-                    .param("page", "0")
-                    .param("pageSize", "10"),
-            ).andExpect(status().isOk)
+        performAsync(
+            mockMvc
+                .perform(
+                    get("/api/auctions/search")
+                        .contextPath("/api")
+                        .param("region", "eu")
+                        .param("realmSlug", "argent-dawn")
+                        .param("page", "0")
+                        .param("pageSize", "10"),
+                ).andReturn(),
+        ).andExpect(status().isOk)
             .andExpect(jsonPath("$.items[?(@.item.id == 19020)].preferredScope").value(contains("commodity")))
             .andExpect(jsonPath("$.items[?(@.item.id == 19020)].isCommodity").value(contains(true)))
             .andExpect(jsonPath("$.items[?(@.item.id == 19020)].listingPrice").value(contains(555)))

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/controller/HealthControllerTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/controller/HealthControllerTest.kt
@@ -2,6 +2,7 @@ package net.jonasmf.auctionengine.controller
 
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
 import net.jonasmf.auctionengine.service.RuntimeHealthSnapshot
 import net.jonasmf.auctionengine.service.RuntimeHealthTracker
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -16,7 +17,7 @@ class HealthControllerTest {
     fun `health endpoint returns no content`() {
         every { runtimeHealthTracker.snapshot(any()) } returns RuntimeHealthSnapshot(healthy = true)
 
-        val response = controller.health()
+        val response = runBlocking { controller.health() }
 
         assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
     }
@@ -26,7 +27,7 @@ class HealthControllerTest {
         every { runtimeHealthTracker.snapshot(any()) } returns
             RuntimeHealthSnapshot(healthy = false, reason = "stalled")
 
-        val response = controller.health()
+        val response = runBlocking { controller.health() }
 
         assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.statusCode)
         assertEquals(null, response.headers.getFirst("X-Health-Reason"))

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/controller/RealmControllerTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/controller/RealmControllerTest.kt
@@ -2,6 +2,7 @@ package net.jonasmf.auctionengine.controller
 
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
 import net.jonasmf.auctionengine.generated.model.AuctionHouseStatus
 import net.jonasmf.auctionengine.generated.model.Realm
 import net.jonasmf.auctionengine.generated.model.RealmDetail
@@ -33,10 +34,10 @@ class RealmControllerTest {
                     ),
                 queryDuration = 3.milliseconds,
                 mapSortDuration = 2.milliseconds,
-            )
+        )
         every { realmQueryService.listAllRealms() } returns catalog
 
-        val response = controller.listRealms()
+        val response = runBlocking { controller.listRealms() }
 
         assertEquals(200, response.statusCode.value())
         assertEquals(listOf("Stormrage"), response.body?.map { it.name })
@@ -70,10 +71,10 @@ class RealmControllerTest {
                         lastModified = null,
                         nextUpdate = null,
                     ),
-            )
+        )
         every { realmQueryService.getRealmDetail("eu", "stormrage") } returns detail
 
-        val response = controller.getRealm("eu", "stormrage")
+        val response = runBlocking { controller.getRealm("eu", "stormrage") }
 
         assertEquals(200, response.statusCode.value())
         assertEquals("stormrage", response.body?.realm?.slug)

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/mapper/admin/ToUserTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/mapper/admin/ToUserTest.kt
@@ -5,7 +5,6 @@ import aws.sdk.kotlin.services.cognitoidentityprovider.model.UserStatusType
 import aws.sdk.kotlin.services.cognitoidentityprovider.model.UserType
 import aws.smithy.kotlin.runtime.time.Instant
 import net.jonasmf.auctionengine.generated.model.User
-import net.jonasmf.auctionengine.generated.model.Users
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.time.OffsetDateTime

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/mapper/admin/ToUserTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/mapper/admin/ToUserTest.kt
@@ -1,0 +1,55 @@
+package net.jonasmf.auctionengine.mapper.admin
+
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.AttributeType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.UserStatusType
+import aws.sdk.kotlin.services.cognitoidentityprovider.model.UserType
+import aws.smithy.kotlin.runtime.time.Instant
+import net.jonasmf.auctionengine.generated.model.User
+import net.jonasmf.auctionengine.generated.model.Users
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+class ToUserTest {
+    @Test
+    fun `maps UserType to Users`() {
+        val userType =
+            UserType {
+                attributes =
+                    listOf(
+                        AttributeType {
+                            name = "sub"
+                            value = "user-sub"
+                        },
+                        AttributeType {
+                            name = "email"
+                            value = "user@example.com"
+                        },
+                        AttributeType {
+                            name = "email_verified"
+                            value = "true"
+                        },
+                    )
+                username = "username"
+                userStatus = UserStatusType.Confirmed
+                userCreateDate = Instant.fromIso8601("2026-05-21T10:15:30Z")
+                userLastModifiedDate = Instant.fromIso8601("2026-05-22T12:30:45Z")
+            }
+
+        val user = userType.toUser()
+
+        assertEquals(
+            User(
+                sub = "user-sub",
+                username = "username",
+                email = "user@example.com",
+                emailVerified = true,
+                status = "CONFIRMED",
+                created = OffsetDateTime.of(2026, 5, 21, 10, 15, 30, 0, ZoneOffset.UTC),
+                lastModified = OffsetDateTime.of(2026, 5, 22, 12, 30, 45, 0, ZoneOffset.UTC),
+            ),
+            user,
+        )
+    }
+}

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/service/AuctionHouseServiceTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/service/AuctionHouseServiceTest.kt
@@ -359,19 +359,40 @@ class AuctionHouseServiceTest : IntegrationTestBase() {
 
         @Test
         fun `should update the next update time, and add a new log entry for successful updates`() {
-            val originalState = repository.findById(1)
-            val newLastModified = originalState?.lastModified?.plus(60.minutes)
-            auctionHouseService.updateTimes(1, newLastModified, true)
+            val connectedRealmId = 1004
+            repository.save(
+                AuctionHouse(
+                    id = connectedRealmId,
+                    connectedId = connectedRealmId,
+                    autoUpdate = true,
+                    region = Region.Europe,
+                    avgDelay = 60,
+                    nextUpdate = getOffsetFromNow(-10),
+                    lastModified = getOffsetFromNow(-300),
+                ),
+            )
 
-            val result = repository.findById(1)
+            var lastModified = requireNotNull(repository.findById(connectedRealmId)?.lastModified)
+            auctionHouseService.updateTimes(
+                connectedRealmId,
+                lastModified.plus(60.minutes),
+                true,
+            )
+            lastModified = requireNotNull(repository.findById(connectedRealmId)?.lastModified)
+
+            val newLastModified = lastModified.plus(60.minutes)
+            auctionHouseService.updateTimes(connectedRealmId, newLastModified, true)
+
+            val result = repository.findById(connectedRealmId)
             assertEquals(newLastModified, result?.lastModified)
             assertTrue(result?.lastModified!! < result.nextUpdate!!)
             assertEquals(60, result.lowestDelay)
             assertEquals(60, result.avgDelay)
             assertEquals(60, result.highestDelay)
+            assertEquals(60, result.nextUpdate!!.minus(result.lastModified!!).inWholeMinutes)
 
-            val logEntries = auctionHouseUpdateLogRepository.findByIdAndMostRecentLastModified(1)
-            assertEquals(2, logEntries.size)
+            val logEntries = auctionHouseUpdateLogRepository.findByIdAndMostRecentLastModified(connectedRealmId)
+            assertEquals(3, logEntries.size)
         }
 
         @Test

--- a/openapi/components/schemas/admin/user.yml
+++ b/openapi/components/schemas/admin/user.yml
@@ -8,7 +8,7 @@ properties:
     email:
         type: string
     email_verified:
-        type: string
+        type: boolean
     status: # UNCONFIRMED, CONFIRMED
         type: string
     created:

--- a/openapi/components/schemas/admin/users.yml
+++ b/openapi/components/schemas/admin/users.yml
@@ -1,0 +1,19 @@
+type: object
+properties:
+    sub:
+        type: string
+        description: This is the users GUID id.
+    username:
+        type: string
+    email:
+        type: string
+    email_verified:
+        type: string
+    status: # UNCONFIRMED, CONFIRMED
+        type: string
+    created:
+        type: string
+        format: date-time
+    lastModified:
+        type: string
+        format: date-time

--- a/openapi/components/schemas/auction-market-filter-response.yml
+++ b/openapi/components/schemas/auction-market-filter-response.yml
@@ -5,4 +5,4 @@ properties:
   filters:
     type: array
     items:
-      $ref: ./auction-market-filter.yml
+      $ref: "../../openapi.yml#/components/schemas/AuctionMarketFilter"

--- a/openapi/components/schemas/auction-market-filter.yml
+++ b/openapi/components/schemas/auction-market-filter.yml
@@ -14,7 +14,7 @@ properties:
   options:
     type: array
     items:
-      $ref: ./auction-market-filter-option.yml
+      $ref: "../../openapi.yml#/components/schemas/AuctionMarketFilterOption"
   min:
     type: integer
     format: int64

--- a/openapi/components/schemas/auction-market-item-crafting-analytics-response.yml
+++ b/openapi/components/schemas/auction-market-item-crafting-analytics-response.yml
@@ -6,8 +6,8 @@ properties:
     dailySeries:
         type: array
         items:
-            $ref: ./auction-market-item-crafting-analytics-point.yml
+            $ref: "../../openapi.yml#/components/schemas/AuctionMarketItemCraftingAnalyticsPoint"
     heatmap:
         type: array
         items:
-            $ref: ./auction-market-item-crafting-heatmap-cell.yml
+            $ref: "../../openapi.yml#/components/schemas/AuctionMarketItemCraftingHeatmapCell"

--- a/openapi/components/schemas/auction-market-item-crafting-detail.yml
+++ b/openapi/components/schemas/auction-market-item-crafting-detail.yml
@@ -20,7 +20,7 @@ properties:
     reagents:
         type: array
         items:
-            $ref: ./auction-market-item-crafting-reagent.yml
+            $ref: "../../openapi.yml#/components/schemas/AuctionMarketItemCraftingReagent"
     reagentCost:
         type: integer
         format: int64

--- a/openapi/components/schemas/auction-market-item-detail-response.yml
+++ b/openapi/components/schemas/auction-market-item-detail-response.yml
@@ -17,9 +17,9 @@ required:
     - craftings
 properties:
     item:
-        $ref: ./auction-market-item.yml
+        $ref: "../../openapi.yml#/components/schemas/AuctionMarketItem"
     listingKey:
-        $ref: ./auction-listing-key.yml
+        $ref: "../../openapi.yml#/components/schemas/AuctionListingKey"
         description: Effective listing key used for all queries (defaults applied when query omitted).
     rollupListing:
         type: boolean
@@ -29,42 +29,42 @@ properties:
     marketDataSources:
         type: array
         items:
-            $ref: ./market-data-source.yml
+            $ref: "../../openapi.yml#/components/schemas/MarketDataSource"
     selectedRealm:
-        $ref: ./auction-market-metrics.yml
+        $ref: "../../openapi.yml#/components/schemas/AuctionMarketMetrics"
     commodity:
-        $ref: ./auction-market-metrics.yml
+        $ref: "../../openapi.yml#/components/schemas/AuctionMarketMetrics"
     summary:
-        $ref: ./auction-market-item-detail-summary.yml
+        $ref: "../../openapi.yml#/components/schemas/AuctionMarketItemDetailSummary"
     dailySeriesRealm:
         type: array
         items:
-            $ref: ./auction-market-item-detail-point.yml
+            $ref: "../../openapi.yml#/components/schemas/AuctionMarketItemDetailPoint"
     dailySeriesCommodity:
         type: array
         items:
-            $ref: ./auction-market-item-detail-point.yml
+            $ref: "../../openapi.yml#/components/schemas/AuctionMarketItemDetailPoint"
     hourlySeriesRealm:
         type: array
         items:
-            $ref: ./auction-market-item-hourly-point.yml
+            $ref: "../../openapi.yml#/components/schemas/AuctionMarketItemHourlyPoint"
     hourlySeriesCommodity:
         type: array
         items:
-            $ref: ./auction-market-item-hourly-point.yml
+            $ref: "../../openapi.yml#/components/schemas/AuctionMarketItemHourlyPoint"
     quantityPieRealm:
         type: array
         items:
-            $ref: ./auction-market-quantity-pie-slice.yml
+            $ref: "../../openapi.yml#/components/schemas/AuctionMarketQuantityPieSlice"
     quantityPieCommodity:
         type: array
         items:
-            $ref: ./auction-market-quantity-pie-slice.yml
+            $ref: "../../openapi.yml#/components/schemas/AuctionMarketQuantityPieSlice"
     crafting:
-        $ref: ./auction-market-item-crafting.yml
+        $ref: "../../openapi.yml#/components/schemas/AuctionMarketItemCrafting"
         nullable: true
         deprecated: true
     craftings:
         type: array
         items:
-            $ref: ./auction-market-item-crafting-detail.yml
+            $ref: "../../openapi.yml#/components/schemas/AuctionMarketItemCraftingDetail"

--- a/openapi/components/schemas/auction-market-item.yml
+++ b/openapi/components/schemas/auction-market-item.yml
@@ -11,10 +11,10 @@ properties:
     type: string
     nullable: true
   quality:
-    $ref: ./auction-market-named-id.yml
+    $ref: "../../openapi.yml#/components/schemas/AuctionMarketNamedId"
   itemClass:
-    $ref: ./auction-market-named-id.yml
+    $ref: "../../openapi.yml#/components/schemas/AuctionMarketNamedId"
   itemSubclass:
-    $ref: ./auction-market-named-id.yml
+    $ref: "../../openapi.yml#/components/schemas/AuctionMarketNamedId"
   recipe:
-    $ref: ./auction-market-recipe.yml
+    $ref: "../../openapi.yml#/components/schemas/AuctionMarketRecipe"

--- a/openapi/components/schemas/auction-market-search-page.yml
+++ b/openapi/components/schemas/auction-market-search-page.yml
@@ -7,8 +7,8 @@ properties:
   items:
     type: array
     items:
-      $ref: ./auction-market-search-row.yml
+      $ref: "../../openapi.yml#/components/schemas/AuctionMarketSearchRow"
   page:
-    $ref: ./page-metadata.yml
+    $ref: "../../openapi.yml#/components/schemas/PageMetadata"
   sort:
-    $ref: ./auction-market-sort.yml
+    $ref: "../../openapi.yml#/components/schemas/AuctionMarketSort"

--- a/openapi/components/schemas/auction-market-search-row.yml
+++ b/openapi/components/schemas/auction-market-search-row.yml
@@ -4,7 +4,7 @@ required:
   - preferredScope
 properties:
   item:
-    $ref: ./auction-market-item.yml
+    $ref: "../../openapi.yml#/components/schemas/AuctionMarketItem"
   preferredScope:
     type: string
     description: Preferred detail scope for this row (`realm` or `commodity`).
@@ -20,9 +20,9 @@ properties:
     type: boolean
     description: True when the unified listing values come from commodity only (no realm snapshot row).
   listingKey:
-    $ref: ./auction-listing-key.yml
+    $ref: "../../openapi.yml#/components/schemas/AuctionListingKey"
     description: Bucket that supplied selectedRealm price (lowest unit price at snapshot hour).
   selectedRealm:
-    $ref: ./auction-market-metrics.yml
+    $ref: "../../openapi.yml#/components/schemas/AuctionMarketMetrics"
   commodity:
-    $ref: ./auction-market-metrics.yml
+    $ref: "../../openapi.yml#/components/schemas/AuctionMarketMetrics"

--- a/openapi/components/schemas/crafting-market-filter-response.yml
+++ b/openapi/components/schemas/crafting-market-filter-response.yml
@@ -5,4 +5,4 @@ properties:
   filters:
     type: array
     items:
-      $ref: ./auction-market-filter.yml
+      $ref: "../../openapi.yml#/components/schemas/AuctionMarketFilter"

--- a/openapi/components/schemas/crafting-market-search-page.yml
+++ b/openapi/components/schemas/crafting-market-search-page.yml
@@ -7,8 +7,8 @@ properties:
   items:
     type: array
     items:
-      $ref: ./crafting-market-search-row.yml
+      $ref: "../../openapi.yml#/components/schemas/CraftingMarketSearchRow"
   page:
-    $ref: ./page-metadata.yml
+    $ref: "../../openapi.yml#/components/schemas/PageMetadata"
   sort:
-    $ref: ./auction-market-sort.yml
+    $ref: "../../openapi.yml#/components/schemas/AuctionMarketSort"

--- a/openapi/components/schemas/crafting-market-search-row.yml
+++ b/openapi/components/schemas/crafting-market-search-row.yml
@@ -14,11 +14,11 @@ properties:
     type: integer
     format: int32
   recipe:
-    $ref: ./auction-market-recipe.yml
+    $ref: "../../openapi.yml#/components/schemas/AuctionMarketRecipe"
   item:
-    $ref: ./auction-market-item.yml
+    $ref: "../../openapi.yml#/components/schemas/AuctionMarketItem"
   listingKey:
-    $ref: ./auction-listing-key.yml
+    $ref: "../../openapi.yml#/components/schemas/AuctionListingKey"
   professionId:
     type: integer
     format: int32

--- a/openapi/components/schemas/realm-detail.yml
+++ b/openapi/components/schemas/realm-detail.yml
@@ -2,8 +2,8 @@ type: object
 required: [realm, auctionHouse, commodity]
 properties:
   realm:
-    $ref: ./realm.yml
+    $ref: "../../openapi.yml#/components/schemas/Realm"
   auctionHouse:
-    $ref: ./auction-house-status.yml
+    $ref: "../../openapi.yml#/components/schemas/AuctionHouseStatus"
   commodity:
-    $ref: ./auction-house-status.yml
+    $ref: "../../openapi.yml#/components/schemas/AuctionHouseStatus"

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -40,3 +40,67 @@ paths:
     $ref: ./paths/crafting.yml#/search
   /crafting/filters:
     $ref: ./paths/crafting.yml#/filters
+components:
+  schemas:
+    AdminUser:
+      $ref: ./components/schemas/admin/users.yml
+    AuctionHouseStatus:
+      $ref: ./components/schemas/auction-house-status.yml
+    AuctionListingKey:
+      $ref: ./components/schemas/auction-listing-key.yml
+    AuctionMarketFilter:
+      $ref: ./components/schemas/auction-market-filter.yml
+    AuctionMarketFilterOption:
+      $ref: ./components/schemas/auction-market-filter-option.yml
+    AuctionMarketFilterResponse:
+      $ref: ./components/schemas/auction-market-filter-response.yml
+    AuctionMarketItem:
+      $ref: ./components/schemas/auction-market-item.yml
+    AuctionMarketItemCrafting:
+      $ref: ./components/schemas/auction-market-item-crafting.yml
+    AuctionMarketItemCraftingAnalyticsPoint:
+      $ref: ./components/schemas/auction-market-item-crafting-analytics-point.yml
+    AuctionMarketItemCraftingAnalyticsResponse:
+      $ref: ./components/schemas/auction-market-item-crafting-analytics-response.yml
+    AuctionMarketItemCraftingDetail:
+      $ref: ./components/schemas/auction-market-item-crafting-detail.yml
+    AuctionMarketItemCraftingHeatmapCell:
+      $ref: ./components/schemas/auction-market-item-crafting-heatmap-cell.yml
+    AuctionMarketItemCraftingReagent:
+      $ref: ./components/schemas/auction-market-item-crafting-reagent.yml
+    AuctionMarketItemDetailPoint:
+      $ref: ./components/schemas/auction-market-item-detail-point.yml
+    AuctionMarketItemDetailResponse:
+      $ref: ./components/schemas/auction-market-item-detail-response.yml
+    AuctionMarketItemDetailSummary:
+      $ref: ./components/schemas/auction-market-item-detail-summary.yml
+    AuctionMarketItemHourlyPoint:
+      $ref: ./components/schemas/auction-market-item-hourly-point.yml
+    AuctionMarketMetrics:
+      $ref: ./components/schemas/auction-market-metrics.yml
+    AuctionMarketNamedId:
+      $ref: ./components/schemas/auction-market-named-id.yml
+    AuctionMarketQuantityPieSlice:
+      $ref: ./components/schemas/auction-market-quantity-pie-slice.yml
+    AuctionMarketRecipe:
+      $ref: ./components/schemas/auction-market-recipe.yml
+    AuctionMarketSearchPage:
+      $ref: ./components/schemas/auction-market-search-page.yml
+    AuctionMarketSearchRow:
+      $ref: ./components/schemas/auction-market-search-row.yml
+    AuctionMarketSort:
+      $ref: ./components/schemas/auction-market-sort.yml
+    CraftingMarketFilterResponse:
+      $ref: ./components/schemas/crafting-market-filter-response.yml
+    CraftingMarketSearchPage:
+      $ref: ./components/schemas/crafting-market-search-page.yml
+    CraftingMarketSearchRow:
+      $ref: ./components/schemas/crafting-market-search-row.yml
+    MarketDataSource:
+      $ref: ./components/schemas/market-data-source.yml
+    PageMetadata:
+      $ref: ./components/schemas/page-metadata.yml
+    Realm:
+      $ref: ./components/schemas/realm.yml
+    RealmDetail:
+      $ref: ./components/schemas/realm-detail.yml

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -42,8 +42,8 @@ paths:
     $ref: ./paths/crafting.yml#/filters
 components:
   schemas:
-    AdminUser:
-      $ref: ./components/schemas/admin/users.yml
+    User:
+      $ref: ./components/schemas/admin/user.yml
     AuctionHouseStatus:
       $ref: ./components/schemas/auction-house-status.yml
     AuctionListingKey:

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -11,6 +11,8 @@ servers:
 tags:
   - name: Health
     description: Runtime health endpoints.
+  - name: Admin
+    description: Endpoints for administrating users and data.
   - name: Realm
     description: Realm catalog and per-realm auction house status.
   - name: AuctionMarket
@@ -20,6 +22,8 @@ tags:
 paths:
   /health:
     $ref: ./paths/health.yml#/health
+  /admin/users:
+    $ref: ./paths/admin.yml#/getUsers
   /realms:
     $ref: ./paths/realm.yml#/listRealms
   /realms/{region}/{slug}:

--- a/openapi/paths/admin.yml
+++ b/openapi/paths/admin.yml
@@ -1,0 +1,17 @@
+getUsers:
+    get:
+        tags:
+            - Admin
+            - Users
+        operationId: listUsers
+        summary: Lists all registered users and their current status
+        description: Allows an administrator to review the current users
+        responses:
+            "200":
+                description: A list of users
+                content:
+                    application/json:
+                        schema:
+                            type: array
+                            items:
+                                $ref: "../openapi.yml#/components/schemas/AdminUser"

--- a/openapi/paths/admin.yml
+++ b/openapi/paths/admin.yml
@@ -2,7 +2,6 @@ getUsers:
     get:
         tags:
             - Admin
-            - Users
         operationId: listUsers
         summary: Lists all registered users and their current status
         description: Allows an administrator to review the current users
@@ -14,4 +13,4 @@ getUsers:
                         schema:
                             type: array
                             items:
-                                $ref: "../openapi.yml#/components/schemas/AdminUser"
+                                $ref: "../openapi.yml#/components/schemas/User"

--- a/openapi/paths/auction.yml
+++ b/openapi/paths/auction.yml
@@ -131,7 +131,7 @@ search:
         content:
           application/json:
             schema:
-              $ref: ../components/schemas/auction-market-search-page.yml
+              $ref: "../openapi.yml#/components/schemas/AuctionMarketSearchPage"
       "400":
         description: Invalid search request.
       "404":
@@ -168,7 +168,7 @@ filters:
         content:
           application/json:
             schema:
-              $ref: ../components/schemas/auction-market-filter-response.yml
+              $ref: "../openapi.yml#/components/schemas/AuctionMarketFilterResponse"
       "400":
         description: Invalid filter request.
       "404":
@@ -245,7 +245,7 @@ getAuctionItemDetail:
         content:
           application/json:
             schema:
-              $ref: ../components/schemas/auction-market-item-detail-response.yml
+              $ref: "../openapi.yml#/components/schemas/AuctionMarketItemDetailResponse"
       "400":
         description: Invalid request.
       "404":
@@ -311,7 +311,7 @@ getAuctionItemCraftingAnalytics:
         content:
           application/json:
             schema:
-              $ref: ../components/schemas/auction-market-item-crafting-analytics-response.yml
+              $ref: "../openapi.yml#/components/schemas/AuctionMarketItemCraftingAnalyticsResponse"
       "400":
         description: Invalid request.
       "404":

--- a/openapi/paths/crafting.yml
+++ b/openapi/paths/crafting.yml
@@ -148,7 +148,7 @@ search:
         content:
           application/json:
             schema:
-              $ref: ../components/schemas/crafting-market-search-page.yml
+              $ref: "../openapi.yml#/components/schemas/CraftingMarketSearchPage"
       "400":
         description: Invalid search request.
       "404":
@@ -184,7 +184,7 @@ filters:
         content:
           application/json:
             schema:
-              $ref: ../components/schemas/auction-market-filter-response.yml
+              $ref: "../openapi.yml#/components/schemas/AuctionMarketFilterResponse"
       "400":
         description: Invalid filter request.
       "404":

--- a/openapi/paths/realm.yml
+++ b/openapi/paths/realm.yml
@@ -13,7 +13,7 @@ listRealms:
             schema:
               type: array
               items:
-                $ref: ../components/schemas/realm.yml
+                $ref: "../openapi.yml#/components/schemas/Realm"
 
 getRealm:
   get:
@@ -39,6 +39,6 @@ getRealm:
         content:
           application/json:
             schema:
-              $ref: ../components/schemas/realm-detail.yml
+              $ref: "../openapi.yml#/components/schemas/RealmDetail"
       "404":
         description: No realm exists for the given region and slug, or the regional commodity placeholder has not been seeded yet.


### PR DESCRIPTION
## Summary
Implements initial user administration features by integrating with AWS Cognito and transitions all API endpoints to reactive suspend functions.

## Type of change
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [x] 🧹 Code refactor
- [x] 🧪 Tests
- [x] 📚 Documentation
- [x] 🔧 Build/CI
- [ ] 🔄 Other (describe below)

## What has been done?
- Introduces a new `/admin/users` endpoint to list users directly from AWS Cognito.
- Integrates the AWS SDK for Kotlin (`cognitoidentityprovider-jvm`) to facilitate interaction with Cognito.
- Configures Spring Security to map "cognito:groups" claims from JWTs to Spring Security authorities, enabling role-based access control for admin endpoints using `@EnableMethodSecurity` and `@PreAuthorize`.
- Converts all existing API controller methods to `suspend` functions, fully embracing reactive programming with Kotlin Coroutines.
- Updates the OpenAPI specification to reflect the new admin API, define the `User` schema, generate reactive client code, and standardize `$ref` paths.
- Adds `kotlinx-coroutines-reactor` for reactive programming support.
- Creates dedicated mapper and service classes (`UserMapper`, `UserService`) for handling Cognito user data.
- Updates existing tests and adds new tests for the admin features and reactive endpoint handling.

## Motivation / Context
This change enables the foundational backend for administrative user management, leveraging AWS Cognito as the identity provider. It also completes the migration of all API endpoints to a reactive, coroutine-based architecture for enhanced performance and scalability, aligning with modern Kotlin backend development practices.

## Screenshots (if applicable)
N/A

## Checklist
- [x] I’ve tested this manually
- [x] I’ve added tests if applicable
- [x] I’ve updated docs if needed
- [x] I’ve followed the coding conventions

## Related Issues
Closes #[issue_number], Fixes #[issue_number]