### PR TITLE
Add current prices to market item details + bugfix for auction quantity

### DIFF
--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketItemDetailRepository.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketItemDetailRepository.kt
@@ -1,98 +1,9 @@
 package net.jonasmf.auctionengine.repository.rds
 
 import org.springframework.jdbc.core.JdbcTemplate
-import org.springframework.jdbc.core.RowMapper
 import org.springframework.stereotype.Repository
 import java.sql.Date
-import java.sql.ResultSet
 import java.time.LocalDate
-import java.time.OffsetDateTime
-import java.time.ZoneOffset
-
-data class AuctionMarketItemDetailDailyRow(
-    val statDate: LocalDate,
-    val pointTimestamp: OffsetDateTime,
-    val minPrice: Long?,
-    val avgPrice: Double?,
-    val p25Price: Long?,
-    val p75Price: Long?,
-    val maxPrice: Long?,
-    val minQuantity: Long?,
-    val avgQuantity: Double?,
-    val maxQuantity: Long?,
-)
-
-data class AuctionMarketItemDetailHourlyRow(
-    val timestamp: OffsetDateTime,
-    val hourOfDay: Int,
-    val minPrice: Long?,
-    val avgPrice: Double?,
-    val p25Price: Long?,
-    val p75Price: Long?,
-    val maxPrice: Long?,
-    val totalQuantity: Long?,
-)
-
-data class AuctionMarketItemDetailPieRow(
-    val hourOfDay: Int,
-    val quantity: Long?,
-    val fraction: Double,
-)
-
-data class AuctionMarketItemHeaderRow(
-    val itemId: Int,
-    val itemName: String,
-    val itemMediaUrl: String?,
-    val qualityId: Int?,
-    val qualityType: String?,
-    val qualityName: String?,
-    val itemClassId: Int?,
-    val itemClassName: String?,
-    val itemSubclassId: Int?,
-    val itemSubclassName: String?,
-    val recipeId: Int?,
-    val recipeName: String?,
-    val recipeMediaUrl: String?,
-)
-
-data class AuctionMarketItemCraftingRow(
-    val recipeId: Int,
-    val recipeName: String,
-    val recipeMediaUrl: String?,
-    val craftedQuantity: Int,
-    val reagentCost: Long?,
-    val reagentsFullyPriced: Boolean,
-    val outputUnitPrice: Long?,
-    val profit: Long?,
-    val roiPercent: Double?,
-)
-
-data class AuctionMarketItemCraftingReagentRow(
-    val recipeId: Int,
-    val itemId: Int,
-    val name: String,
-    val mediaUrl: String?,
-    val quantity: Int,
-    val unitPrice: Long?,
-    val lineTotal: Long?,
-)
-
-data class AuctionMarketItemCraftingAnalyticsDailyRow(
-    val statDate: LocalDate,
-    val profit: Long?,
-    val roiPercent: Double?,
-    val reagentCost: Long?,
-    val outputUnitPrice: Long?,
-)
-
-data class AuctionMarketItemCraftingHeatmapRow(
-    val dayOfWeek: Int,
-    val hourOfDay: Int,
-    val profit: Double?,
-    val outputUnitPrice: Double?,
-    val roiPercent: Double?,
-    val sampleCount: Int,
-)
 
 @Repository
 class AuctionMarketItemDetailRepository(
@@ -122,7 +33,7 @@ class AuctionMarketItemDetailRepository(
             WHERE d.item_id = ?
             LIMIT 1
             """.trimIndent(),
-            headerRowMapper,
+            AuctionMarketItemDetailRowMappers.headerRowMapper,
             itemId,
         ).firstOrNull()
 
@@ -172,14 +83,29 @@ class AuctionMarketItemDetailRepository(
                 )
             }
         return jdbcTemplate
-            .query(sql, snapshotRowMapper, *params)
+            .query(sql, AuctionMarketItemDetailRowMappers.snapshotRowMapper, *params)
             .firstOrNull() ?: (null to null)
     }
 
-    private val snapshotRowMapper =
-        RowMapper { rs: ResultSet, _: Int ->
-            rs.getNullableLong("price") to rs.getNullableLong("qty")
-        }
+    fun loadCurrentListings(
+        connectedRealmId: Int,
+        itemId: Int,
+        variant: Boolean,
+        bonusKey: String,
+        modifierKey: String,
+        petSpeciesId: Int,
+    ): List<AuctionMarketItemCurrentListingRow> {
+        val (sql, params) =
+            buildCurrentListingsSqlAndArgs(
+                connectedRealmId,
+                itemId,
+                variant,
+                bonusKey,
+                modifierKey,
+                petSpeciesId,
+            )
+        return jdbcTemplate.query(sql, AuctionMarketItemDetailRowMappers.currentListingRowMapper, *params)
+    }
 
     fun loadDailySeries(
         connectedRealmId: Int,
@@ -202,7 +128,7 @@ class AuctionMarketItemDetailRepository(
                 modifierKey,
                 petSpeciesId,
             )
-        return jdbcTemplate.query(sql, dailyRowMapper, *params)
+        return jdbcTemplate.query(sql, AuctionMarketItemDetailRowMappers.dailyRowMapper, *params)
     }
 
     fun loadHourlySeries(
@@ -226,7 +152,7 @@ class AuctionMarketItemDetailRepository(
                 modifierKey,
                 petSpeciesId,
             )
-        return jdbcTemplate.query(sql, hourlyRowMapper, *params)
+        return jdbcTemplate.query(sql, AuctionMarketItemDetailRowMappers.hourlyRowMapper, *params)
     }
 
     fun loadQuantityPie(
@@ -248,7 +174,7 @@ class AuctionMarketItemDetailRepository(
                 modifierKey,
                 petSpeciesId,
             )
-        return jdbcTemplate.query(sql, pieRowMapper, *params)
+        return jdbcTemplate.query(sql, AuctionMarketItemDetailRowMappers.pieRowMapper, *params)
     }
 
     fun loadCraftings(
@@ -282,7 +208,7 @@ class AuctionMarketItemDetailRepository(
                 preferredRecipeId,
                 localeColumnSuffix,
             )
-        return jdbcTemplate.query(sql, craftingRowMapper, *params)
+        return jdbcTemplate.query(sql, AuctionMarketItemDetailRowMappers.craftingRowMapper, *params)
     }
 
     fun loadCraftingReagents(
@@ -365,111 +291,25 @@ class AuctionMarketItemDetailRepository(
                 *recipeIds.toTypedArray(),
                 *recipeIds.toTypedArray(),
             )
-        return jdbcTemplate.query(sql, craftingReagentRowMapper, *params)
+        return jdbcTemplate.query(sql, AuctionMarketItemDetailRowMappers.craftingReagentRowMapper, *params)
     }
 
-    private val headerRowMapper =
-        RowMapper { rs: ResultSet, _: Int ->
-            AuctionMarketItemHeaderRow(
-                itemId = rs.getInt("item_id"),
-                itemName = rs.getString("item_name"),
-                itemMediaUrl = rs.getString("item_media_url"),
-                qualityId = rs.getNullableInt("quality_id"),
-                qualityType = rs.getString("quality_type"),
-                qualityName = rs.getString("quality_name"),
-                itemClassId = rs.getNullableInt("item_class_id"),
-                itemClassName = rs.getString("item_class_name"),
-                itemSubclassId = rs.getNullableInt("item_subclass_id"),
-                itemSubclassName = rs.getString("item_subclass_name"),
-                recipeId = rs.getNullableInt("recipe_id"),
-                recipeName = rs.getString("recipe_name"),
-                recipeMediaUrl = rs.getString("recipe_media_url"),
-            )
-        }
-
-    private val dailyRowMapper =
-        RowMapper { rs: ResultSet, _: Int ->
-            val d = rs.getObject("stat_date", LocalDate::class.java)
-            AuctionMarketItemDetailDailyRow(
-                statDate = d,
-                pointTimestamp = d.atStartOfDay(ZoneOffset.UTC).toOffsetDateTime(),
-                minPrice = rs.getNullableLong("min_price"),
-                avgPrice = rs.getNullableDouble("avg_price"),
-                p25Price = rs.getNullableLong("p25_price"),
-                p75Price = rs.getNullableLong("p75_price"),
-                maxPrice = rs.getNullableLong("max_price"),
-                minQuantity = rs.getNullableLong("min_quantity"),
-                avgQuantity = rs.getNullableDouble("avg_quantity"),
-                maxQuantity = rs.getNullableLong("max_quantity"),
-            )
-        }
-
-    private val hourlyRowMapper =
-        RowMapper { rs: ResultSet, _: Int ->
-            val ts = rs.getTimestamp("timestamp").toInstant().atOffset(ZoneOffset.UTC)
-            AuctionMarketItemDetailHourlyRow(
-                timestamp = ts,
-                hourOfDay = rs.getInt("hour_of_day"),
-                minPrice = rs.getNullableLong("min_price"),
-                avgPrice = rs.getNullableDouble("avg_price"),
-                p25Price = rs.getNullableLong("p25_price"),
-                p75Price = rs.getNullableLong("p75_price"),
-                maxPrice = rs.getNullableLong("max_price"),
-                totalQuantity = rs.getNullableLong("total_quantity"),
-            )
-        }
-
-    private val pieRowMapper =
-        RowMapper { rs: ResultSet, _: Int ->
-            AuctionMarketItemDetailPieRow(
-                hourOfDay = rs.getInt("hour_of_day"),
-                quantity = rs.getNullableLong("quantity"),
-                fraction = rs.getDouble("fraction"),
-            )
-        }
-
-    private val craftingRowMapper =
-        RowMapper { rs: ResultSet, _: Int ->
-            AuctionMarketItemCraftingRow(
-                recipeId = rs.getInt("recipe_id"),
-                recipeName = rs.getString("recipe_name") ?: "",
-                recipeMediaUrl = rs.getString("recipe_media_url"),
-                craftedQuantity = rs.getInt("crafted_quantity"),
-                reagentCost = rs.getNullableLong("reagent_cost"),
-                reagentsFullyPriced = rs.getBoolean("reagents_fully_priced"),
-                outputUnitPrice = rs.getNullableLong("output_unit_price"),
-                profit = rs.getNullableLong("profit"),
-                roiPercent = rs.getNullableDouble("roi_percent"),
-            )
-        }
-
-    private val craftingReagentRowMapper =
-        RowMapper { rs: ResultSet, _: Int ->
-            AuctionMarketItemCraftingReagentRow(
-                recipeId = rs.getInt("recipe_id"),
-                itemId = rs.getInt("item_id"),
-                name = rs.getString("name") ?: "",
-                mediaUrl = rs.getString("media_url"),
-                quantity = rs.getInt("quantity"),
-                unitPrice = rs.getNullableLong("unit_price"),
-                lineTotal = rs.getNullableLong("line_total"),
-            )
-        }
-
-    private fun ResultSet.getNullableInt(column: String): Int? {
-        val v = getInt(column)
-        return if (wasNull()) null else v
-    }
-
-    private fun ResultSet.getNullableLong(column: String): Long? {
-        val v = getLong(column)
-        return if (wasNull()) null else v
-    }
-
-    private fun ResultSet.getNullableDouble(column: String): Double? {
-        val v = getDouble(column)
-        return if (wasNull()) null else v
-    }
+    internal fun buildCurrentListingsSqlAndArgs(
+        connectedRealmId: Int,
+        itemId: Int,
+        variant: Boolean,
+        bonusKey: String,
+        modifierKey: String,
+        petSpeciesId: Int,
+    ): Pair<String, Array<Any?>> =
+        AuctionMarketItemDetailSql.buildCurrentListingsSqlAndArgs(
+            connectedRealmId,
+            itemId,
+            variant,
+            bonusKey,
+            modifierKey,
+            petSpeciesId,
+        )
 
     internal fun buildDailySqlAndArgs(
         connectedRealmId: Int,
@@ -480,143 +320,17 @@ class AuctionMarketItemDetailRepository(
         bonusKey: String,
         modifierKey: String,
         petSpeciesId: Int,
-    ): Pair<String, Array<Any?>> {
-        val sql =
-            if (variant) {
-                """
-                WITH RECURSIVE date_spine AS (
-                    SELECT ? AS stat_date
-                    UNION ALL
-                    SELECT DATE_ADD(stat_date, INTERVAL 1 DAY)
-                    FROM date_spine
-                    WHERE stat_date < ?
-                ),
-                priced AS (
-                    SELECT
-                        v.date,
-                        v.price,
-                        v.quantity,
-                        PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY v.price) OVER (
-                            PARTITION BY v.connected_realm_id, v.item_id, v.bonus_key, v.modifier_key, v.pet_species_id, v.date
-                        ) AS p25_price,
-                        PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY v.price) OVER (
-                            PARTITION BY v.connected_realm_id, v.item_id, v.bonus_key, v.modifier_key, v.pet_species_id, v.date
-                        ) AS p75_price
-                    FROM v_auction_house_prices v
-                    WHERE v.connected_realm_id = ?
-                      AND v.item_id = ?
-                      AND v.date BETWEEN ? AND ?
-                      AND v.bonus_key <=> ?
-                      AND v.modifier_key <=> ?
-                      AND v.pet_species_id = ?
-                ),
-                daily_agg AS (
-                    SELECT
-                        date AS stat_date,
-                        MIN(price) AS min_price,
-                        AVG(price) AS avg_price,
-                        MIN(p25_price) AS p25_price,
-                        MIN(p75_price) AS p75_price,
-                        MAX(price) AS max_price,
-                        MIN(quantity) AS min_quantity,
-                        AVG(quantity) AS avg_quantity,
-                        MAX(quantity) AS max_quantity
-                    FROM priced
-                    GROUP BY date
-                )
-                SELECT
-                    ds.stat_date,
-                    da.min_price,
-                    da.avg_price,
-                    da.p25_price,
-                    da.p75_price,
-                    da.max_price,
-                    da.min_quantity,
-                    da.avg_quantity,
-                    da.max_quantity
-                FROM date_spine ds
-                LEFT JOIN daily_agg da ON da.stat_date = ds.stat_date
-                ORDER BY ds.stat_date
-                """.trimIndent()
-            } else {
-                """
-                WITH RECURSIVE date_spine AS (
-                    SELECT ? AS stat_date
-                    UNION ALL
-                    SELECT DATE_ADD(stat_date, INTERVAL 1 DAY)
-                    FROM date_spine
-                    WHERE stat_date < ?
-                ),
-                priced AS (
-                    SELECT
-                        v.date,
-                        v.price,
-                        v.quantity,
-                        PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY v.price) OVER (
-                            PARTITION BY v.connected_realm_id, v.item_id, v.date
-                        ) AS p25_price,
-                        PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY v.price) OVER (
-                            PARTITION BY v.connected_realm_id, v.item_id, v.date
-                        ) AS p75_price
-                    FROM v_auction_house_prices v
-                    WHERE v.connected_realm_id = ?
-                      AND v.item_id = ?
-                      AND v.date BETWEEN ? AND ?
-                ),
-                daily_agg AS (
-                    SELECT
-                        date AS stat_date,
-                        MIN(price) AS min_price,
-                        AVG(price) AS avg_price,
-                        MIN(p25_price) AS p25_price,
-                        MIN(p75_price) AS p75_price,
-                        MAX(price) AS max_price,
-                        MIN(quantity) AS min_quantity,
-                        AVG(quantity) AS avg_quantity,
-                        MAX(quantity) AS max_quantity
-                    FROM priced
-                    GROUP BY date
-                )
-                SELECT
-                    ds.stat_date,
-                    da.min_price,
-                    da.avg_price,
-                    da.p25_price,
-                    da.p75_price,
-                    da.max_price,
-                    da.min_quantity,
-                    da.avg_quantity,
-                    da.max_quantity
-                FROM date_spine ds
-                LEFT JOIN daily_agg da ON da.stat_date = ds.stat_date
-                ORDER BY ds.stat_date
-                """.trimIndent()
-            }
-        val params: Array<Any?> =
-            if (variant) {
-                arrayOf(
-                    Date.valueOf(fromDate),
-                    Date.valueOf(toDate),
-                    connectedRealmId,
-                    itemId,
-                    Date.valueOf(fromDate),
-                    Date.valueOf(toDate),
-                    bonusKey,
-                    modifierKey,
-                    petSpeciesId,
-                )
-            } else {
-                arrayOf(
-                    Date.valueOf(fromDate),
-                    Date.valueOf(toDate),
-                    connectedRealmId,
-                    itemId,
-                    Date.valueOf(fromDate),
-                    Date.valueOf(toDate),
-                )
-            }
-        return sql to params
-    }
+    ): Pair<String, Array<Any?>> =
+        AuctionMarketItemDetailSql.buildDailySqlAndArgs(
+            connectedRealmId,
+            itemId,
+            fromDate,
+            toDate,
+            variant,
+            bonusKey,
+            modifierKey,
+            petSpeciesId,
+        )
 
     internal fun buildHourlySqlAndArgs(
         connectedRealmId: Int,
@@ -627,129 +341,17 @@ class AuctionMarketItemDetailRepository(
         bonusKey: String,
         modifierKey: String,
         petSpeciesId: Int,
-    ): Pair<String, Array<Any?>> {
-        val priceCase = hourlyPriceCaseExpression("ash", "hs.hour_of_day")
-        val quantityCase = hourlyQuantityCaseExpression("ash", "hs.hour_of_day")
-        val sql =
-            if (variant) {
-                """
-                WITH RECURSIVE date_spine AS (
-                    SELECT ? AS stat_date
-                    UNION ALL
-                    SELECT DATE_ADD(stat_date, INTERVAL 1 DAY)
-                    FROM date_spine
-                    WHERE stat_date < ?
-                ),
-                hour_spine AS (
-                    SELECT 0 AS hour_of_day
-                    UNION ALL
-                    SELECT hour_of_day + 1 FROM hour_spine WHERE hour_of_day < 23
-                ),
-                hourly_agg AS (
-                    SELECT
-                        ds.stat_date,
-                        hs.hour_of_day,
-                        MIN($priceCase) AS min_price,
-                        AVG($priceCase) AS avg_price,
-                        MAX($priceCase) AS max_price,
-                        SUM($quantityCase) AS total_quantity
-                    FROM date_spine ds
-                    CROSS JOIN hour_spine hs
-                    LEFT JOIN auction_stats_hourly ash
-                      ON ash.connected_realm_id = ?
-                     AND ash.item_id = ?
-                     AND ash.date = ds.stat_date
-                     AND ash.bonus_key <=> ?
-                     AND ash.modifier_key <=> ?
-                     AND ash.pet_species_id = ?
-                    GROUP BY ds.stat_date, hs.hour_of_day
-                )
-                SELECT
-                    ds.stat_date,
-                    hs.hour_of_day,
-                    DATE_ADD(TIMESTAMP(ds.stat_date), INTERVAL hs.hour_of_day HOUR) AS timestamp,
-                    ha.min_price,
-                    ha.avg_price,
-                    NULL AS p25_price,
-                    NULL AS p75_price,
-                    ha.max_price,
-                    ha.total_quantity
-                FROM date_spine ds
-                CROSS JOIN hour_spine hs
-                LEFT JOIN hourly_agg ha
-                  ON ha.stat_date = ds.stat_date
-                 AND ha.hour_of_day = hs.hour_of_day
-                ORDER BY ds.stat_date, hs.hour_of_day
-                """.trimIndent()
-            } else {
-                """
-                WITH RECURSIVE date_spine AS (
-                    SELECT ? AS stat_date
-                    UNION ALL
-                    SELECT DATE_ADD(stat_date, INTERVAL 1 DAY)
-                    FROM date_spine
-                    WHERE stat_date < ?
-                ),
-                hour_spine AS (
-                    SELECT 0 AS hour_of_day
-                    UNION ALL
-                    SELECT hour_of_day + 1 FROM hour_spine WHERE hour_of_day < 23
-                ),
-                hourly_agg AS (
-                    SELECT
-                        ds.stat_date,
-                        hs.hour_of_day,
-                        MIN($priceCase) AS min_price,
-                        AVG($priceCase) AS avg_price,
-                        MAX($priceCase) AS max_price,
-                        SUM($quantityCase) AS total_quantity
-                    FROM date_spine ds
-                    CROSS JOIN hour_spine hs
-                    LEFT JOIN auction_stats_hourly ash
-                      ON ash.connected_realm_id = ?
-                     AND ash.item_id = ?
-                     AND ash.date = ds.stat_date
-                    GROUP BY ds.stat_date, hs.hour_of_day
-                )
-                SELECT
-                    ds.stat_date,
-                    hs.hour_of_day,
-                    DATE_ADD(TIMESTAMP(ds.stat_date), INTERVAL hs.hour_of_day HOUR) AS timestamp,
-                    ha.min_price,
-                    ha.avg_price,
-                    NULL AS p25_price,
-                    NULL AS p75_price,
-                    ha.max_price,
-                    ha.total_quantity
-                FROM date_spine ds
-                CROSS JOIN hour_spine hs
-                LEFT JOIN hourly_agg ha
-                  ON ha.stat_date = ds.stat_date
-                 AND ha.hour_of_day = hs.hour_of_day
-                ORDER BY ds.stat_date, hs.hour_of_day
-                """.trimIndent()
-            }
-        val params: Array<Any?> =
-            if (variant) {
-                arrayOf(
-                    Date.valueOf(fromDate),
-                    Date.valueOf(toDate),
-                    connectedRealmId,
-                    itemId,
-                    bonusKey,
-                    modifierKey,
-                    petSpeciesId,
-                )
-            } else {
-                arrayOf(
-                    Date.valueOf(fromDate),
-                    Date.valueOf(toDate),
-                    connectedRealmId,
-                    itemId,
-                )
-            }
-        return sql to params
-    }
+    ): Pair<String, Array<Any?>> =
+        AuctionMarketItemDetailSql.buildHourlySqlAndArgs(
+            connectedRealmId,
+            itemId,
+            fromDate,
+            toDate,
+            variant,
+            bonusKey,
+            modifierKey,
+            petSpeciesId,
+        )
 
     internal fun buildPieSqlAndArgs(
         connectedRealmId: Int,
@@ -759,54 +361,16 @@ class AuctionMarketItemDetailRepository(
         bonusKey: String,
         modifierKey: String,
         petSpeciesId: Int,
-    ): Pair<String, Array<Any?>> {
-        val whereVariant =
-            if (variant) {
-                "AND v.bonus_key <=> ? AND v.modifier_key <=> ? AND v.pet_species_id = ?"
-            } else {
-                ""
-            }
-        val sql =
-            """
-            WITH hours AS (
-                SELECT v.hour_of_day, SUM(v.quantity) AS qty
-                FROM v_auction_house_prices v
-                WHERE v.connected_realm_id = ?
-                  AND v.item_id = ?
-                  AND v.date = ?
-                  $whereVariant
-                GROUP BY v.hour_of_day
-            ),
-            total AS (
-                SELECT COALESCE(SUM(qty), 0) AS t FROM hours
-            )
-            SELECT
-                h.hour_of_day,
-                h.qty AS quantity,
-                CASE WHEN total.t > 0 THEN h.qty / total.t ELSE 0 END AS fraction
-            FROM hours h
-            CROSS JOIN total
-            ORDER BY h.hour_of_day
-            """.trimIndent()
-        val params: Array<Any?> =
-            if (variant) {
-                arrayOf(
-                    connectedRealmId,
-                    itemId,
-                    Date.valueOf(statDate),
-                    bonusKey,
-                    modifierKey,
-                    petSpeciesId,
-                )
-            } else {
-                arrayOf(
-                    connectedRealmId,
-                    itemId,
-                    Date.valueOf(statDate),
-                )
-            }
-        return sql to params
-    }
+    ): Pair<String, Array<Any?>> =
+        AuctionMarketItemDetailSql.buildPieSqlAndArgs(
+            connectedRealmId,
+            itemId,
+            statDate,
+            variant,
+            bonusKey,
+            modifierKey,
+            petSpeciesId,
+        )
 
     internal fun buildCraftingSqlAndArgs(
         connectedRealmId: Int,
@@ -822,176 +386,22 @@ class AuctionMarketItemDetailRepository(
         petSpeciesId: Int,
         preferredRecipeId: Int?,
         localeColumnSuffix: String,
-    ): Pair<String, Array<Any?>> {
-        val hourSuffix = hourColumnSuffix(hourOfDay)
-        val commodityHourSuffix = hourColumnSuffix(commodityHourOfDay)
-        val outputWhere =
-            if (variant) {
-                "AND ash.bonus_key <=> ? AND ash.modifier_key <=> ? AND ash.pet_species_id = ?"
-            } else {
-                ""
-            }
-        val sql =
-            """
-            WITH
-            reagent_sel_base AS (
-                SELECT ash.item_id, ash.price$hourSuffix AS price, ash.bonus_key, ash.modifier_key, ash.pet_species_id
-                FROM auction_stats_hourly ash
-                WHERE ash.connected_realm_id = ?
-                  AND ash.date = ?
-                  AND ash.price$hourSuffix IS NOT NULL
-                  AND ash.item_id IN (SELECT DISTINCT rr.item_id FROM recipe_reagent rr)
-            ),
-            reagent_sel_ranked AS (
-                SELECT item_id, price,
-                       ROW_NUMBER() OVER (PARTITION BY item_id ORDER BY price ASC, bonus_key, modifier_key, pet_species_id) AS rn
-                FROM reagent_sel_base
-            ),
-            reagent_sel AS (
-                SELECT item_id, price FROM reagent_sel_ranked WHERE rn = 1
-            ),
-            reagent_com_base AS (
-                SELECT ash.item_id, ash.price$commodityHourSuffix AS price, ash.bonus_key, ash.modifier_key, ash.pet_species_id
-                FROM auction_stats_hourly ash
-                WHERE ash.connected_realm_id = ?
-                  AND ash.date = ?
-                  AND ash.price$commodityHourSuffix IS NOT NULL
-                  AND ash.item_id IN (SELECT DISTINCT rr.item_id FROM recipe_reagent rr)
-            ),
-            reagent_com_ranked AS (
-                SELECT item_id, price,
-                       ROW_NUMBER() OVER (PARTITION BY item_id ORDER BY price ASC, bonus_key, modifier_key, pet_species_id) AS rn
-                FROM reagent_com_base
-            ),
-            reagent_com AS (
-                SELECT item_id, price FROM reagent_com_ranked WHERE rn = 1
-            ),
-            reagent_price AS (
-                SELECT items.item_id, COALESCE(rs.price, rc.price) AS price
-                FROM (SELECT DISTINCT item_id FROM recipe_reagent) items
-                LEFT JOIN reagent_sel rs ON rs.item_id = items.item_id
-                LEFT JOIN reagent_com rc ON rc.item_id = items.item_id
-            ),
-            recipe_reagent_agg AS (
-                SELECT
-                    r.id AS recipe_id,
-                    SUM(CASE WHEN rr.internal_id IS NULL THEN 0 WHEN rp.price IS NULL THEN 1 ELSE 0 END) AS missing_reagents,
-                    SUM(CASE WHEN rr.internal_id IS NULL THEN 0 ELSE COALESCE(rp.price, 0) * rr.quantity END) AS reagent_cost_partial
-                FROM recipe r
-                LEFT JOIN recipe_reagent rr ON rr.recipe_id = r.id
-                LEFT JOIN reagent_price rp ON rp.item_id = rr.item_id
-                WHERE r.crafted_item_id = ?
-                GROUP BY r.id
-            ),
-            recipe_reagent_cost AS (
-                SELECT
-                    recipe_id,
-                    CASE WHEN missing_reagents > 0 THEN NULL ELSE reagent_cost_partial END AS reagent_cost,
-                    missing_reagents = 0 AS reagents_fully_priced
-                FROM recipe_reagent_agg
-            ),
-            output_sel_base AS (
-                SELECT ash.item_id, ash.price$hourSuffix AS output_unit_price, ash.bonus_key, ash.modifier_key, ash.pet_species_id
-                FROM auction_stats_hourly ash
-                WHERE ash.connected_realm_id = ?
-                  AND ash.date = ?
-                  AND ash.item_id = ?
-                  AND ash.price$hourSuffix IS NOT NULL
-                  $outputWhere
-            ),
-            output_sel_ranked AS (
-                SELECT output_unit_price,
-                       ROW_NUMBER() OVER (ORDER BY output_unit_price ASC, bonus_key, modifier_key, pet_species_id) AS rn
-                FROM output_sel_base
-            ),
-            output_sel AS (
-                SELECT output_unit_price FROM output_sel_ranked WHERE rn = 1
-            ),
-            output_com_base AS (
-                SELECT ash.item_id, ash.price$commodityHourSuffix AS output_unit_price, ash.bonus_key, ash.modifier_key, ash.pet_species_id
-                FROM auction_stats_hourly ash
-                WHERE ash.connected_realm_id = ?
-                  AND ash.date = ?
-                  AND ash.item_id = ?
-                  AND ash.price$commodityHourSuffix IS NOT NULL
-                  $outputWhere
-            ),
-            output_com_ranked AS (
-                SELECT output_unit_price,
-                       ROW_NUMBER() OVER (ORDER BY output_unit_price ASC, bonus_key, modifier_key, pet_species_id) AS rn
-                FROM output_com_base
-            ),
-            output_com AS (
-                SELECT output_unit_price FROM output_com_ranked WHERE rn = 1
-            ),
-            output_price AS (
-                SELECT COALESCE(os.output_unit_price, oc.output_unit_price) AS output_unit_price
-                FROM (SELECT 1 AS id) seed
-                LEFT JOIN output_sel os ON TRUE
-                LEFT JOIN output_com oc ON TRUE
-            )
-            SELECT
-                r.id AS recipe_id,
-                COALESCE(l.$localeColumnSuffix, l.en_gb, l.en_us, CAST(r.id AS CHAR)) AS recipe_name,
-                r.media_url AS recipe_media_url,
-                COALESCE(NULLIF(r.crafted_quantity, 0), 1) AS crafted_quantity,
-                rrc.reagent_cost,
-                COALESCE(rrc.reagents_fully_priced, TRUE) AS reagents_fully_priced,
-                op.output_unit_price,
-                CASE
-                    WHEN rrc.reagents_fully_priced AND rrc.reagent_cost IS NOT NULL AND op.output_unit_price IS NOT NULL
-                    THEN op.output_unit_price * COALESCE(NULLIF(r.crafted_quantity, 0), 1) - rrc.reagent_cost
-                    ELSE NULL
-                END AS profit,
-                CASE
-                    WHEN rrc.reagents_fully_priced AND rrc.reagent_cost IS NOT NULL AND rrc.reagent_cost > 0 AND op.output_unit_price IS NOT NULL
-                    THEN 100.0 * (op.output_unit_price * COALESCE(NULLIF(r.crafted_quantity, 0), 1) - rrc.reagent_cost) / rrc.reagent_cost
-                    ELSE NULL
-                END AS roi_percent
-            FROM recipe r
-            LEFT JOIN recipe_reagent_cost rrc ON rrc.recipe_id = r.id
-            LEFT JOIN locale l ON l.id = r.name_id
-            LEFT JOIN output_price op ON TRUE
-            WHERE r.crafted_item_id = ?
-            ORDER BY (r.id = ?) DESC, (profit IS NULL), profit DESC, r.id
-            """.trimIndent()
-        val outputParams: Array<Any?> =
-            if (variant) {
-                arrayOf(
-                    connectedRealmId,
-                    Date.valueOf(statDate),
-                    itemId,
-                    bonusKey,
-                    modifierKey,
-                    petSpeciesId,
-                    commodityConnectedRealmId,
-                    Date.valueOf(commodityStatDate),
-                    itemId,
-                    bonusKey,
-                    modifierKey,
-                    petSpeciesId,
-                )
-            } else {
-                arrayOf(
-                    connectedRealmId,
-                    Date.valueOf(statDate),
-                    itemId,
-                    commodityConnectedRealmId,
-                    Date.valueOf(commodityStatDate),
-                    itemId,
-                )
-            }
-        return sql to arrayOf(
+    ): Pair<String, Array<Any?>> =
+        AuctionMarketItemDetailSql.buildCraftingSqlAndArgs(
             connectedRealmId,
-            Date.valueOf(statDate),
             commodityConnectedRealmId,
-            Date.valueOf(commodityStatDate),
             itemId,
-            *outputParams,
-            itemId,
-            preferredRecipeId ?: -1,
+            statDate,
+            commodityStatDate,
+            hourOfDay,
+            commodityHourOfDay,
+            variant,
+            bonusKey,
+            modifierKey,
+            petSpeciesId,
+            preferredRecipeId,
+            localeColumnSuffix,
         )
-    }
 
     /**
      * Returns true when the given recipe exists and produces the given crafted item. Used to enforce
@@ -1144,7 +554,7 @@ class AuctionMarketItemDetailRepository(
         val outputParams: Array<Any?> = if (variant) arrayOf(bonusKey, modifierKey, petSpeciesId) else emptyArray()
         return jdbcTemplate.query(
             sql,
-            craftingAnalyticsDailyRowMapper,
+            AuctionMarketItemDetailRowMappers.craftingAnalyticsDailyRowMapper,
             Date.valueOf(fromDate),
             Date.valueOf(toDate),
             connectedRealmId,
@@ -1353,7 +763,7 @@ class AuctionMarketItemDetailRepository(
         val variantParams: Array<Any?> = if (variant) arrayOf(bonusKey, modifierKey, petSpeciesId) else emptyArray()
         return jdbcTemplate.query(
             sql,
-            craftingAnalyticsHeatmapRowMapper,
+            AuctionMarketItemDetailRowMappers.craftingAnalyticsHeatmapRowMapper,
             Date.valueOf(fromDate),
             Date.valueOf(toDate),
             connectedRealmId,
@@ -1380,29 +790,6 @@ class AuctionMarketItemDetailRepository(
             itemId,
         )
     }
-
-    private val craftingAnalyticsDailyRowMapper =
-        RowMapper { rs: ResultSet, _: Int ->
-            AuctionMarketItemCraftingAnalyticsDailyRow(
-                statDate = rs.getObject("stat_date", LocalDate::class.java),
-                profit = rs.getNullableLong("profit"),
-                roiPercent = rs.getNullableDouble("roi_percent"),
-                reagentCost = rs.getNullableLong("reagent_cost"),
-                outputUnitPrice = rs.getNullableLong("output_unit_price"),
-            )
-        }
-
-    private val craftingAnalyticsHeatmapRowMapper =
-        RowMapper { rs: ResultSet, _: Int ->
-            AuctionMarketItemCraftingHeatmapRow(
-                dayOfWeek = rs.getInt("day_of_week"),
-                hourOfDay = rs.getInt("hour_of_day"),
-                profit = rs.getNullableDouble("profit"),
-                outputUnitPrice = rs.getNullableDouble("output_unit_price"),
-                roiPercent = rs.getNullableDouble("roi_percent"),
-                sampleCount = rs.getInt("sample_count"),
-            )
-        }
 
     private fun hourColumnSuffix(hourOfDay: Int): String = hourOfDay.coerceIn(0, 23).toString().padStart(2, '0')
 

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketItemDetailRepository.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketItemDetailRepository.kt
@@ -13,29 +13,30 @@ class AuctionMarketItemDetailRepository(
         itemId: Int,
         localeColumnSuffix: String,
     ): AuctionMarketItemHeaderRow? =
-        jdbcTemplate.query(
-            """
-            SELECT
-                d.item_id,
-                COALESCE(d.item_name_$localeColumnSuffix, d.item_name_en_gb, d.item_name_en_us) AS item_name,
-                d.item_media_url,
-                d.quality_id,
-                d.quality_type,
-                COALESCE(d.quality_name_$localeColumnSuffix, d.quality_name_en_gb, d.quality_name_en_us) AS quality_name,
-                d.item_class_id,
-                COALESCE(d.item_class_name_$localeColumnSuffix, d.item_class_name_en_gb, d.item_class_name_en_us) AS item_class_name,
-                d.item_subclass_id,
-                COALESCE(d.item_subclass_name_$localeColumnSuffix, d.item_subclass_name_en_gb, d.item_subclass_name_en_us) AS item_subclass_name,
-                d.recipe_id,
-                COALESCE(d.recipe_name_$localeColumnSuffix, d.recipe_name_en_gb, d.recipe_name_en_us) AS recipe_name,
-                d.recipe_media_url
-            FROM v_auction_market_item_details d
-            WHERE d.item_id = ?
-            LIMIT 1
-            """.trimIndent(),
-            AuctionMarketItemDetailRowMappers.headerRowMapper,
-            itemId,
-        ).firstOrNull()
+        jdbcTemplate
+            .query(
+                """
+                SELECT
+                    d.item_id,
+                    COALESCE(d.item_name_$localeColumnSuffix, d.item_name_en_gb, d.item_name_en_us) AS item_name,
+                    d.item_media_url,
+                    d.quality_id,
+                    d.quality_type,
+                    COALESCE(d.quality_name_$localeColumnSuffix, d.quality_name_en_gb, d.quality_name_en_us) AS quality_name,
+                    d.item_class_id,
+                    COALESCE(d.item_class_name_$localeColumnSuffix, d.item_class_name_en_gb, d.item_class_name_en_us) AS item_class_name,
+                    d.item_subclass_id,
+                    COALESCE(d.item_subclass_name_$localeColumnSuffix, d.item_subclass_name_en_gb, d.item_subclass_name_en_us) AS item_subclass_name,
+                    d.recipe_id,
+                    COALESCE(d.recipe_name_$localeColumnSuffix, d.recipe_name_en_gb, d.recipe_name_en_us) AS recipe_name,
+                    d.recipe_media_url
+                FROM v_auction_market_item_details d
+                WHERE d.item_id = ?
+                LIMIT 1
+                """.trimIndent(),
+                AuctionMarketItemDetailRowMappers.headerRowMapper,
+                itemId,
+            ).firstOrNull()
 
     fun loadSnapshotPriceQuantity(
         connectedRealmId: Int,

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketItemDetailRowMappers.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketItemDetailRowMappers.kt
@@ -1,0 +1,147 @@
+package net.jonasmf.auctionengine.repository.rds
+
+import org.springframework.jdbc.core.RowMapper
+import java.sql.ResultSet
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+internal object AuctionMarketItemDetailRowMappers {
+    val headerRowMapper =
+        RowMapper { rs: ResultSet, _: Int ->
+            AuctionMarketItemHeaderRow(
+                itemId = rs.getInt("item_id"),
+                itemName = rs.getString("item_name"),
+                itemMediaUrl = rs.getString("item_media_url"),
+                qualityId = rs.getNullableInt("quality_id"),
+                qualityType = rs.getString("quality_type"),
+                qualityName = rs.getString("quality_name"),
+                itemClassId = rs.getNullableInt("item_class_id"),
+                itemClassName = rs.getString("item_class_name"),
+                itemSubclassId = rs.getNullableInt("item_subclass_id"),
+                itemSubclassName = rs.getString("item_subclass_name"),
+                recipeId = rs.getNullableInt("recipe_id"),
+                recipeName = rs.getString("recipe_name"),
+                recipeMediaUrl = rs.getString("recipe_media_url"),
+            )
+        }
+
+    val snapshotRowMapper =
+        RowMapper { rs: ResultSet, _: Int ->
+            rs.getNullableLong("price") to rs.getNullableLong("qty")
+        }
+
+    val currentListingRowMapper =
+        RowMapper { rs: ResultSet, _: Int ->
+            AuctionMarketItemCurrentListingRow(
+                price = rs.getLong("price"),
+                quantity = rs.getInt("quantity"),
+            )
+        }
+
+    val dailyRowMapper =
+        RowMapper { rs: ResultSet, _: Int ->
+            val d = rs.getObject("stat_date", LocalDate::class.java)
+            AuctionMarketItemDetailDailyRow(
+                statDate = d,
+                pointTimestamp = d.atStartOfDay(ZoneOffset.UTC).toOffsetDateTime(),
+                minPrice = rs.getNullableLong("min_price"),
+                avgPrice = rs.getNullableDouble("avg_price"),
+                p25Price = rs.getNullableLong("p25_price"),
+                p75Price = rs.getNullableLong("p75_price"),
+                maxPrice = rs.getNullableLong("max_price"),
+                minQuantity = rs.getNullableLong("min_quantity"),
+                avgQuantity = rs.getNullableDouble("avg_quantity"),
+                maxQuantity = rs.getNullableLong("max_quantity"),
+            )
+        }
+
+    val hourlyRowMapper =
+        RowMapper { rs: ResultSet, _: Int ->
+            val ts = rs.getTimestamp("timestamp").toInstant().atOffset(ZoneOffset.UTC)
+            AuctionMarketItemDetailHourlyRow(
+                timestamp = ts,
+                hourOfDay = rs.getInt("hour_of_day"),
+                minPrice = rs.getNullableLong("min_price"),
+                avgPrice = rs.getNullableDouble("avg_price"),
+                p25Price = rs.getNullableLong("p25_price"),
+                p75Price = rs.getNullableLong("p75_price"),
+                maxPrice = rs.getNullableLong("max_price"),
+                totalQuantity = rs.getNullableLong("total_quantity"),
+            )
+        }
+
+    val pieRowMapper =
+        RowMapper { rs: ResultSet, _: Int ->
+            AuctionMarketItemDetailPieRow(
+                hourOfDay = rs.getInt("hour_of_day"),
+                quantity = rs.getNullableLong("quantity"),
+                fraction = rs.getDouble("fraction"),
+            )
+        }
+
+    val craftingRowMapper =
+        RowMapper { rs: ResultSet, _: Int ->
+            AuctionMarketItemCraftingRow(
+                recipeId = rs.getInt("recipe_id"),
+                recipeName = rs.getString("recipe_name") ?: "",
+                recipeMediaUrl = rs.getString("recipe_media_url"),
+                craftedQuantity = rs.getInt("crafted_quantity"),
+                reagentCost = rs.getNullableLong("reagent_cost"),
+                reagentsFullyPriced = rs.getBoolean("reagents_fully_priced"),
+                outputUnitPrice = rs.getNullableLong("output_unit_price"),
+                profit = rs.getNullableLong("profit"),
+                roiPercent = rs.getNullableDouble("roi_percent"),
+            )
+        }
+
+    val craftingReagentRowMapper =
+        RowMapper { rs: ResultSet, _: Int ->
+            AuctionMarketItemCraftingReagentRow(
+                recipeId = rs.getInt("recipe_id"),
+                itemId = rs.getInt("item_id"),
+                name = rs.getString("name") ?: "",
+                mediaUrl = rs.getString("media_url"),
+                quantity = rs.getInt("quantity"),
+                unitPrice = rs.getNullableLong("unit_price"),
+                lineTotal = rs.getNullableLong("line_total"),
+            )
+        }
+
+    val craftingAnalyticsDailyRowMapper =
+        RowMapper { rs: ResultSet, _: Int ->
+            AuctionMarketItemCraftingAnalyticsDailyRow(
+                statDate = rs.getObject("stat_date", LocalDate::class.java),
+                profit = rs.getNullableLong("profit"),
+                roiPercent = rs.getNullableDouble("roi_percent"),
+                reagentCost = rs.getNullableLong("reagent_cost"),
+                outputUnitPrice = rs.getNullableLong("output_unit_price"),
+            )
+        }
+
+    val craftingAnalyticsHeatmapRowMapper =
+        RowMapper { rs: ResultSet, _: Int ->
+            AuctionMarketItemCraftingHeatmapRow(
+                dayOfWeek = rs.getInt("day_of_week"),
+                hourOfDay = rs.getInt("hour_of_day"),
+                profit = rs.getNullableDouble("profit"),
+                outputUnitPrice = rs.getNullableDouble("output_unit_price"),
+                roiPercent = rs.getNullableDouble("roi_percent"),
+                sampleCount = rs.getInt("sample_count"),
+            )
+        }
+}
+
+internal fun ResultSet.getNullableInt(column: String): Int? {
+    val v = getInt(column)
+    return if (wasNull()) null else v
+}
+
+internal fun ResultSet.getNullableLong(column: String): Long? {
+    val v = getLong(column)
+    return if (wasNull()) null else v
+}
+
+internal fun ResultSet.getNullableDouble(column: String): Double? {
+    val v = getDouble(column)
+    return if (wasNull()) null else v
+}

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketItemDetailRows.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketItemDetailRows.kt
@@ -1,0 +1,94 @@
+package net.jonasmf.auctionengine.repository.rds
+
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+data class AuctionMarketItemDetailDailyRow(
+    val statDate: LocalDate,
+    val pointTimestamp: OffsetDateTime,
+    val minPrice: Long?,
+    val avgPrice: Double?,
+    val p25Price: Long?,
+    val p75Price: Long?,
+    val maxPrice: Long?,
+    val minQuantity: Long?,
+    val avgQuantity: Double?,
+    val maxQuantity: Long?,
+)
+
+data class AuctionMarketItemDetailHourlyRow(
+    val timestamp: OffsetDateTime,
+    val hourOfDay: Int,
+    val minPrice: Long?,
+    val avgPrice: Double?,
+    val p25Price: Long?,
+    val p75Price: Long?,
+    val maxPrice: Long?,
+    val totalQuantity: Long?,
+)
+
+data class AuctionMarketItemDetailPieRow(
+    val hourOfDay: Int,
+    val quantity: Long?,
+    val fraction: Double,
+)
+
+data class AuctionMarketItemHeaderRow(
+    val itemId: Int,
+    val itemName: String,
+    val itemMediaUrl: String?,
+    val qualityId: Int?,
+    val qualityType: String?,
+    val qualityName: String?,
+    val itemClassId: Int?,
+    val itemClassName: String?,
+    val itemSubclassId: Int?,
+    val itemSubclassName: String?,
+    val recipeId: Int?,
+    val recipeName: String?,
+    val recipeMediaUrl: String?,
+)
+
+data class AuctionMarketItemCurrentListingRow(
+    val price: Long,
+    val quantity: Int,
+)
+
+data class AuctionMarketItemCraftingRow(
+    val recipeId: Int,
+    val recipeName: String,
+    val recipeMediaUrl: String?,
+    val craftedQuantity: Int,
+    val reagentCost: Long?,
+    val reagentsFullyPriced: Boolean,
+    val outputUnitPrice: Long?,
+    val profit: Long?,
+    val roiPercent: Double?,
+)
+
+data class AuctionMarketItemCraftingReagentRow(
+    val recipeId: Int,
+    val itemId: Int,
+    val name: String,
+    val mediaUrl: String?,
+    val quantity: Int,
+    val unitPrice: Long?,
+    val lineTotal: Long?,
+)
+
+data class AuctionMarketItemCraftingAnalyticsDailyRow(
+    val statDate: LocalDate,
+    val profit: Long?,
+    val roiPercent: Double?,
+    val reagentCost: Long?,
+    val outputUnitPrice: Long?,
+)
+
+data class AuctionMarketItemCraftingHeatmapRow(
+    val dayOfWeek: Int,
+    val hourOfDay: Int,
+    val profit: Double?,
+    val outputUnitPrice: Double?,
+    val roiPercent: Double?,
+    val sampleCount: Int,
+)

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketItemDetailSql.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketItemDetailSql.kt
@@ -15,9 +15,9 @@ internal object AuctionMarketItemDetailSql {
         val variantWhere =
             if (variant) {
                 """
-                  AND a.bonus_key <=> ?
-                  AND a.modifier_key <=> ?
-                  AND COALESCE(a.pet_species_id, -1) = ?
+                AND a.bonus_key <=> ?
+                AND a.modifier_key <=> ?
+                AND COALESCE(a.pet_species_id, -1) = ?
                 """.trimIndent()
             } else {
                 ""
@@ -31,7 +31,7 @@ internal object AuctionMarketItemDetailSql {
             )
             SELECT
                 ap.buyout AS price,
-                ap.quantity AS quantity
+                SUM(ap.quantity) AS quantity
             FROM auction_price ap
             INNER JOIN auction a ON a.id = ap.auction_id
             INNER JOIN latest_history lh
@@ -42,7 +42,8 @@ internal object AuctionMarketItemDetailSql {
               AND a.buyout IS NOT NULL
               AND ap.buyout IS NOT NULL
               $variantWhere
-            ORDER BY ap.buyout ASC, ap.quantity ASC, ap.id ASC
+            GROUP BY ap.buyout
+            ORDER BY ap.buyout ASC
             """.trimIndent()
         val params: Array<Any?> =
             if (variant) {
@@ -574,18 +575,18 @@ internal object AuctionMarketItemDetailSql {
                     itemId,
                 )
             }
-        return sql to arrayOf(
-            connectedRealmId,
-            Date.valueOf(statDate),
-            commodityConnectedRealmId,
-            Date.valueOf(commodityStatDate),
-            itemId,
-            *outputParams,
-            itemId,
-            preferredRecipeId ?: -1,
-        )
+        return sql to
+            arrayOf(
+                connectedRealmId,
+                Date.valueOf(statDate),
+                commodityConnectedRealmId,
+                Date.valueOf(commodityStatDate),
+                itemId,
+                *outputParams,
+                itemId,
+                preferredRecipeId ?: -1,
+            )
     }
-
 
     private fun hourColumnSuffix(hourOfDay: Int): String = hourOfDay.coerceIn(0, 23).toString().padStart(2, '0')
 

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketItemDetailSql.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketItemDetailSql.kt
@@ -1,0 +1,618 @@
+package net.jonasmf.auctionengine.repository.rds
+
+import java.sql.Date
+import java.time.LocalDate
+
+internal object AuctionMarketItemDetailSql {
+    internal fun buildCurrentListingsSqlAndArgs(
+        connectedRealmId: Int,
+        itemId: Int,
+        variant: Boolean,
+        bonusKey: String,
+        modifierKey: String,
+        petSpeciesId: Int,
+    ): Pair<String, Array<Any?>> {
+        val variantWhere =
+            if (variant) {
+                """
+                  AND a.bonus_key <=> ?
+                  AND a.modifier_key <=> ?
+                  AND COALESCE(a.pet_species_id, -1) = ?
+                """.trimIndent()
+            } else {
+                ""
+            }
+        val sql =
+            """
+            WITH latest_history AS (
+                SELECT MAX(id) AS update_history_id
+                FROM connected_realm_update_history
+                WHERE connected_realm_id = ?
+            )
+            SELECT
+                ap.buyout AS price,
+                ap.quantity AS quantity
+            FROM auction_price ap
+            INNER JOIN auction a ON a.id = ap.auction_id
+            INNER JOIN latest_history lh
+                ON lh.update_history_id = a.update_history_id
+               AND lh.update_history_id = ap.update_history_id
+            WHERE a.connected_realm_id = ?
+              AND a.item_id = ?
+              AND a.buyout IS NOT NULL
+              AND ap.buyout IS NOT NULL
+              $variantWhere
+            ORDER BY ap.buyout ASC, ap.quantity ASC, ap.id ASC
+            """.trimIndent()
+        val params: Array<Any?> =
+            if (variant) {
+                arrayOf(
+                    connectedRealmId,
+                    connectedRealmId,
+                    itemId,
+                    bonusKey,
+                    modifierKey,
+                    petSpeciesId,
+                )
+            } else {
+                arrayOf(
+                    connectedRealmId,
+                    connectedRealmId,
+                    itemId,
+                )
+            }
+        return sql to params
+    }
+
+    internal fun buildDailySqlAndArgs(
+        connectedRealmId: Int,
+        itemId: Int,
+        fromDate: LocalDate,
+        toDate: LocalDate,
+        variant: Boolean,
+        bonusKey: String,
+        modifierKey: String,
+        petSpeciesId: Int,
+    ): Pair<String, Array<Any?>> {
+        val sql =
+            if (variant) {
+                """
+                WITH RECURSIVE date_spine AS (
+                    SELECT ? AS stat_date
+                    UNION ALL
+                    SELECT DATE_ADD(stat_date, INTERVAL 1 DAY)
+                    FROM date_spine
+                    WHERE stat_date < ?
+                ),
+                priced AS (
+                    SELECT
+                        v.date,
+                        v.price,
+                        v.quantity,
+                        PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY v.price) OVER (
+                            PARTITION BY v.connected_realm_id, v.item_id, v.bonus_key, v.modifier_key, v.pet_species_id, v.date
+                        ) AS p25_price,
+                        PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY v.price) OVER (
+                            PARTITION BY v.connected_realm_id, v.item_id, v.bonus_key, v.modifier_key, v.pet_species_id, v.date
+                        ) AS p75_price
+                    FROM v_auction_house_prices v
+                    WHERE v.connected_realm_id = ?
+                      AND v.item_id = ?
+                      AND v.date BETWEEN ? AND ?
+                      AND v.bonus_key <=> ?
+                      AND v.modifier_key <=> ?
+                      AND v.pet_species_id = ?
+                ),
+                daily_agg AS (
+                    SELECT
+                        date AS stat_date,
+                        MIN(price) AS min_price,
+                        AVG(price) AS avg_price,
+                        MIN(p25_price) AS p25_price,
+                        MIN(p75_price) AS p75_price,
+                        MAX(price) AS max_price,
+                        MIN(quantity) AS min_quantity,
+                        AVG(quantity) AS avg_quantity,
+                        MAX(quantity) AS max_quantity
+                    FROM priced
+                    GROUP BY date
+                )
+                SELECT
+                    ds.stat_date,
+                    da.min_price,
+                    da.avg_price,
+                    da.p25_price,
+                    da.p75_price,
+                    da.max_price,
+                    da.min_quantity,
+                    da.avg_quantity,
+                    da.max_quantity
+                FROM date_spine ds
+                LEFT JOIN daily_agg da ON da.stat_date = ds.stat_date
+                ORDER BY ds.stat_date
+                """.trimIndent()
+            } else {
+                """
+                WITH RECURSIVE date_spine AS (
+                    SELECT ? AS stat_date
+                    UNION ALL
+                    SELECT DATE_ADD(stat_date, INTERVAL 1 DAY)
+                    FROM date_spine
+                    WHERE stat_date < ?
+                ),
+                priced AS (
+                    SELECT
+                        v.date,
+                        v.price,
+                        v.quantity,
+                        PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY v.price) OVER (
+                            PARTITION BY v.connected_realm_id, v.item_id, v.date
+                        ) AS p25_price,
+                        PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY v.price) OVER (
+                            PARTITION BY v.connected_realm_id, v.item_id, v.date
+                        ) AS p75_price
+                    FROM v_auction_house_prices v
+                    WHERE v.connected_realm_id = ?
+                      AND v.item_id = ?
+                      AND v.date BETWEEN ? AND ?
+                ),
+                daily_agg AS (
+                    SELECT
+                        date AS stat_date,
+                        MIN(price) AS min_price,
+                        AVG(price) AS avg_price,
+                        MIN(p25_price) AS p25_price,
+                        MIN(p75_price) AS p75_price,
+                        MAX(price) AS max_price,
+                        MIN(quantity) AS min_quantity,
+                        AVG(quantity) AS avg_quantity,
+                        MAX(quantity) AS max_quantity
+                    FROM priced
+                    GROUP BY date
+                )
+                SELECT
+                    ds.stat_date,
+                    da.min_price,
+                    da.avg_price,
+                    da.p25_price,
+                    da.p75_price,
+                    da.max_price,
+                    da.min_quantity,
+                    da.avg_quantity,
+                    da.max_quantity
+                FROM date_spine ds
+                LEFT JOIN daily_agg da ON da.stat_date = ds.stat_date
+                ORDER BY ds.stat_date
+                """.trimIndent()
+            }
+        val params: Array<Any?> =
+            if (variant) {
+                arrayOf(
+                    Date.valueOf(fromDate),
+                    Date.valueOf(toDate),
+                    connectedRealmId,
+                    itemId,
+                    Date.valueOf(fromDate),
+                    Date.valueOf(toDate),
+                    bonusKey,
+                    modifierKey,
+                    petSpeciesId,
+                )
+            } else {
+                arrayOf(
+                    Date.valueOf(fromDate),
+                    Date.valueOf(toDate),
+                    connectedRealmId,
+                    itemId,
+                    Date.valueOf(fromDate),
+                    Date.valueOf(toDate),
+                )
+            }
+        return sql to params
+    }
+
+    internal fun buildHourlySqlAndArgs(
+        connectedRealmId: Int,
+        itemId: Int,
+        fromDate: LocalDate,
+        toDate: LocalDate,
+        variant: Boolean,
+        bonusKey: String,
+        modifierKey: String,
+        petSpeciesId: Int,
+    ): Pair<String, Array<Any?>> {
+        val priceCase = hourlyPriceCaseExpression("ash", "hs.hour_of_day")
+        val quantityCase = hourlyQuantityCaseExpression("ash", "hs.hour_of_day")
+        val sql =
+            if (variant) {
+                """
+                WITH RECURSIVE date_spine AS (
+                    SELECT ? AS stat_date
+                    UNION ALL
+                    SELECT DATE_ADD(stat_date, INTERVAL 1 DAY)
+                    FROM date_spine
+                    WHERE stat_date < ?
+                ),
+                hour_spine AS (
+                    SELECT 0 AS hour_of_day
+                    UNION ALL
+                    SELECT hour_of_day + 1 FROM hour_spine WHERE hour_of_day < 23
+                ),
+                hourly_agg AS (
+                    SELECT
+                        ds.stat_date,
+                        hs.hour_of_day,
+                        MIN($priceCase) AS min_price,
+                        AVG($priceCase) AS avg_price,
+                        MAX($priceCase) AS max_price,
+                        SUM($quantityCase) AS total_quantity
+                    FROM date_spine ds
+                    CROSS JOIN hour_spine hs
+                    LEFT JOIN auction_stats_hourly ash
+                      ON ash.connected_realm_id = ?
+                     AND ash.item_id = ?
+                     AND ash.date = ds.stat_date
+                     AND ash.bonus_key <=> ?
+                     AND ash.modifier_key <=> ?
+                     AND ash.pet_species_id = ?
+                    GROUP BY ds.stat_date, hs.hour_of_day
+                )
+                SELECT
+                    ds.stat_date,
+                    hs.hour_of_day,
+                    DATE_ADD(TIMESTAMP(ds.stat_date), INTERVAL hs.hour_of_day HOUR) AS timestamp,
+                    ha.min_price,
+                    ha.avg_price,
+                    NULL AS p25_price,
+                    NULL AS p75_price,
+                    ha.max_price,
+                    ha.total_quantity
+                FROM date_spine ds
+                CROSS JOIN hour_spine hs
+                LEFT JOIN hourly_agg ha
+                  ON ha.stat_date = ds.stat_date
+                 AND ha.hour_of_day = hs.hour_of_day
+                ORDER BY ds.stat_date, hs.hour_of_day
+                """.trimIndent()
+            } else {
+                """
+                WITH RECURSIVE date_spine AS (
+                    SELECT ? AS stat_date
+                    UNION ALL
+                    SELECT DATE_ADD(stat_date, INTERVAL 1 DAY)
+                    FROM date_spine
+                    WHERE stat_date < ?
+                ),
+                hour_spine AS (
+                    SELECT 0 AS hour_of_day
+                    UNION ALL
+                    SELECT hour_of_day + 1 FROM hour_spine WHERE hour_of_day < 23
+                ),
+                hourly_agg AS (
+                    SELECT
+                        ds.stat_date,
+                        hs.hour_of_day,
+                        MIN($priceCase) AS min_price,
+                        AVG($priceCase) AS avg_price,
+                        MAX($priceCase) AS max_price,
+                        SUM($quantityCase) AS total_quantity
+                    FROM date_spine ds
+                    CROSS JOIN hour_spine hs
+                    LEFT JOIN auction_stats_hourly ash
+                      ON ash.connected_realm_id = ?
+                     AND ash.item_id = ?
+                     AND ash.date = ds.stat_date
+                    GROUP BY ds.stat_date, hs.hour_of_day
+                )
+                SELECT
+                    ds.stat_date,
+                    hs.hour_of_day,
+                    DATE_ADD(TIMESTAMP(ds.stat_date), INTERVAL hs.hour_of_day HOUR) AS timestamp,
+                    ha.min_price,
+                    ha.avg_price,
+                    NULL AS p25_price,
+                    NULL AS p75_price,
+                    ha.max_price,
+                    ha.total_quantity
+                FROM date_spine ds
+                CROSS JOIN hour_spine hs
+                LEFT JOIN hourly_agg ha
+                  ON ha.stat_date = ds.stat_date
+                 AND ha.hour_of_day = hs.hour_of_day
+                ORDER BY ds.stat_date, hs.hour_of_day
+                """.trimIndent()
+            }
+        val params: Array<Any?> =
+            if (variant) {
+                arrayOf(
+                    Date.valueOf(fromDate),
+                    Date.valueOf(toDate),
+                    connectedRealmId,
+                    itemId,
+                    bonusKey,
+                    modifierKey,
+                    petSpeciesId,
+                )
+            } else {
+                arrayOf(
+                    Date.valueOf(fromDate),
+                    Date.valueOf(toDate),
+                    connectedRealmId,
+                    itemId,
+                )
+            }
+        return sql to params
+    }
+
+    internal fun buildPieSqlAndArgs(
+        connectedRealmId: Int,
+        itemId: Int,
+        statDate: LocalDate,
+        variant: Boolean,
+        bonusKey: String,
+        modifierKey: String,
+        petSpeciesId: Int,
+    ): Pair<String, Array<Any?>> {
+        val whereVariant =
+            if (variant) {
+                "AND v.bonus_key <=> ? AND v.modifier_key <=> ? AND v.pet_species_id = ?"
+            } else {
+                ""
+            }
+        val sql =
+            """
+            WITH hours AS (
+                SELECT v.hour_of_day, SUM(v.quantity) AS qty
+                FROM v_auction_house_prices v
+                WHERE v.connected_realm_id = ?
+                  AND v.item_id = ?
+                  AND v.date = ?
+                  $whereVariant
+                GROUP BY v.hour_of_day
+            ),
+            total AS (
+                SELECT COALESCE(SUM(qty), 0) AS t FROM hours
+            )
+            SELECT
+                h.hour_of_day,
+                h.qty AS quantity,
+                CASE WHEN total.t > 0 THEN h.qty / total.t ELSE 0 END AS fraction
+            FROM hours h
+            CROSS JOIN total
+            ORDER BY h.hour_of_day
+            """.trimIndent()
+        val params: Array<Any?> =
+            if (variant) {
+                arrayOf(
+                    connectedRealmId,
+                    itemId,
+                    Date.valueOf(statDate),
+                    bonusKey,
+                    modifierKey,
+                    petSpeciesId,
+                )
+            } else {
+                arrayOf(
+                    connectedRealmId,
+                    itemId,
+                    Date.valueOf(statDate),
+                )
+            }
+        return sql to params
+    }
+
+    internal fun buildCraftingSqlAndArgs(
+        connectedRealmId: Int,
+        commodityConnectedRealmId: Int,
+        itemId: Int,
+        statDate: LocalDate,
+        commodityStatDate: LocalDate,
+        hourOfDay: Int,
+        commodityHourOfDay: Int,
+        variant: Boolean,
+        bonusKey: String,
+        modifierKey: String,
+        petSpeciesId: Int,
+        preferredRecipeId: Int?,
+        localeColumnSuffix: String,
+    ): Pair<String, Array<Any?>> {
+        val hourSuffix = hourColumnSuffix(hourOfDay)
+        val commodityHourSuffix = hourColumnSuffix(commodityHourOfDay)
+        val outputWhere =
+            if (variant) {
+                "AND ash.bonus_key <=> ? AND ash.modifier_key <=> ? AND ash.pet_species_id = ?"
+            } else {
+                ""
+            }
+        val sql =
+            """
+            WITH
+            reagent_sel_base AS (
+                SELECT ash.item_id, ash.price$hourSuffix AS price, ash.bonus_key, ash.modifier_key, ash.pet_species_id
+                FROM auction_stats_hourly ash
+                WHERE ash.connected_realm_id = ?
+                  AND ash.date = ?
+                  AND ash.price$hourSuffix IS NOT NULL
+                  AND ash.item_id IN (SELECT DISTINCT rr.item_id FROM recipe_reagent rr)
+            ),
+            reagent_sel_ranked AS (
+                SELECT item_id, price,
+                       ROW_NUMBER() OVER (PARTITION BY item_id ORDER BY price ASC, bonus_key, modifier_key, pet_species_id) AS rn
+                FROM reagent_sel_base
+            ),
+            reagent_sel AS (
+                SELECT item_id, price FROM reagent_sel_ranked WHERE rn = 1
+            ),
+            reagent_com_base AS (
+                SELECT ash.item_id, ash.price$commodityHourSuffix AS price, ash.bonus_key, ash.modifier_key, ash.pet_species_id
+                FROM auction_stats_hourly ash
+                WHERE ash.connected_realm_id = ?
+                  AND ash.date = ?
+                  AND ash.price$commodityHourSuffix IS NOT NULL
+                  AND ash.item_id IN (SELECT DISTINCT rr.item_id FROM recipe_reagent rr)
+            ),
+            reagent_com_ranked AS (
+                SELECT item_id, price,
+                       ROW_NUMBER() OVER (PARTITION BY item_id ORDER BY price ASC, bonus_key, modifier_key, pet_species_id) AS rn
+                FROM reagent_com_base
+            ),
+            reagent_com AS (
+                SELECT item_id, price FROM reagent_com_ranked WHERE rn = 1
+            ),
+            reagent_price AS (
+                SELECT items.item_id, COALESCE(rs.price, rc.price) AS price
+                FROM (SELECT DISTINCT item_id FROM recipe_reagent) items
+                LEFT JOIN reagent_sel rs ON rs.item_id = items.item_id
+                LEFT JOIN reagent_com rc ON rc.item_id = items.item_id
+            ),
+            recipe_reagent_agg AS (
+                SELECT
+                    r.id AS recipe_id,
+                    SUM(CASE WHEN rr.internal_id IS NULL THEN 0 WHEN rp.price IS NULL THEN 1 ELSE 0 END) AS missing_reagents,
+                    SUM(CASE WHEN rr.internal_id IS NULL THEN 0 ELSE COALESCE(rp.price, 0) * rr.quantity END) AS reagent_cost_partial
+                FROM recipe r
+                LEFT JOIN recipe_reagent rr ON rr.recipe_id = r.id
+                LEFT JOIN reagent_price rp ON rp.item_id = rr.item_id
+                WHERE r.crafted_item_id = ?
+                GROUP BY r.id
+            ),
+            recipe_reagent_cost AS (
+                SELECT
+                    recipe_id,
+                    CASE WHEN missing_reagents > 0 THEN NULL ELSE reagent_cost_partial END AS reagent_cost,
+                    missing_reagents = 0 AS reagents_fully_priced
+                FROM recipe_reagent_agg
+            ),
+            output_sel_base AS (
+                SELECT ash.item_id, ash.price$hourSuffix AS output_unit_price, ash.bonus_key, ash.modifier_key, ash.pet_species_id
+                FROM auction_stats_hourly ash
+                WHERE ash.connected_realm_id = ?
+                  AND ash.date = ?
+                  AND ash.item_id = ?
+                  AND ash.price$hourSuffix IS NOT NULL
+                  $outputWhere
+            ),
+            output_sel_ranked AS (
+                SELECT output_unit_price,
+                       ROW_NUMBER() OVER (ORDER BY output_unit_price ASC, bonus_key, modifier_key, pet_species_id) AS rn
+                FROM output_sel_base
+            ),
+            output_sel AS (
+                SELECT output_unit_price FROM output_sel_ranked WHERE rn = 1
+            ),
+            output_com_base AS (
+                SELECT ash.item_id, ash.price$commodityHourSuffix AS output_unit_price, ash.bonus_key, ash.modifier_key, ash.pet_species_id
+                FROM auction_stats_hourly ash
+                WHERE ash.connected_realm_id = ?
+                  AND ash.date = ?
+                  AND ash.item_id = ?
+                  AND ash.price$commodityHourSuffix IS NOT NULL
+                  $outputWhere
+            ),
+            output_com_ranked AS (
+                SELECT output_unit_price,
+                       ROW_NUMBER() OVER (ORDER BY output_unit_price ASC, bonus_key, modifier_key, pet_species_id) AS rn
+                FROM output_com_base
+            ),
+            output_com AS (
+                SELECT output_unit_price FROM output_com_ranked WHERE rn = 1
+            ),
+            output_price AS (
+                SELECT COALESCE(os.output_unit_price, oc.output_unit_price) AS output_unit_price
+                FROM (SELECT 1 AS id) seed
+                LEFT JOIN output_sel os ON TRUE
+                LEFT JOIN output_com oc ON TRUE
+            )
+            SELECT
+                r.id AS recipe_id,
+                COALESCE(l.$localeColumnSuffix, l.en_gb, l.en_us, CAST(r.id AS CHAR)) AS recipe_name,
+                r.media_url AS recipe_media_url,
+                COALESCE(NULLIF(r.crafted_quantity, 0), 1) AS crafted_quantity,
+                rrc.reagent_cost,
+                COALESCE(rrc.reagents_fully_priced, TRUE) AS reagents_fully_priced,
+                op.output_unit_price,
+                CASE
+                    WHEN rrc.reagents_fully_priced AND rrc.reagent_cost IS NOT NULL AND op.output_unit_price IS NOT NULL
+                    THEN op.output_unit_price * COALESCE(NULLIF(r.crafted_quantity, 0), 1) - rrc.reagent_cost
+                    ELSE NULL
+                END AS profit,
+                CASE
+                    WHEN rrc.reagents_fully_priced AND rrc.reagent_cost IS NOT NULL AND rrc.reagent_cost > 0 AND op.output_unit_price IS NOT NULL
+                    THEN 100.0 * (op.output_unit_price * COALESCE(NULLIF(r.crafted_quantity, 0), 1) - rrc.reagent_cost) / rrc.reagent_cost
+                    ELSE NULL
+                END AS roi_percent
+            FROM recipe r
+            LEFT JOIN recipe_reagent_cost rrc ON rrc.recipe_id = r.id
+            LEFT JOIN locale l ON l.id = r.name_id
+            LEFT JOIN output_price op ON TRUE
+            WHERE r.crafted_item_id = ?
+            ORDER BY (r.id = ?) DESC, (profit IS NULL), profit DESC, r.id
+            """.trimIndent()
+        val outputParams: Array<Any?> =
+            if (variant) {
+                arrayOf(
+                    connectedRealmId,
+                    Date.valueOf(statDate),
+                    itemId,
+                    bonusKey,
+                    modifierKey,
+                    petSpeciesId,
+                    commodityConnectedRealmId,
+                    Date.valueOf(commodityStatDate),
+                    itemId,
+                    bonusKey,
+                    modifierKey,
+                    petSpeciesId,
+                )
+            } else {
+                arrayOf(
+                    connectedRealmId,
+                    Date.valueOf(statDate),
+                    itemId,
+                    commodityConnectedRealmId,
+                    Date.valueOf(commodityStatDate),
+                    itemId,
+                )
+            }
+        return sql to arrayOf(
+            connectedRealmId,
+            Date.valueOf(statDate),
+            commodityConnectedRealmId,
+            Date.valueOf(commodityStatDate),
+            itemId,
+            *outputParams,
+            itemId,
+            preferredRecipeId ?: -1,
+        )
+    }
+
+
+    private fun hourColumnSuffix(hourOfDay: Int): String = hourOfDay.coerceIn(0, 23).toString().padStart(2, '0')
+
+    private fun hoursCteSql(): String = (0..23).joinToString(separator = " UNION ALL ") { "SELECT $it AS hour_of_day" }
+
+    /**
+     * Returns a `CASE h.hour_of_day WHEN 0 THEN ash.price00 ... WHEN 23 THEN ash.price23 END` expression
+     * used to unpivot the 24 hourly price columns of `auction_stats_hourly` into a single column when
+     * cross-joined with the `hours_t` 0..23 table.
+     */
+    private fun hourlyPriceCaseExpression(
+        tableAlias: String = "ash",
+        hourCol: String = "h.hour_of_day",
+    ): String =
+        (0..23).joinToString(
+            prefix = "CASE $hourCol ",
+            separator = " ",
+            postfix = " END",
+        ) { "WHEN $it THEN $tableAlias.price${hourColumnSuffix(it)}" }
+
+    private fun hourlyQuantityCaseExpression(
+        tableAlias: String = "ash",
+        hourCol: String = "h.hour_of_day",
+    ): String =
+        (0..23).joinToString(
+            prefix = "CASE $hourCol ",
+            separator = " ",
+            postfix = " END",
+        ) { "WHEN $it THEN $tableAlias.quantity${hourColumnSuffix(it)}" }
+}

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/service/AuctionMarketItemDetailService.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/service/AuctionMarketItemDetailService.kt
@@ -1,5 +1,10 @@
 package net.jonasmf.auctionengine.service
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import net.jonasmf.auctionengine.generated.model.AuctionListingKey
 import net.jonasmf.auctionengine.generated.model.AuctionMarketItem
 import net.jonasmf.auctionengine.generated.model.AuctionMarketItemCrafting
@@ -8,6 +13,7 @@ import net.jonasmf.auctionengine.generated.model.AuctionMarketItemCraftingAnalyt
 import net.jonasmf.auctionengine.generated.model.AuctionMarketItemCraftingDetail
 import net.jonasmf.auctionengine.generated.model.AuctionMarketItemCraftingHeatmapCell
 import net.jonasmf.auctionengine.generated.model.AuctionMarketItemCraftingReagent
+import net.jonasmf.auctionengine.generated.model.AuctionMarketItemCurrentListing
 import net.jonasmf.auctionengine.generated.model.AuctionMarketItemDetailPoint
 import net.jonasmf.auctionengine.generated.model.AuctionMarketItemDetailResponse
 import net.jonasmf.auctionengine.generated.model.AuctionMarketItemDetailSummary
@@ -25,12 +31,29 @@ import net.jonasmf.auctionengine.repository.rds.AuctionMarketItemCraftingAnalyti
 import net.jonasmf.auctionengine.repository.rds.AuctionMarketItemCraftingHeatmapRow
 import net.jonasmf.auctionengine.repository.rds.AuctionMarketItemCraftingReagentRow
 import net.jonasmf.auctionengine.repository.rds.AuctionMarketItemCraftingRow
+import net.jonasmf.auctionengine.repository.rds.AuctionMarketItemCurrentListingRow
 import net.jonasmf.auctionengine.repository.rds.AuctionMarketItemHeaderRow
+import org.slf4j.MDC
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
+
+private data class AuctionMarketItemDetailRepositoryRows(
+    val header: AuctionMarketItemHeaderRow?,
+    val dailyRealm: List<AuctionMarketItemDetailDailyRow>,
+    val dailyCommodity: List<AuctionMarketItemDetailDailyRow>,
+    val hourlyRealm: List<AuctionMarketItemDetailHourlyRow>,
+    val hourlyCommodity: List<AuctionMarketItemDetailHourlyRow>,
+    val pieRealm: List<AuctionMarketItemDetailPieRow>,
+    val pieCommodity: List<AuctionMarketItemDetailPieRow>,
+    val selectedSnapshot: Pair<Long?, Long?>,
+    val commoditySnapshot: Pair<Long?, Long?>,
+    val currentListings: List<AuctionMarketItemCurrentListingRow>,
+    val craftingRows: List<AuctionMarketItemCraftingRow>,
+    val reagentRows: Map<Int, List<AuctionMarketItemCraftingReagentRow>>,
+)
 
 @Service
 class AuctionMarketItemDetailService(
@@ -56,10 +79,6 @@ class AuctionMarketItemDetailService(
         val variant = !rollupListing
         val localeSuffix = context.localeColumnSuffix
 
-        val header =
-            detailRepository.loadItemHeader(itemId, localeSuffix)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Item not found: $itemId")
-
         val listingKey = AuctionListingKey(bonusKey, modifierKey, petSpeciesId)
         val redundant =
             context.selectedSnapshot.connectedRealmId == context.commoditySnapshot.connectedRealmId
@@ -71,136 +90,249 @@ class AuctionMarketItemDetailService(
         val commodityFrom = context.commoditySnapshot.date.minusDays(13)
         val commodityTo = context.commoditySnapshot.date
 
-        val dailyRealm =
-            if (loadCommodity) {
-                emptyList()
-            } else {
-                detailRepository
-                    .loadDailySeries(
-                        context.selectedSnapshot.connectedRealmId,
-                        itemId,
-                        realmFrom,
-                        realmTo,
-                        variant,
-                        bonusKey,
-                        modifierKey,
-                        petSpeciesId,
-                    ).map { it.toDetailPoint() }
+        val mdcSnapshot = MDC.getCopyOfContextMap()
+        val repositoryRows =
+            runBlocking {
+                coroutineScope {
+                    val headerDef =
+                        async {
+                            withAuctionMdc(mdcSnapshot) {
+                                detailRepository.loadItemHeader(itemId, localeSuffix)
+                            }
+                        }
+                    val dailyRealmDef =
+                        async {
+                            if (loadCommodity) {
+                                emptyList()
+                            } else {
+                                withAuctionMdc(mdcSnapshot) {
+                                    detailRepository.loadDailySeries(
+                                        context.selectedSnapshot.connectedRealmId,
+                                        itemId,
+                                        realmFrom,
+                                        realmTo,
+                                        variant,
+                                        bonusKey,
+                                        modifierKey,
+                                        petSpeciesId,
+                                    )
+                                }
+                            }
+                        }
+                    val dailyCommodityDef =
+                        async {
+                            if (loadCommodity) {
+                                withAuctionMdc(mdcSnapshot) {
+                                    detailRepository.loadDailySeries(
+                                        context.commoditySnapshot.connectedRealmId,
+                                        itemId,
+                                        commodityFrom,
+                                        commodityTo,
+                                        variant,
+                                        bonusKey,
+                                        modifierKey,
+                                        petSpeciesId,
+                                    )
+                                }
+                            } else {
+                                emptyList()
+                            }
+                        }
+                    val hourlyRealmDef =
+                        async {
+                            if (loadCommodity) {
+                                emptyList()
+                            } else {
+                                withAuctionMdc(mdcSnapshot) {
+                                    detailRepository.loadHourlySeries(
+                                        context.selectedSnapshot.connectedRealmId,
+                                        itemId,
+                                        realmFrom,
+                                        realmTo,
+                                        variant,
+                                        bonusKey,
+                                        modifierKey,
+                                        petSpeciesId,
+                                    )
+                                }
+                            }
+                        }
+                    val hourlyCommodityDef =
+                        async {
+                            if (loadCommodity) {
+                                withAuctionMdc(mdcSnapshot) {
+                                    detailRepository.loadHourlySeries(
+                                        context.commoditySnapshot.connectedRealmId,
+                                        itemId,
+                                        commodityFrom,
+                                        commodityTo,
+                                        variant,
+                                        bonusKey,
+                                        modifierKey,
+                                        petSpeciesId,
+                                    )
+                                }
+                            } else {
+                                emptyList()
+                            }
+                        }
+                    val pieRealmDef =
+                        async {
+                            if (loadCommodity) {
+                                emptyList()
+                            } else {
+                                withAuctionMdc(mdcSnapshot) {
+                                    detailRepository.loadQuantityPie(
+                                        context.selectedSnapshot.connectedRealmId,
+                                        itemId,
+                                        context.selectedSnapshot.date,
+                                        variant,
+                                        bonusKey,
+                                        modifierKey,
+                                        petSpeciesId,
+                                    )
+                                }
+                            }
+                        }
+                    val pieCommodityDef =
+                        async {
+                            if (loadCommodity) {
+                                withAuctionMdc(mdcSnapshot) {
+                                    detailRepository.loadQuantityPie(
+                                        context.commoditySnapshot.connectedRealmId,
+                                        itemId,
+                                        context.commoditySnapshot.date,
+                                        variant,
+                                        bonusKey,
+                                        modifierKey,
+                                        petSpeciesId,
+                                    )
+                                }
+                            } else {
+                                emptyList()
+                            }
+                        }
+                    val selectedSnapshotDef =
+                        async {
+                            if (loadCommodity) {
+                                null to null
+                            } else {
+                                withAuctionMdc(mdcSnapshot) {
+                                    detailRepository.loadSnapshotPriceQuantity(
+                                        context.selectedSnapshot.connectedRealmId,
+                                        itemId,
+                                        context.selectedSnapshot.date,
+                                        context.selectedSnapshot.hour,
+                                        variant,
+                                        bonusKey,
+                                        modifierKey,
+                                        petSpeciesId,
+                                    )
+                                }
+                            }
+                        }
+                    val commoditySnapshotDef =
+                        async {
+                            if (loadCommodity) {
+                                withAuctionMdc(mdcSnapshot) {
+                                    detailRepository.loadSnapshotPriceQuantity(
+                                        context.commoditySnapshot.connectedRealmId,
+                                        itemId,
+                                        context.commoditySnapshot.date,
+                                        context.commoditySnapshot.hour,
+                                        variant,
+                                        bonusKey,
+                                        modifierKey,
+                                        petSpeciesId,
+                                    )
+                                }
+                            } else {
+                                null to null
+                            }
+                        }
+                    val currentListingsDef =
+                        async {
+                            withAuctionMdc(mdcSnapshot) {
+                                val snapshot =
+                                    if (loadCommodity) {
+                                        context.commoditySnapshot
+                                    } else {
+                                        context.selectedSnapshot
+                                    }
+                                detailRepository.loadCurrentListings(
+                                    snapshot.connectedRealmId,
+                                    itemId,
+                                    variant,
+                                    bonusKey,
+                                    modifierKey,
+                                    petSpeciesId,
+                                )
+                            }
+                        }
+                    val craftingDef =
+                        async {
+                            withAuctionMdc(mdcSnapshot) {
+                                val craftingRows =
+                                    detailRepository.loadCraftings(
+                                        context.selectedSnapshot.connectedRealmId,
+                                        context.commoditySnapshot.connectedRealmId,
+                                        itemId,
+                                        context.selectedSnapshot.date,
+                                        context.commoditySnapshot.date,
+                                        context.selectedSnapshot.hour,
+                                        context.commoditySnapshot.hour,
+                                        variant,
+                                        bonusKey,
+                                        modifierKey,
+                                        petSpeciesId,
+                                        preferredRecipeId,
+                                        localeSuffix,
+                                    )
+                                val reagentRows =
+                                    detailRepository
+                                        .loadCraftingReagents(
+                                            context.selectedSnapshot.connectedRealmId,
+                                            context.commoditySnapshot.connectedRealmId,
+                                            craftingRows.map { it.recipeId },
+                                            context.selectedSnapshot.date,
+                                            context.commoditySnapshot.date,
+                                            context.selectedSnapshot.hour,
+                                            context.commoditySnapshot.hour,
+                                            localeSuffix,
+                                        ).groupBy { it.recipeId }
+                                craftingRows to reagentRows
+                            }
+                        }
+
+                    val (craftingRows, reagentRows) = craftingDef.await()
+                    AuctionMarketItemDetailRepositoryRows(
+                        header = headerDef.await(),
+                        dailyRealm = dailyRealmDef.await(),
+                        dailyCommodity = dailyCommodityDef.await(),
+                        hourlyRealm = hourlyRealmDef.await(),
+                        hourlyCommodity = hourlyCommodityDef.await(),
+                        pieRealm = pieRealmDef.await(),
+                        pieCommodity = pieCommodityDef.await(),
+                        selectedSnapshot = selectedSnapshotDef.await(),
+                        commoditySnapshot = commoditySnapshotDef.await(),
+                        currentListings = currentListingsDef.await(),
+                        craftingRows = craftingRows,
+                        reagentRows = reagentRows,
+                    )
+                }
             }
 
-        val dailyCommodity =
-            if (loadCommodity) {
-                detailRepository
-                    .loadDailySeries(
-                        context.commoditySnapshot.connectedRealmId,
-                        itemId,
-                        commodityFrom,
-                        commodityTo,
-                        variant,
-                        bonusKey,
-                        modifierKey,
-                        petSpeciesId,
-                    ).map { it.toDetailPoint() }
-            } else {
-                emptyList()
-            }
-
-        val hourlyRealm =
-            if (loadCommodity) {
-                emptyList()
-            } else {
-                detailRepository
-                    .loadHourlySeries(
-                        context.selectedSnapshot.connectedRealmId,
-                        itemId,
-                        realmFrom,
-                        realmTo,
-                        variant,
-                        bonusKey,
-                        modifierKey,
-                        petSpeciesId,
-                    ).map { it.toHourlyPoint() }
-            }
-
-        val hourlyCommodity =
-            if (loadCommodity) {
-                detailRepository
-                    .loadHourlySeries(
-                        context.commoditySnapshot.connectedRealmId,
-                        itemId,
-                        commodityFrom,
-                        commodityTo,
-                        variant,
-                        bonusKey,
-                        modifierKey,
-                        petSpeciesId,
-                    ).map { it.toHourlyPoint() }
-            } else {
-                emptyList()
-            }
-
-        val pieRealm =
-            if (loadCommodity) {
-                emptyList()
-            } else {
-                detailRepository.loadQuantityPie(
-                    context.selectedSnapshot.connectedRealmId,
-                    itemId,
-                    context.selectedSnapshot.date,
-                    variant,
-                    bonusKey,
-                    modifierKey,
-                    petSpeciesId,
-                ).map { it.toPieSlice() }
-            }
-
-        val pieCommodity =
-            if (loadCommodity) {
-                detailRepository
-                    .loadQuantityPie(
-                        context.commoditySnapshot.connectedRealmId,
-                        itemId,
-                        context.commoditySnapshot.date,
-                        variant,
-                        bonusKey,
-                        modifierKey,
-                        petSpeciesId,
-                    ).map { it.toPieSlice() }
-            } else {
-                emptyList()
-            }
-
-        val (selPrice, selQty) =
-            if (loadCommodity) {
-                null to null
-            } else {
-                detailRepository.loadSnapshotPriceQuantity(
-                    context.selectedSnapshot.connectedRealmId,
-                    itemId,
-                    context.selectedSnapshot.date,
-                    context.selectedSnapshot.hour,
-                    variant,
-                    bonusKey,
-                    modifierKey,
-                    petSpeciesId,
-                )
-            }
-
-        val (comPrice, comQty) =
-            if (loadCommodity) {
-                detailRepository.loadSnapshotPriceQuantity(
-                    context.commoditySnapshot.connectedRealmId,
-                    itemId,
-                    context.commoditySnapshot.date,
-                    context.commoditySnapshot.hour,
-                    variant,
-                    bonusKey,
-                    modifierKey,
-                    petSpeciesId,
-                )
-            } else {
-                null to null
-            }
+        val header =
+            repositoryRows.header
+                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Item not found: $itemId")
+        val dailyRealm = repositoryRows.dailyRealm.map { it.toDetailPoint() }
+        val dailyCommodity = repositoryRows.dailyCommodity.map { it.toDetailPoint() }
+        val hourlyRealm = repositoryRows.hourlyRealm.map { it.toHourlyPoint() }
+        val hourlyCommodity = repositoryRows.hourlyCommodity.map { it.toHourlyPoint() }
+        val pieRealm = repositoryRows.pieRealm.map { it.toPieSlice() }
+        val pieCommodity = repositoryRows.pieCommodity.map { it.toPieSlice() }
+        val (selPrice, selQty) = repositoryRows.selectedSnapshot
+        val (comPrice, comQty) = repositoryRows.commoditySnapshot
 
         val selectedMetrics =
             AuctionMarketMetrics(
@@ -233,34 +365,8 @@ class AuctionMarketItemDetailService(
                 regionalMetricsRedundant = redundant,
             )
 
-        val craftingRows =
-            detailRepository.loadCraftings(
-                context.selectedSnapshot.connectedRealmId,
-                context.commoditySnapshot.connectedRealmId,
-                itemId,
-                context.selectedSnapshot.date,
-                context.commoditySnapshot.date,
-                context.selectedSnapshot.hour,
-                context.commoditySnapshot.hour,
-                variant,
-                bonusKey,
-                modifierKey,
-                petSpeciesId,
-                preferredRecipeId,
-                localeSuffix,
-            )
-        val reagentRows =
-            detailRepository
-                .loadCraftingReagents(
-                    context.selectedSnapshot.connectedRealmId,
-                    context.commoditySnapshot.connectedRealmId,
-                    craftingRows.map { it.recipeId },
-                    context.selectedSnapshot.date,
-                    context.commoditySnapshot.date,
-                    context.selectedSnapshot.hour,
-                    context.commoditySnapshot.hour,
-                    localeSuffix,
-                ).groupBy { it.recipeId }
+        val craftingRows = repositoryRows.craftingRows
+        val reagentRows = repositoryRows.reagentRows
         val craftingDtos = craftingRows.map { it.toCraftingDetailDto(reagentRows[it.recipeId].orEmpty()) }
         val craftingDto = craftingRows.firstOrNull()?.toCraftingDto()
 
@@ -279,6 +385,7 @@ class AuctionMarketItemDetailService(
             hourlySeriesCommodity = hourlyCommodity,
             quantityPieRealm = pieRealm,
             quantityPieCommodity = pieCommodity,
+            currentListings = repositoryRows.currentListings.map { it.toCurrentListingDto() },
             crafting = craftingDto,
             craftings = craftingDtos,
         )
@@ -422,6 +529,12 @@ class AuctionMarketItemDetailService(
             quantity = quantity,
         )
 
+    private fun AuctionMarketItemCurrentListingRow.toCurrentListingDto(): AuctionMarketItemCurrentListing =
+        AuctionMarketItemCurrentListing(
+            price = price,
+            quantity = quantity,
+        )
+
     fun craftingAnalytics(
         regionCode: String,
         realmSlug: String,
@@ -540,4 +653,26 @@ class AuctionMarketItemDetailService(
             roiPercent = roiPercent,
             sampleCount = sampleCount,
         )
+
+    private suspend fun <T> withAuctionMdc(
+        mdc: Map<String, String>?,
+        block: () -> T,
+    ): T =
+        withContext(Dispatchers.IO) {
+            val previous = MDC.getCopyOfContextMap()
+            try {
+                if (mdc != null) {
+                    MDC.setContextMap(mdc)
+                } else {
+                    MDC.clear()
+                }
+                block()
+            } finally {
+                if (previous != null) {
+                    MDC.setContextMap(previous)
+                } else {
+                    MDC.clear()
+                }
+            }
+        }
 }

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/service/AuctionSnapshotPersistenceService.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/service/AuctionSnapshotPersistenceService.kt
@@ -58,6 +58,8 @@ class AuctionSnapshotPersistenceService(
         auctions.forEach { uniqueAuctionItem ->
             val value = uniqueAuctionItem.value
             val auction = value.first().toDBO(connectedRealm, updateHistory)
+            auction.quantity = 0 // Resetting, so that we don't include the initial value as we summerize below
+
             val prices =
                 uniqueAuctionItem.value
                     .map { auctionItem ->
@@ -66,6 +68,7 @@ class AuctionSnapshotPersistenceService(
                         }
                         val priceItem = auctionItem.toAuctionPriceDBO(updateHistory.lastModified?.toInstant())
                         priceItem.auction = auction
+                        auction.quantity += auctionItem.quantity
                         priceItem
                     }
             val pricedEntries = prices.filter { it.buyout != null }.sortedBy { it.buyout }
@@ -81,7 +84,6 @@ class AuctionSnapshotPersistenceService(
                 auction.p25 = null
                 auction.p75 = null
             }
-
             auctionBatches.add(auction)
             priceBatches.addAll(prices)
         }

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketItemDetailQueryPlanIntegrationTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketItemDetailQueryPlanIntegrationTest.kt
@@ -64,6 +64,15 @@ class AuctionMarketItemDetailQueryPlanIntegrationTest : IntegrationTestBase() {
                 modifierKey = "",
                 petSpeciesId = 0,
             )
+        val (currentListings, currentListingsArgs) =
+            repository.buildCurrentListingsSqlAndArgs(
+                connectedRealmId = 1084,
+                itemId = 19019,
+                variant = false,
+                bonusKey = "",
+                modifierKey = "",
+                petSpeciesId = 0,
+            )
         val (craft, craftArgs) =
             repository.buildCraftingSqlAndArgs(
                 connectedRealmId = 1084,
@@ -85,6 +94,7 @@ class AuctionMarketItemDetailQueryPlanIntegrationTest : IntegrationTestBase() {
         assertTrue(jdbcTemplate.queryForList("EXPLAIN $dailyVar", *dailyVarArgs).isNotEmpty())
         assertTrue(jdbcTemplate.queryForList("EXPLAIN $hourly", *hourlyArgs).isNotEmpty())
         assertTrue(jdbcTemplate.queryForList("EXPLAIN $pie", *pieArgs).isNotEmpty())
+        assertTrue(jdbcTemplate.queryForList("EXPLAIN $currentListings", *currentListingsArgs).isNotEmpty())
         assertTrue(jdbcTemplate.queryForList("EXPLAIN $craft", *craftArgs).isNotEmpty())
     }
 }

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/service/AuctionMarketItemDetailServiceTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/service/AuctionMarketItemDetailServiceTest.kt
@@ -101,6 +101,79 @@ class AuctionMarketItemDetailServiceTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `item detail exposes current realm listings from latest auction price rows`() {
+        MarketSearchTestFixtures.seedMarketSearchData(jdbcTemplate)
+
+        val detail =
+            service.itemDetail(
+                regionCode = "eu",
+                realmSlug = "argent-dawn",
+                itemId = 19019,
+                bonusKey = "",
+                modifierKey = "",
+                petSpeciesId = 0,
+                scope = "realm",
+                localeOverride = null,
+            )
+
+        assertEquals(listOf(950L, 1_200L), detail.currentListings.map { it.price })
+        assertEquals(listOf(1, 3), detail.currentListings.map { it.quantity })
+    }
+
+    @Test
+    fun `commodity scope item detail exposes current commodity listings`() {
+        MarketSearchTestFixtures.seedMarketSearchData(jdbcTemplate)
+
+        val detail =
+            service.itemDetail(
+                regionCode = "eu",
+                realmSlug = "argent-dawn",
+                itemId = 19019,
+                bonusKey = "",
+                modifierKey = "",
+                petSpeciesId = 0,
+                scope = "commodity",
+                localeOverride = null,
+            )
+
+        assertEquals(listOf(880L, 930L), detail.currentListings.map { it.price })
+        assertEquals(listOf(3, 5), detail.currentListings.map { it.quantity })
+    }
+
+    @Test
+    fun `item detail current listings filter variants only when variant key is explicit`() {
+        MarketSearchTestFixtures.seedMarketSearchData(jdbcTemplate)
+        addVariantCurrentListingForHealingPotion()
+
+        val rollup =
+            service.itemDetail(
+                regionCode = "eu",
+                realmSlug = "argent-dawn",
+                itemId = 19019,
+                bonusKey = "",
+                modifierKey = "",
+                petSpeciesId = 0,
+                scope = "realm",
+                localeOverride = null,
+            )
+        val variant =
+            service.itemDetail(
+                regionCode = "eu",
+                realmSlug = "argent-dawn",
+                itemId = 19019,
+                bonusKey = "bonus-a",
+                modifierKey = "mod-a",
+                petSpeciesId = 123,
+                scope = "realm",
+                localeOverride = null,
+            )
+
+        assertEquals(listOf(950L, 1_200L, 2_222L), rollup.currentListings.map { it.price })
+        assertEquals(listOf(2_222L), variant.currentListings.map { it.price })
+        assertEquals(7, variant.currentListings.single().quantity)
+    }
+
+    @Test
     fun `item detail falls back to commodity reagent price`() {
         MarketSearchTestFixtures.seedMarketSearchData(jdbcTemplate)
         MarketSearchTestFixtures.augmentMarketSearchDataForCrafting(jdbcTemplate)
@@ -395,6 +468,65 @@ class AuctionMarketItemDetailServiceTest : IntegrationTestBase() {
             INSERT INTO auction_stats_hourly (
                 connected_realm_id, item_id, date, pet_species_id, modifier_key, bonus_key, price10, quantity10
             ) VALUES (-2, 19199, '2026-05-01', -1, '', '', 145, 30)
+            """.trimIndent(),
+        )
+    }
+
+    private fun addVariantCurrentListingForHealingPotion() {
+        jdbcTemplate.update(
+            """
+            INSERT INTO auction (
+                id,
+                connected_realm_id,
+                item_id,
+                context,
+                pet_breed_id,
+                pet_species_id,
+                pet_quality_id,
+                pet_level,
+                modifier_key,
+                bonus_key,
+                buyout,
+                bid,
+                p25,
+                p75,
+                quantity,
+                first_seen,
+                last_seen,
+                update_history_id
+            ) VALUES (
+                '1084-current-19019-variant',
+                1084,
+                19019,
+                NULL,
+                NULL,
+                123,
+                NULL,
+                NULL,
+                'mod-a',
+                'bonus-a',
+                2222,
+                NULL,
+                2222,
+                2222,
+                7,
+                '2026-05-01 11:15:00',
+                '2026-05-01 11:15:00',
+                1001
+            )
+            """.trimIndent(),
+        )
+        jdbcTemplate.update(
+            """
+            INSERT INTO auction_price (
+                id,
+                auction_id,
+                buyout,
+                bid,
+                quantity,
+                last_modified,
+                update_history_id
+            ) VALUES (10000005, '1084-current-19019-variant', 2222, NULL, 7, '2026-05-01 11:15:00', 1001)
             """.trimIndent(),
         )
     }

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/service/AuctionSnapshotPersistenceServiceTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/service/AuctionSnapshotPersistenceServiceTest.kt
@@ -155,6 +155,7 @@ class AuctionSnapshotPersistenceServiceTest : IntegrationTestBase() {
             assertEquals(5, firstItem.bid)
             assertEquals(2, firstItem.p25)
             assertEquals(4, firstItem.p75)
+            assertEquals(52, firstItem.quantity)
             assertNull(onlyBidItem.buyout)
             assertEquals(50, onlyBidItem.bid)
             assertNull(onlyBidItem.p25)

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/testsupport/MarketSearchTestFixtures.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/testsupport/MarketSearchTestFixtures.kt
@@ -74,6 +74,42 @@ object MarketSearchTestFixtures {
             lastSeen = "2026-05-01 11:15:00",
             updateHistoryId = 1_001,
         )
+        insertAuctionPrice(
+            jdbcTemplate,
+            id = 10_000_001,
+            auctionId = "1084-old-19019",
+            buyout = 777,
+            quantity = 1,
+            lastModified = "2026-04-30 11:15:00",
+            updateHistoryId = 1_000,
+        )
+        insertAuctionPrice(
+            jdbcTemplate,
+            id = 10_000_002,
+            auctionId = "1084-current-19019",
+            buyout = 1_200,
+            quantity = 3,
+            lastModified = "2026-05-01 11:15:00",
+            updateHistoryId = 1_001,
+        )
+        insertAuctionPrice(
+            jdbcTemplate,
+            id = 10_000_003,
+            auctionId = "1084-current-19019",
+            buyout = 950,
+            quantity = 1,
+            lastModified = "2026-05-01 11:15:00",
+            updateHistoryId = 1_001,
+        )
+        insertAuctionPrice(
+            jdbcTemplate,
+            id = 10_000_004,
+            auctionId = "1084-current-19019",
+            buyout = 500,
+            quantity = 99,
+            lastModified = "2026-04-30 11:15:00",
+            updateHistoryId = 1_000,
+        )
         insertAuction(
             jdbcTemplate,
             id = "-2-old-19019",
@@ -94,6 +130,33 @@ object MarketSearchTestFixtures {
             p75 = 950,
             quantity = 8,
             lastSeen = "2026-05-01 10:30:00",
+            updateHistoryId = 2_001,
+        )
+        insertAuctionPrice(
+            jdbcTemplate,
+            id = 20_000_001,
+            auctionId = "-2-old-19019",
+            buyout = 444,
+            quantity = 2,
+            lastModified = "2026-04-30 10:30:00",
+            updateHistoryId = 2_000,
+        )
+        insertAuctionPrice(
+            jdbcTemplate,
+            id = 20_000_002,
+            auctionId = "-2-current-19019",
+            buyout = 930,
+            quantity = 5,
+            lastModified = "2026-05-01 10:30:00",
+            updateHistoryId = 2_001,
+        )
+        insertAuctionPrice(
+            jdbcTemplate,
+            id = 20_000_003,
+            auctionId = "-2-current-19019",
+            buyout = 880,
+            quantity = 3,
+            lastModified = "2026-05-01 10:30:00",
             updateHistoryId = 2_001,
         )
         jdbcTemplate.update(
@@ -489,6 +552,36 @@ object MarketSearchTestFixtures {
             quantity,
             lastSeen,
             lastSeen,
+            updateHistoryId,
+        )
+    }
+
+    private fun insertAuctionPrice(
+        jdbcTemplate: JdbcTemplate,
+        id: Long,
+        auctionId: String,
+        buyout: Long,
+        quantity: Int,
+        lastModified: String,
+        updateHistoryId: Long,
+    ) {
+        jdbcTemplate.update(
+            """
+            INSERT INTO auction_price (
+                id,
+                auction_id,
+                buyout,
+                bid,
+                quantity,
+                last_modified,
+                update_history_id
+            ) VALUES (?, ?, ?, NULL, ?, ?, ?)
+            """.trimIndent(),
+            id,
+            auctionId,
+            buyout,
+            quantity,
+            lastModified,
             updateHistoryId,
         )
     }

--- a/frontend/src/app/features/market-browser/market-item-detail.helpers.ts
+++ b/frontend/src/app/features/market-browser/market-item-detail.helpers.ts
@@ -138,6 +138,7 @@ export function mergeCommodityScope(
     dailySeriesCommodity: commodity.dailySeriesCommodity,
     hourlySeriesCommodity: commodity.hourlySeriesCommodity,
     quantityPieCommodity: commodity.quantityPieCommodity,
+    currentListings: commodity.currentListings,
     marketDataSources:
       commodity.marketDataSources.length > 0
         ? commodity.marketDataSources

--- a/frontend/src/app/features/market-browser/market-item-detail.page.html
+++ b/frontend/src/app/features/market-browser/market-item-detail.page.html
@@ -227,6 +227,51 @@
       </div>
     </div>
 
+    <section class="ee-glass rounded-lg p-inner-padding">
+      <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <h2 class="ee-section-heading flex items-center gap-2 text-on-surface">
+          <ee-symbol-icon class="text-outline" name="receipt_long" />
+          <ng-container i18n="@@itemDetail.currentListings">Current listings</ng-container>
+        </h2>
+        <span class="ee-label text-outline">
+          {{ currentListingsForActiveScope().length }}
+          <ng-container i18n="@@itemDetail.listingsCount">listings</ng-container>
+        </span>
+      </div>
+
+      @if (currentListingsForActiveScope().length) {
+        <div class="overflow-x-auto">
+          <table class="w-full border-collapse ee-data text-left text-on-surface">
+            <thead>
+              <tr class="border-b border-white/10 ee-label text-outline">
+                <th class="py-2 pr-4 text-right" i18n="@@itemDetail.unitPrice">Unit price</th>
+                <th class="py-2 text-right" i18n="@@itemDetail.quantity">Quantity</th>
+              </tr>
+            </thead>
+            <tbody>
+              @for (listing of currentListingsForActiveScope(); track $index) {
+                <tr class="border-b border-white/5">
+                  <td class="py-3 pr-4 text-right tabular-nums select-text">
+                    <ee-currency-amount
+                      class="inline-flex justify-end"
+                      [amount]="listing.price | copperToCurrency"
+                    />
+                  </td>
+                  <td class="py-3 text-right tabular-nums select-text">
+                    {{ quantityLabel(listing.quantity) }}
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      } @else {
+        <p class="ee-data text-outline" i18n="@@itemDetail.noCurrentListings">
+          No current listings for this item.
+        </p>
+      }
+    </section>
+
     @if (d.craftings.length) {
       <section class="ee-glass rounded-lg p-inner-padding">
         <div class="mb-4 flex flex-wrap items-center justify-between gap-3">

--- a/frontend/src/app/features/market-browser/market-item-detail.page.html
+++ b/frontend/src/app/features/market-browser/market-item-detail.page.html
@@ -135,22 +135,6 @@
       </ng-container>
     </div>
   } @else if (detail(); as d) {
-    <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-      <ee-item-stat-card
-        [label]="activeScopePriceLabel()"
-        icon="payments"
-        [currency]="activeScopePrice(d.summary) | copperToCurrency"
-        [caption]="activeScopePriceCaption(d.summary)"
-        tone="primary"
-      />
-      <ee-item-stat-card
-        [label]="activeScopeQuantityLabel()"
-        icon="inventory_2"
-        [value]="quantityLabel(activeScopeQuantity(d.summary))"
-        [caption]="''"
-      />
-    </div>
-
     <ng-template #dailyChartTip let-ctx>
       @let rows = dailyTooltipRows(d, ctx.x);
       <ee-tooltip-card
@@ -182,95 +166,122 @@
       <div class="font-space-mono">{{ cell.label }}</div>
     </ng-template>
 
-    <div class="grid gap-4 xl:grid-cols-2 2xl:grid-cols-3">
-      <div class="min-w-0 max-w-full">
-        <ee-chart-panel
-          i18n-title="@@itemDetail.dailyMarket"
-          title="Daily market"
-          i18n-rangeLabel="@@itemDetail.range14Days"
-          rangeLabel="14 days"
-          [series]="dailyChartSeries()"
-          [options]="dailyChartOptions()"
-          [tooltipTemplate]="dailyChartTip"
-          i18n-description="@@itemDetail.dailyMarketDescription"
-          description="Average quantity per hour as bars; buyout spread and average as lines."
-        />
-      </div>
-
-      <div class="min-w-0 max-w-full">
-        <ee-chart-panel
-          i18n-title="@@itemDetail.hourlyMarket"
-          title="Hourly market"
-          i18n-rangeLabel="@@itemDetail.range14Days"
-          rangeLabel="14 days"
-          [series]="hourlyChartSeries()"
-          [options]="hourlyChartOptions()"
-          [tooltipTemplate]="hourlyChartTip"
-          i18n-description="@@itemDetail.hourlyMarketDescription"
-          description="Listed quantity per hour over 14 days as bars; buyout spread and average as lines."
-        />
-      </div>
-
-      <div class="min-w-0 max-w-full">
-        <ee-heatmap-grid
-          i18n-title="@@itemDetail.hourlyPriceHeatmap"
-          title="Hourly price heatmap"
-          i18n-rangeLabel="@@itemDetail.range14Days"
-          rangeLabel="14 days"
-          i18n-description="@@itemDetail.hourlyPriceHeatmapDescription"
-          description="Average market unit price by day and hour."
-          [rowLabels]="heatmapRowLabels"
-          [columnLabels]="heatmapColumnLabels"
-          [cells]="hourlyPriceHeatmapCells()"
-          [tooltipTemplate]="priceHeatmapTip"
-        />
-      </div>
-    </div>
-
-    <section class="ee-glass rounded-lg p-inner-padding">
-      <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
-        <h2 class="ee-section-heading flex items-center gap-2 text-on-surface">
-          <ee-symbol-icon class="text-outline" name="receipt_long" />
-          <ng-container i18n="@@itemDetail.currentListings">Current listings</ng-container>
-        </h2>
-        <span class="ee-label text-outline">
-          {{ currentListingsForActiveScope().length }}
-          <ng-container i18n="@@itemDetail.listingsCount">listings</ng-container>
-        </span>
-      </div>
-
-      @if (currentListingsForActiveScope().length) {
-        <div class="overflow-x-auto">
-          <table class="w-full border-collapse ee-data text-left text-on-surface">
-            <thead>
-              <tr class="border-b border-white/10 ee-label text-outline">
-                <th class="py-2 pr-4 text-right" i18n="@@itemDetail.unitPrice">Unit price</th>
-                <th class="py-2 text-right" i18n="@@itemDetail.quantity">Quantity</th>
-              </tr>
-            </thead>
-            <tbody>
-              @for (listing of currentListingsForActiveScope(); track $index) {
-                <tr class="border-b border-white/5">
-                  <td class="py-3 pr-4 text-right tabular-nums select-text">
-                    <ee-currency-amount
-                      class="inline-flex justify-end"
-                      [amount]="listing.price | copperToCurrency"
-                    />
-                  </td>
-                  <td class="py-3 text-right tabular-nums select-text">
-                    {{ quantityLabel(listing.quantity) }}
-                  </td>
-                </tr>
-              }
-            </tbody>
-          </table>
+    <div class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(18rem,24rem)]">
+      <div class="space-y-4 min-w-0">
+        <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-1">
+          <ee-item-stat-card
+            [label]="activeScopePriceLabel()"
+            icon="payments"
+            [currency]="activeScopePrice(d.summary) | copperToCurrency"
+            [caption]="activeScopePriceCaption(d.summary)"
+            tone="primary"
+          />
+          <ee-item-stat-card
+            [label]="activeScopeQuantityLabel()"
+            icon="inventory_2"
+            [value]="quantityLabel(activeScopeQuantity(d.summary))"
+            [caption]="''"
+          />
         </div>
-      } @else {
-        <p class="ee-data text-outline" i18n="@@itemDetail.noCurrentListings">
-          No current listings for this item.
-        </p>
-      }
-    </section>
+
+        <div class="grid gap-4 2xl:grid-cols-2">
+          <div class="min-w-0 max-w-full">
+            <ee-chart-panel
+              i18n-title="@@itemDetail.dailyMarket"
+              title="Daily market"
+              i18n-rangeLabel="@@itemDetail.range14Days"
+              rangeLabel="14 days"
+              [series]="dailyChartSeries()"
+              [options]="dailyChartOptions()"
+              [tooltipTemplate]="dailyChartTip"
+              i18n-description="@@itemDetail.dailyMarketDescription"
+              description="Average quantity per hour as bars; buyout spread and average as lines."
+            />
+          </div>
+
+          <div class="min-w-0 max-w-full">
+            <ee-chart-panel
+              i18n-title="@@itemDetail.hourlyMarket"
+              title="Hourly market"
+              i18n-rangeLabel="@@itemDetail.range14Days"
+              rangeLabel="14 days"
+              [series]="hourlyChartSeries()"
+              [options]="hourlyChartOptions()"
+              [tooltipTemplate]="hourlyChartTip"
+              i18n-description="@@itemDetail.hourlyMarketDescription"
+              description="Listed quantity per hour over 14 days as bars; buyout spread and average as lines."
+            />
+          </div>
+
+          <div class="min-w-0 max-w-full 2xl:col-span-2">
+            <ee-heatmap-grid
+              i18n-title="@@itemDetail.hourlyPriceHeatmap"
+              title="Hourly price heatmap"
+              i18n-rangeLabel="@@itemDetail.range14Days"
+              rangeLabel="14 days"
+              i18n-description="@@itemDetail.hourlyPriceHeatmapDescription"
+              description="Average market unit price by day and hour."
+              [rowLabels]="heatmapRowLabels"
+              [columnLabels]="heatmapColumnLabels"
+              [cells]="hourlyPriceHeatmapCells()"
+              [tooltipTemplate]="priceHeatmapTip"
+            />
+          </div>
+        </div>
+      </div>
+
+      <section class="ee-glass min-w-0 rounded-lg p-inner-padding xl:self-start">
+        <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <h2 class="ee-section-heading flex items-center gap-2 text-on-surface">
+            <ee-symbol-icon class="text-outline" name="receipt_long" />
+            <ng-container i18n="@@itemDetail.currentListings">Current listings</ng-container>
+          </h2>
+          <span class="ee-label text-outline">
+            {{ currentListingsForActiveScope().length }}
+            <ng-container i18n="@@itemDetail.listingsCount">listings</ng-container>
+          </span>
+        </div>
+
+        @if (currentListingsForActiveScope().length) {
+          <div class="overflow-x-auto">
+            <table class="w-full border-collapse ee-data text-left text-on-surface">
+              <thead>
+                <tr class="border-b border-white/10 ee-label text-outline">
+                  <th class="py-2 pr-4 text-right" i18n="@@itemDetail.unitPrice">Unit price</th>
+                  <th class="py-2 text-right" i18n="@@itemDetail.quantity">Quantity</th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (listing of pagedCurrentListings(); track $index) {
+                  <tr class="border-b border-white/5">
+                    <td class="py-3 pr-4 text-right tabular-nums select-text">
+                      <ee-currency-amount
+                        class="inline-flex justify-end"
+                        [amount]="listing.price | copperToCurrency"
+                      />
+                    </td>
+                    <td class="py-3 text-right tabular-nums select-text">
+                      {{ quantityLabel(listing.quantity) }}
+                    </td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+          <ee-pagination
+            class="mt-4 ee-label text-outline"
+            [pageState]="currentListingsPagination()"
+            [rowLabel]="currentListingsRowLabel"
+            [emptySummary]="currentListingsEmptySummary"
+            (pageChange)="onCurrentListingsPageChange($event)"
+          />
+        } @else {
+          <p class="ee-data text-outline" i18n="@@itemDetail.noCurrentListings">
+            No current listings for this item.
+          </p>
+        }
+      </section>
+    </div>
 
     @if (d.craftings.length) {
       <section class="ee-glass rounded-lg p-inner-padding">
@@ -438,7 +449,7 @@
             }
           </div>
         </section>
-      } @else if (craftingAnalytics(); as analytics) {
+      } @else if (craftingAnalytics()) {
         <ng-template
           #heatmapTip
           let-cell="cell"

--- a/frontend/src/app/features/market-browser/market-item-detail.page.ts
+++ b/frontend/src/app/features/market-browser/market-item-detail.page.ts
@@ -28,6 +28,7 @@ import {
 import {
   AuctionMarketItemCraftingAnalyticsResponse,
   AuctionMarketItemCraftingDetail,
+  AuctionMarketItemCurrentListing,
   AuctionMarketItemDetailPoint,
   AuctionMarketItemDetailResponse,
   AuctionMarketItemDetailSummary,
@@ -110,6 +111,10 @@ export class MarketItemDetailPage {
   protected readonly commodityLoading = signal(false);
   protected readonly error = signal(false);
   protected readonly detail = signal<AuctionMarketItemDetailResponse | null>(null);
+  protected readonly realmCurrentListings = signal<readonly AuctionMarketItemCurrentListing[]>([]);
+  protected readonly commodityCurrentListings = signal<readonly AuctionMarketItemCurrentListing[]>(
+    [],
+  );
   protected readonly commodityLoaded = signal(false);
   protected readonly chartScope = signal<'realm' | 'commodity'>('realm');
   protected readonly selectedRecipeId = signal<number | null>(null);
@@ -242,6 +247,13 @@ export class MarketItemDetailPage {
     return hourlyPriceHeatmapCellsFromPoints(points);
   });
 
+  protected readonly currentListingsForActiveScope = computed(() => {
+    if (this.chartScope() === 'commodity' && this.commodityCurrentListings().length > 0) {
+      return this.commodityCurrentListings();
+    }
+    return this.realmCurrentListings();
+  });
+
   constructor() {
     if (isPlatformBrowser(this.platformId)) {
       const raw = window.history.state as Record<string, unknown> | null;
@@ -302,6 +314,8 @@ export class MarketItemDetailPage {
           this.loading.set(true);
           this.error.set(false);
           this.commodityLoaded.set(false);
+          this.realmCurrentListings.set([]);
+          this.commodityCurrentListings.set([]);
           this.craftingAnalytics.set(null);
           this.analyticsError.set(false);
           this.selectedRecipeId.set(null);
@@ -332,6 +346,11 @@ export class MarketItemDetailPage {
       .subscribe((res) => {
         if (res) {
           this.detail.set(res);
+          if (this.chartScope() === 'commodity') {
+            this.commodityCurrentListings.set(res.currentListings);
+          } else {
+            this.realmCurrentListings.set(res.currentListings);
+          }
           this.selectedRecipeId.set(res.craftings[0]?.recipeId ?? null);
           this.loadSelectedRecipeAnalytics();
           if (shouldFallbackToCommodityFetch(res)) {
@@ -466,6 +485,7 @@ export class MarketItemDetailPage {
       .subscribe({
         next: (commodityRes) => {
           this.detail.update((existing) => mergeCommodityScope(existing, commodityRes));
+          this.commodityCurrentListings.set(commodityRes.currentListings);
           this.commodityLoaded.set(true);
           this.chartScope.set('commodity');
         },

--- a/frontend/src/app/features/market-browser/market-item-detail.page.ts
+++ b/frontend/src/app/features/market-browser/market-item-detail.page.ts
@@ -20,6 +20,8 @@ import {
   type ChartSeries,
   type HeatmapCell,
   ItemStatCardComponent,
+  PaginationComponent,
+  type PaginationState,
   PageFrameComponent,
   SymbolIconComponent,
   TooltipCardComponent,
@@ -92,6 +94,7 @@ interface ItemDetailBackState {
     HeatmapGridComponent,
     CurrencyAmountComponent,
     ItemStatCardComponent,
+    PaginationComponent,
     SymbolIconComponent,
     TooltipCardComponent,
   ],
@@ -115,6 +118,8 @@ export class MarketItemDetailPage {
   protected readonly commodityCurrentListings = signal<readonly AuctionMarketItemCurrentListing[]>(
     [],
   );
+  protected readonly currentListingsPage = signal(0);
+  protected readonly currentListingsPageSize = 10;
   protected readonly commodityLoaded = signal(false);
   protected readonly chartScope = signal<'realm' | 'commodity'>('realm');
   protected readonly selectedRecipeId = signal<number | null>(null);
@@ -145,6 +150,8 @@ export class MarketItemDetailPage {
     { index: 11, height: 66 },
   ] as const;
   protected readonly heatmapSkeletonRows = Array.from({ length: 7 }, (_, i) => i);
+  protected readonly currentListingsRowLabel = $localize`:@@itemDetail.listingsCount:listings`;
+  protected readonly currentListingsEmptySummary = $localize`:@@itemDetail.noCurrentListings:No current listings for this item.`;
 
   protected pageEyebrow(): string {
     return $localize`:@@itemDetail.eyebrow:Item Codex`;
@@ -248,10 +255,29 @@ export class MarketItemDetailPage {
   });
 
   protected readonly currentListingsForActiveScope = computed(() => {
-    if (this.chartScope() === 'commodity' && this.commodityCurrentListings().length > 0) {
+    if (this.chartScope() === 'commodity') {
       return this.commodityCurrentListings();
     }
     return this.realmCurrentListings();
+  });
+
+  protected readonly currentListingsPagination = computed<PaginationState>(() => {
+    const totalItems = this.currentListingsForActiveScope().length;
+    const totalPages = Math.ceil(totalItems / this.currentListingsPageSize);
+    const page = totalPages > 0 ? Math.min(this.currentListingsPage(), totalPages - 1) : 0;
+    return {
+      page,
+      pageSize: this.currentListingsPageSize,
+      totalItems,
+      totalPages,
+    };
+  });
+
+  protected readonly pagedCurrentListings = computed(() => {
+    const listings = this.currentListingsForActiveScope();
+    const page = this.currentListingsPagination().page;
+    const start = page * this.currentListingsPageSize;
+    return listings.slice(start, start + this.currentListingsPageSize);
   });
 
   constructor() {
@@ -316,6 +342,7 @@ export class MarketItemDetailPage {
           this.commodityLoaded.set(false);
           this.realmCurrentListings.set([]);
           this.commodityCurrentListings.set([]);
+          this.currentListingsPage.set(0);
           this.craftingAnalytics.set(null);
           this.analyticsError.set(false);
           this.selectedRecipeId.set(null);
@@ -459,10 +486,12 @@ export class MarketItemDetailPage {
   protected onScopeSelected(scope: ItemDetailScope): void {
     if (scope === 'realm') {
       this.chartScope.set('realm');
+      this.currentListingsPage.set(0);
       return;
     }
     if (this.commodityLoaded()) {
       this.chartScope.set('commodity');
+      this.currentListingsPage.set(0);
       return;
     }
     const ctx = this.routeCtx();
@@ -488,6 +517,7 @@ export class MarketItemDetailPage {
           this.commodityCurrentListings.set(commodityRes.currentListings);
           this.commodityLoaded.set(true);
           this.chartScope.set('commodity');
+          this.currentListingsPage.set(0);
         },
         error: () => {
           this.error.set(true);
@@ -512,6 +542,10 @@ export class MarketItemDetailPage {
   protected quantityLabel(q: number | null | undefined): string {
     if (q == null || !Number.isFinite(q)) return '—';
     return this.formatDecimal(Math.round(q), '1.0-0');
+  }
+
+  protected onCurrentListingsPageChange(page: number): void {
+    this.currentListingsPage.set(page);
   }
 
   protected dailyTooltipTitle(d: AuctionMarketItemDetailResponse, x: number): string {

--- a/frontend/src/locale/messages.de.xlf
+++ b/frontend/src/locale/messages.de.xlf
@@ -1142,6 +1142,22 @@
           <context context-type="linenumber">298</context>
         </context-group>
       </trans-unit>
+<trans-unit id="itemDetail.currentListings" datatype="html">
+  <source>Current listings</source>
+  <target>Current listings</target>
+</trans-unit>
+<trans-unit id="itemDetail.listingsCount" datatype="html">
+  <source>listings</source>
+  <target>listings</target>
+</trans-unit>
+<trans-unit id="itemDetail.quantity" datatype="html">
+  <source>Quantity</source>
+  <target>Quantity</target>
+</trans-unit>
+<trans-unit id="itemDetail.noCurrentListings" datatype="html">
+  <source>No current listings for this item.</source>
+  <target>No current listings for this item.</target>
+</trans-unit>
       <trans-unit id="itemDetail.reagent" datatype="html">
         <source>Reagent</source>
         <target>Reagenz</target>

--- a/frontend/src/locale/messages.es.xlf
+++ b/frontend/src/locale/messages.es.xlf
@@ -1142,6 +1142,22 @@
           <context context-type="linenumber">298</context>
         </context-group>
       </trans-unit>
+<trans-unit id="itemDetail.currentListings" datatype="html">
+  <source>Current listings</source>
+  <target>Current listings</target>
+</trans-unit>
+<trans-unit id="itemDetail.listingsCount" datatype="html">
+  <source>listings</source>
+  <target>listings</target>
+</trans-unit>
+<trans-unit id="itemDetail.quantity" datatype="html">
+  <source>Quantity</source>
+  <target>Quantity</target>
+</trans-unit>
+<trans-unit id="itemDetail.noCurrentListings" datatype="html">
+  <source>No current listings for this item.</source>
+  <target>No current listings for this item.</target>
+</trans-unit>
       <trans-unit id="itemDetail.reagent" datatype="html">
         <source>Reagent</source>
         <target>Reactivo</target>

--- a/frontend/src/locale/messages.fr.xlf
+++ b/frontend/src/locale/messages.fr.xlf
@@ -1142,6 +1142,22 @@
           <context context-type="linenumber">298</context>
         </context-group>
       </trans-unit>
+<trans-unit id="itemDetail.currentListings" datatype="html">
+  <source>Current listings</source>
+  <target>Current listings</target>
+</trans-unit>
+<trans-unit id="itemDetail.listingsCount" datatype="html">
+  <source>listings</source>
+  <target>listings</target>
+</trans-unit>
+<trans-unit id="itemDetail.quantity" datatype="html">
+  <source>Quantity</source>
+  <target>Quantity</target>
+</trans-unit>
+<trans-unit id="itemDetail.noCurrentListings" datatype="html">
+  <source>No current listings for this item.</source>
+  <target>No current listings for this item.</target>
+</trans-unit>
       <trans-unit id="itemDetail.reagent" datatype="html">
         <source>Reagent</source>
         <target>Composant</target>

--- a/frontend/src/locale/messages.it.xlf
+++ b/frontend/src/locale/messages.it.xlf
@@ -1142,6 +1142,22 @@
           <context context-type="linenumber">298</context>
         </context-group>
       </trans-unit>
+<trans-unit id="itemDetail.currentListings" datatype="html">
+  <source>Current listings</source>
+  <target>Current listings</target>
+</trans-unit>
+<trans-unit id="itemDetail.listingsCount" datatype="html">
+  <source>listings</source>
+  <target>listings</target>
+</trans-unit>
+<trans-unit id="itemDetail.quantity" datatype="html">
+  <source>Quantity</source>
+  <target>Quantity</target>
+</trans-unit>
+<trans-unit id="itemDetail.noCurrentListings" datatype="html">
+  <source>No current listings for this item.</source>
+  <target>No current listings for this item.</target>
+</trans-unit>
       <trans-unit id="itemDetail.reagent" datatype="html">
         <source>Reagent</source>
         <target>Reagent</target>

--- a/frontend/src/locale/messages.ko.xlf
+++ b/frontend/src/locale/messages.ko.xlf
@@ -1142,6 +1142,22 @@
           <context context-type="linenumber">298</context>
         </context-group>
       </trans-unit>
+<trans-unit id="itemDetail.currentListings" datatype="html">
+  <source>Current listings</source>
+  <target>Current listings</target>
+</trans-unit>
+<trans-unit id="itemDetail.listingsCount" datatype="html">
+  <source>listings</source>
+  <target>listings</target>
+</trans-unit>
+<trans-unit id="itemDetail.quantity" datatype="html">
+  <source>Quantity</source>
+  <target>Quantity</target>
+</trans-unit>
+<trans-unit id="itemDetail.noCurrentListings" datatype="html">
+  <source>No current listings for this item.</source>
+  <target>No current listings for this item.</target>
+</trans-unit>
       <trans-unit id="itemDetail.reagent" datatype="html">
         <source>Reagent</source>
         <target>Reagent</target>

--- a/frontend/src/locale/messages.pt.xlf
+++ b/frontend/src/locale/messages.pt.xlf
@@ -1142,6 +1142,22 @@
           <context context-type="linenumber">298</context>
         </context-group>
       </trans-unit>
+<trans-unit id="itemDetail.currentListings" datatype="html">
+  <source>Current listings</source>
+  <target>Current listings</target>
+</trans-unit>
+<trans-unit id="itemDetail.listingsCount" datatype="html">
+  <source>listings</source>
+  <target>listings</target>
+</trans-unit>
+<trans-unit id="itemDetail.quantity" datatype="html">
+  <source>Quantity</source>
+  <target>Quantity</target>
+</trans-unit>
+<trans-unit id="itemDetail.noCurrentListings" datatype="html">
+  <source>No current listings for this item.</source>
+  <target>No current listings for this item.</target>
+</trans-unit>
       <trans-unit id="itemDetail.reagent" datatype="html">
         <source>Reagent</source>
         <target>Reagent</target>

--- a/frontend/src/locale/messages.ru.xlf
+++ b/frontend/src/locale/messages.ru.xlf
@@ -1142,6 +1142,22 @@
           <context context-type="linenumber">298</context>
         </context-group>
       </trans-unit>
+<trans-unit id="itemDetail.currentListings" datatype="html">
+  <source>Current listings</source>
+  <target>Current listings</target>
+</trans-unit>
+<trans-unit id="itemDetail.listingsCount" datatype="html">
+  <source>listings</source>
+  <target>listings</target>
+</trans-unit>
+<trans-unit id="itemDetail.quantity" datatype="html">
+  <source>Quantity</source>
+  <target>Quantity</target>
+</trans-unit>
+<trans-unit id="itemDetail.noCurrentListings" datatype="html">
+  <source>No current listings for this item.</source>
+  <target>No current listings for this item.</target>
+</trans-unit>
       <trans-unit id="itemDetail.reagent" datatype="html">
         <source>Reagent</source>
         <target>Reagent</target>

--- a/frontend/src/locale/messages.xlf
+++ b/frontend/src/locale/messages.xlf
@@ -1071,6 +1071,22 @@
           <context context-type="linenumber">296</context>
         </context-group>
       </trans-unit>
+<trans-unit id="itemDetail.currentListings" datatype="html">
+  <source>Current listings</source>
+  <target>Current listings</target>
+</trans-unit>
+<trans-unit id="itemDetail.listingsCount" datatype="html">
+  <source>listings</source>
+  <target>listings</target>
+</trans-unit>
+<trans-unit id="itemDetail.quantity" datatype="html">
+  <source>Quantity</source>
+  <target>Quantity</target>
+</trans-unit>
+<trans-unit id="itemDetail.noCurrentListings" datatype="html">
+  <source>No current listings for this item.</source>
+  <target>No current listings for this item.</target>
+</trans-unit>
       <trans-unit id="itemDetail.reagent" datatype="html">
         <source>Reagent</source>
         <context-group purpose="location">

--- a/frontend/src/locale/messages.zh.xlf
+++ b/frontend/src/locale/messages.zh.xlf
@@ -1142,6 +1142,22 @@
           <context context-type="linenumber">298</context>
         </context-group>
       </trans-unit>
+<trans-unit id="itemDetail.currentListings" datatype="html">
+  <source>Current listings</source>
+  <target>Current listings</target>
+</trans-unit>
+<trans-unit id="itemDetail.listingsCount" datatype="html">
+  <source>listings</source>
+  <target>listings</target>
+</trans-unit>
+<trans-unit id="itemDetail.quantity" datatype="html">
+  <source>Quantity</source>
+  <target>Quantity</target>
+</trans-unit>
+<trans-unit id="itemDetail.noCurrentListings" datatype="html">
+  <source>No current listings for this item.</source>
+  <target>No current listings for this item.</target>
+</trans-unit>
       <trans-unit id="itemDetail.reagent" datatype="html">
         <source>Reagent</source>
         <target>Reagent</target>

--- a/openapi/components/schemas/auction-market-item-current-listing.yml
+++ b/openapi/components/schemas/auction-market-item-current-listing.yml
@@ -1,0 +1,11 @@
+type: object
+required:
+  - price
+  - quantity
+properties:
+  price:
+    type: integer
+    format: int64
+  quantity:
+    type: integer
+    format: int32

--- a/openapi/components/schemas/auction-market-item-detail-response.yml
+++ b/openapi/components/schemas/auction-market-item-detail-response.yml
@@ -14,6 +14,7 @@ required:
     - hourlySeriesCommodity
     - quantityPieRealm
     - quantityPieCommodity
+    - currentListings
     - craftings
 properties:
     item:
@@ -60,6 +61,10 @@ properties:
         type: array
         items:
             $ref: "../../openapi.yml#/components/schemas/AuctionMarketQuantityPieSlice"
+    currentListings:
+        type: array
+        items:
+            $ref: "../../openapi.yml#/components/schemas/AuctionMarketItemCurrentListing"
     crafting:
         $ref: "../../openapi.yml#/components/schemas/AuctionMarketItemCrafting"
         nullable: true

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -68,6 +68,8 @@ components:
       $ref: ./components/schemas/auction-market-item-crafting-heatmap-cell.yml
     AuctionMarketItemCraftingReagent:
       $ref: ./components/schemas/auction-market-item-crafting-reagent.yml
+    AuctionMarketItemCurrentListing:
+      $ref: ./components/schemas/auction-market-item-current-listing.yml
     AuctionMarketItemDetailPoint:
       $ref: ./components/schemas/auction-market-item-detail-point.yml
     AuctionMarketItemDetailResponse:


### PR DESCRIPTION
## Summary
- Include current listing prices in auction market item detail responses
- Wire the new data through backend queries, services, and API schemas
- Update the market item detail page to display current prices and refresh translations
- Fixing a miscalculation in the total number of auctions for the given item as well

## Testing
- Unit tests updated for the detail service and repository mapping
- Integration coverage added for the detail query plan