### PR TITLE
Migrates deployment to VPS Kubernetes

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -237,6 +237,7 @@ jobs:
           urls = [
               "http://localhost:4000/auth/callback",
               "http://127.0.0.1:4000/auth/callback",
+              "https://ee.jonaskf.net/auth/callback",
           ]
           if root:
               for region in data["regions"]:
@@ -256,6 +257,7 @@ jobs:
           urls = [
               "http://localhost:4000/",
               "http://127.0.0.1:4000/",
+              "https://ee.jonaskf.net/",
           ]
           if root:
               for region in data["regions"]:
@@ -350,6 +352,6 @@ jobs:
       cognito_client_id: ${{ needs.deploy-auth.outputs.cognito_client_id }}
       cognito_hosted_ui_base_url: ${{ needs.deploy-auth.outputs.cognito_hosted_ui_base_url }}
       run_infra_phase: ${{ needs.classify-changes.outputs.infra_apply_required == 'true' }}
-      run_backend_rollout: ${{ needs.classify-changes.outputs.backend_rollout_required == 'true' }}
-      run_frontend_rollout: ${{ needs.classify-changes.outputs.frontend_rollout_required == 'true' }}
+      run_backend_rollout: ${{ needs.classify-changes.outputs.backend_rollout_required == 'true' && matrix.instance_enabled == 'true' }}
+      run_frontend_rollout: ${{ needs.classify-changes.outputs.frontend_rollout_required == 'true' && matrix.instance_enabled == 'true' }}
     secrets: inherit

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -176,6 +176,7 @@ jobs:
       git_ref: ${{ needs.classify-changes.outputs.git_ref }}
       workflow_run_id: ${{ needs.classify-changes.outputs.workflow_run_id }}
       image_tag: ${{ needs.classify-changes.outputs.image_tag }}
+      image_platform: linux/arm64
       service: backend
 
   build-frontend-image:
@@ -188,6 +189,7 @@ jobs:
       git_ref: ${{ needs.classify-changes.outputs.git_ref }}
       workflow_run_id: ${{ needs.classify-changes.outputs.workflow_run_id }}
       image_tag: ${{ needs.classify-changes.outputs.image_tag }}
+      image_platform: linux/arm64
       service: frontend
 
   deploy-auth:

--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -113,6 +113,7 @@ jobs:
       git_ref: ${{ needs.classify-changes.outputs.git_ref }}
       workflow_run_id: ${{ needs.classify-changes.outputs.workflow_run_id }}
       image_tag: ${{ needs.classify-changes.outputs.image_tag }}
+      image_platform: linux/amd64
       service: backend
 
   build-frontend-image:
@@ -123,6 +124,7 @@ jobs:
       git_ref: ${{ needs.classify-changes.outputs.git_ref }}
       workflow_run_id: ${{ needs.classify-changes.outputs.workflow_run_id }}
       image_tag: ${{ needs.classify-changes.outputs.image_tag }}
+      image_platform: linux/amd64
       service: frontend
 
   deploy-vps:
@@ -277,6 +279,24 @@ jobs:
 
           kubectl -n "${APP_NAMESPACE}" create secret generic wow-auction-engine-secrets \
             "${secret_args[@]}" \
+            --dry-run=client \
+            -o yaml | kubectl apply -f -
+
+          frontend_secret_args=(
+            --from-literal=WAE_AUTH_SESSION_SECRET="${WAE_AUTH_SESSION_SECRET}"
+          )
+          frontend_optional_secret_vars=(
+            WAE_COGNITO_CLIENT_ID
+            WAE_COGNITO_HOSTED_UI_BASE_URL
+          )
+          for var_name in "${frontend_optional_secret_vars[@]}"; do
+            if [[ -n "${!var_name:-}" ]]; then
+              frontend_secret_args+=("--from-literal=${var_name}=${!var_name}")
+            fi
+          done
+
+          kubectl -n "${APP_NAMESPACE}" create secret generic wow-auction-engine-frontend-secrets \
+            "${frontend_secret_args[@]}" \
             --dry-run=client \
             -o yaml | kubectl apply -f -
 

--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -1,0 +1,312 @@
+name: Deploy VPS
+
+concurrency:
+  group: >-
+    deploy-vps-${{
+      github.event_name == 'workflow_run'
+        && github.event.workflow_run.head_sha
+        || github.sha
+    }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  APP_NAMESPACE: ee
+  BACKEND_DEPLOYMENT: ee-backend
+  FRONTEND_DEPLOYMENT: ee-frontend
+  BACKEND_CONTAINER: backend
+  FRONTEND_CONTAINER: frontend
+  APP_HOST: ee.jonaskf.net
+  HEALTH_PATH: /api/health
+
+permissions:
+  contents: read
+  actions: read
+  packages: write
+
+on:
+  workflow_run:
+    workflows:
+      - App PR Checks
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      ci_workflow_run_id:
+        description: Optional App PR Checks run id to reuse backend-war and frontend-dist artifacts.
+        required: false
+        type: string
+        default: ""
+      force_app_rollout:
+        description: Run the VPS rollout even if change classification would skip it.
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  classify-changes:
+    if: >-
+      ${{
+        (github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_branch == 'master') ||
+        (github.event_name == 'workflow_dispatch' &&
+          github.ref == 'refs/heads/master')
+      }}
+    runs-on: ubuntu-latest
+    outputs:
+      app_rollout_required: ${{ steps.classify.outputs.app_rollout_required }}
+      relevant_changed: ${{ steps.classify.outputs.relevant_changed }}
+      git_ref: ${{ steps.config.outputs.git_ref }}
+      image_tag: ${{ steps.config.outputs.image_tag }}
+      workflow_run_id: ${{ steps.config.outputs.workflow_run_id }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+          fetch-depth: 2
+
+      - name: Read workflow context
+        id: config
+        shell: bash
+        env:
+          DISPATCH_CI_RUN_ID: ${{ github.event.inputs.ci_workflow_run_id || '' }}
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            echo "git_ref=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+            echo "image_tag=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+            echo "workflow_run_id=${DISPATCH_CI_RUN_ID}" >> "$GITHUB_OUTPUT"
+          else
+            echo "git_ref=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+            echo "image_tag=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+            echo "workflow_run_id=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Classify changed files
+        id: classify
+        shell: bash
+        env:
+          FORCE_APP_ROLLOUT: ${{ github.event.inputs.force_app_rollout }}
+        run: |
+          set -euo pipefail
+          parent_sha="$(git rev-list --parents -n 1 HEAD | awk '{print $2}')"
+          if [[ -z "$parent_sha" ]]; then
+            git ls-tree -r --name-only HEAD > /tmp/changed-files.txt
+          else
+            git diff --name-only "$parent_sha" HEAD > /tmp/changed-files.txt
+          fi
+          classification="$(python3 scripts/deploy/classify_changes.py < /tmp/changed-files.txt)"
+          echo "app_rollout_required=$(python3 -c "import json,sys; print(str(json.load(sys.stdin)['app_rollout_required']).lower())" <<< "$classification")" >> "$GITHUB_OUTPUT"
+          echo "relevant_changed=$(python3 -c "import json,sys; print(str(json.load(sys.stdin)['relevant_changed']).lower())" <<< "$classification")" >> "$GITHUB_OUTPUT"
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && "${FORCE_APP_ROLLOUT:-}" == "true" ]]; then
+            echo "app_rollout_required=true" >> "$GITHUB_OUTPUT"
+            echo "relevant_changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-backend-image:
+    needs: classify-changes
+    if: ${{ needs.classify-changes.outputs.app_rollout_required == 'true' }}
+    uses: ./.github/workflows/reusable-build-image.yml
+    with:
+      git_ref: ${{ needs.classify-changes.outputs.git_ref }}
+      workflow_run_id: ${{ needs.classify-changes.outputs.workflow_run_id }}
+      image_tag: ${{ needs.classify-changes.outputs.image_tag }}
+      service: backend
+
+  build-frontend-image:
+    needs: classify-changes
+    if: ${{ needs.classify-changes.outputs.app_rollout_required == 'true' }}
+    uses: ./.github/workflows/reusable-build-image.yml
+    with:
+      git_ref: ${{ needs.classify-changes.outputs.git_ref }}
+      workflow_run_id: ${{ needs.classify-changes.outputs.workflow_run_id }}
+      image_tag: ${{ needs.classify-changes.outputs.image_tag }}
+      service: frontend
+
+  deploy-vps:
+    needs:
+      - classify-changes
+      - build-backend-image
+      - build-frontend-image
+    if: ${{ always() && needs.classify-changes.outputs.app_rollout_required == 'true' && !failure() && !cancelled() }}
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.classify-changes.outputs.git_ref }}
+
+      - name: Download backend image artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ needs.build-backend-image.outputs.artifact_name }}
+          path: /tmp/backend-image-artifact
+
+      - name: Download frontend image artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ needs.build-frontend-image.outputs.artifact_name }}
+          path: /tmp/frontend-image-artifact
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN || github.token }}
+
+      - name: Publish images to GHCR
+        id: images
+        shell: bash
+        env:
+          BACKEND_ARTIFACT_NAME: ${{ needs.build-backend-image.outputs.artifact_name }}
+          FRONTEND_ARTIFACT_NAME: ${{ needs.build-frontend-image.outputs.artifact_name }}
+          IMAGE_TAG: ${{ needs.classify-changes.outputs.image_tag }}
+        run: |
+          set -euo pipefail
+          image_prefix="ghcr.io/${GITHUB_REPOSITORY,,}"
+          backend_image="${image_prefix}/backend:${IMAGE_TAG}"
+          frontend_image="${image_prefix}/frontend:${IMAGE_TAG}"
+
+          docker load --input "/tmp/backend-image-artifact/${BACKEND_ARTIFACT_NAME}.tar"
+          docker load --input "/tmp/frontend-image-artifact/${FRONTEND_ARTIFACT_NAME}.tar"
+
+          docker tag "localbuild:backend-${IMAGE_TAG}" "$backend_image"
+          docker tag "localbuild:frontend-${IMAGE_TAG}" "$frontend_image"
+          docker push "$backend_image"
+          docker push "$frontend_image"
+
+          echo "backend_image=$backend_image" >> "$GITHUB_OUTPUT"
+          echo "frontend_image=$frontend_image" >> "$GITHUB_OUTPUT"
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubeconfig
+        shell: bash
+        env:
+          KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$KUBECONFIG_B64" ]]; then
+            echo "Missing KUBECONFIG_B64 secret" >&2
+            exit 1
+          fi
+          mkdir -p "${HOME}/.kube"
+          printf '%s' "$KUBECONFIG_B64" | base64 -d > "${HOME}/.kube/config"
+          chmod 600 "${HOME}/.kube/config"
+          kubectl cluster-info
+
+      - name: Apply manifests and runtime secret
+        shell: bash
+        env:
+          BLIZZARD_CLIENT_ID: ${{ secrets.PROD_BLIZZARD_CLIENT_ID }}
+          BLIZZARD_CLIENT_SECRET: ${{ secrets.PROD_BLIZZARD_CLIENT_SECRET }}
+          AUCTION_ENGINE_DB_URL: ${{ secrets.PROD_AUCTION_ENGINE_DB_URL }}
+          AUCTION_ENGINE_DB_USERNAME: ${{ secrets.PROD_AUCTION_ENGINE_DB_USERNAME }}
+          AUCTION_ENGINE_DB_PASSWORD: ${{ secrets.PROD_AUCTION_ENGINE_DB_PASSWORD }}
+          WAE_AUTH_SESSION_SECRET: ${{ secrets.PROD_AUTH_SESSION_SECRET }}
+          AWS_ACCESS_KEY: ${{ secrets.PROD_AWS_ACCESS_KEY }}
+          AWS_SECRET_KEY: ${{ secrets.PROD_AWS_SECRET_KEY }}
+          WAE_DYNAMODB_ENDPOINT: ${{ secrets.PROD_WAE_DYNAMODB_ENDPOINT }}
+          WAE_S3_ENDPOINT: ${{ secrets.PROD_WAE_S3_ENDPOINT }}
+          WAE_COGNITO_ISSUER_URI: ${{ secrets.PROD_COGNITO_ISSUER_URI }}
+          WAE_COGNITO_CLIENT_ID: ${{ secrets.PROD_COGNITO_CLIENT_ID }}
+          WAE_COGNITO_HOSTED_UI_BASE_URL: ${{ secrets.PROD_COGNITO_HOSTED_UI_BASE_URL }}
+          JAVA_TOOL_OPTIONS: ${{ secrets.PROD_JAVA_TOOL_OPTIONS }}
+          GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          required_vars=(
+            BLIZZARD_CLIENT_ID
+            BLIZZARD_CLIENT_SECRET
+            AUCTION_ENGINE_DB_URL
+            AUCTION_ENGINE_DB_USERNAME
+            AUCTION_ENGINE_DB_PASSWORD
+            WAE_AUTH_SESSION_SECRET
+          )
+          for var_name in "${required_vars[@]}"; do
+            if [[ -z "${!var_name:-}" ]]; then
+              echo "Missing required secret-backed env: ${var_name}" >&2
+              exit 1
+            fi
+          done
+
+          kubectl apply -f infra/kubernetes/vps/namespace.yaml
+          kubectl apply -f infra/kubernetes/vps
+
+          if [[ -n "${GITHUB_PERSONAL_ACCESS_TOKEN:-}" ]]; then
+            kubectl -n "${APP_NAMESPACE}" create secret docker-registry ghcr \
+              --docker-server=ghcr.io \
+              --docker-username="${GITHUB_ACTOR}" \
+              --docker-password="${GITHUB_PERSONAL_ACCESS_TOKEN}" \
+              --docker-email="${GITHUB_ACTOR}@users.noreply.github.com" \
+              --dry-run=client \
+              -o yaml | kubectl apply -f -
+          fi
+
+          secret_args=(
+            --from-literal=BLIZZARD_CLIENT_ID="${BLIZZARD_CLIENT_ID}"
+            --from-literal=BLIZZARD_CLIENT_SECRET="${BLIZZARD_CLIENT_SECRET}"
+            --from-literal=AUCTION_ENGINE_DB_URL="${AUCTION_ENGINE_DB_URL}"
+            --from-literal=AUCTION_ENGINE_DB_USERNAME="${AUCTION_ENGINE_DB_USERNAME}"
+            --from-literal=AUCTION_ENGINE_DB_PASSWORD="${AUCTION_ENGINE_DB_PASSWORD}"
+            --from-literal=WAE_AUTH_SESSION_SECRET="${WAE_AUTH_SESSION_SECRET}"
+          )
+          optional_secret_vars=(
+            AWS_ACCESS_KEY
+            AWS_SECRET_KEY
+            WAE_DYNAMODB_ENDPOINT
+            WAE_S3_ENDPOINT
+            WAE_COGNITO_ISSUER_URI
+            WAE_COGNITO_CLIENT_ID
+            WAE_COGNITO_HOSTED_UI_BASE_URL
+            JAVA_TOOL_OPTIONS
+          )
+          for var_name in "${optional_secret_vars[@]}"; do
+            if [[ -n "${!var_name:-}" ]]; then
+              secret_args+=("--from-literal=${var_name}=${!var_name}")
+            fi
+          done
+
+          kubectl -n "${APP_NAMESPACE}" create secret generic wow-auction-engine-secrets \
+            "${secret_args[@]}" \
+            --dry-run=client \
+            -o yaml | kubectl apply -f -
+
+      - name: Update deployments
+        shell: bash
+        env:
+          BACKEND_IMAGE: ${{ steps.images.outputs.backend_image }}
+          FRONTEND_IMAGE: ${{ steps.images.outputs.frontend_image }}
+        run: |
+          set -euo pipefail
+          kubectl -n "${APP_NAMESPACE}" set image "deployment/${BACKEND_DEPLOYMENT}" \
+            "${BACKEND_CONTAINER}=${BACKEND_IMAGE}"
+          kubectl -n "${APP_NAMESPACE}" set image "deployment/${FRONTEND_DEPLOYMENT}" \
+            "${FRONTEND_CONTAINER}=${FRONTEND_IMAGE}"
+          kubectl -n "${APP_NAMESPACE}" rollout status "deployment/${BACKEND_DEPLOYMENT}" --timeout=300s
+          kubectl -n "${APP_NAMESPACE}" rollout status "deployment/${FRONTEND_DEPLOYMENT}" --timeout=180s
+
+      - name: Verify public endpoints
+        shell: bash
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 30); do
+            if curl --fail --silent --show-error --connect-timeout 5 --max-time 10 "https://${APP_HOST}/" >/dev/null; then
+              break
+            fi
+            sleep 10
+          done
+          curl --fail --silent --show-error --connect-timeout 5 --max-time 10 "https://${APP_HOST}/" >/dev/null
+
+          for _ in $(seq 1 30); do
+            if curl --fail --silent --show-error --connect-timeout 5 --max-time 10 "https://${APP_HOST}${HEALTH_PATH}" >/dev/null; then
+              break
+            fi
+            sleep 10
+          done
+          curl --fail --silent --show-error --connect-timeout 5 --max-time 10 "https://${APP_HOST}${HEALTH_PATH}" >/dev/null

--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -156,7 +156,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN || github.token }}
+          password: ${{ secrets.PROD_GHCR_PULL_TOKEN || github.token }}
 
       - name: Publish images to GHCR
         id: images
@@ -216,8 +216,9 @@ jobs:
           WAE_COGNITO_ISSUER_URI: ${{ secrets.PROD_COGNITO_ISSUER_URI }}
           WAE_COGNITO_CLIENT_ID: ${{ secrets.PROD_COGNITO_CLIENT_ID }}
           WAE_COGNITO_HOSTED_UI_BASE_URL: ${{ secrets.PROD_COGNITO_HOSTED_UI_BASE_URL }}
+          WAE_COGNITO_USER_POOL_ID: ${{ secrets.PROD_COGNITO_USER_POOL_ID }}
           JAVA_TOOL_OPTIONS: ${{ secrets.PROD_JAVA_TOOL_OPTIONS }}
-          GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
+          GHCR_PULL_TOKEN: ${{ secrets.PROD_GHCR_PULL_TOKEN }}
         run: |
           set -euo pipefail
           required_vars=(
@@ -227,6 +228,7 @@ jobs:
             AUCTION_ENGINE_DB_USERNAME
             AUCTION_ENGINE_DB_PASSWORD
             WAE_AUTH_SESSION_SECRET
+            GHCR_PULL_TOKEN
           )
           for var_name in "${required_vars[@]}"; do
             if [[ -z "${!var_name:-}" ]]; then
@@ -238,11 +240,11 @@ jobs:
           kubectl apply -f infra/kubernetes/vps/namespace.yaml
           kubectl apply -f infra/kubernetes/vps
 
-          if [[ -n "${GITHUB_PERSONAL_ACCESS_TOKEN:-}" ]]; then
+          if [[ -n "${GHCR_PULL_TOKEN:-}" ]]; then
             kubectl -n "${APP_NAMESPACE}" create secret docker-registry ghcr \
               --docker-server=ghcr.io \
               --docker-username="${GITHUB_ACTOR}" \
-              --docker-password="${GITHUB_PERSONAL_ACCESS_TOKEN}" \
+              --docker-password="${GHCR_PULL_TOKEN}" \
               --docker-email="${GITHUB_ACTOR}@users.noreply.github.com" \
               --dry-run=client \
               -o yaml | kubectl apply -f -
@@ -264,6 +266,7 @@ jobs:
             WAE_COGNITO_ISSUER_URI
             WAE_COGNITO_CLIENT_ID
             WAE_COGNITO_HOSTED_UI_BASE_URL
+            WAE_COGNITO_USER_POOL_ID
             JAVA_TOOL_OPTIONS
           )
           for var_name in "${optional_secret_vars[@]}"; do

--- a/.github/workflows/manual-infra-sync.yml
+++ b/.github/workflows/manual-infra-sync.yml
@@ -114,6 +114,7 @@ jobs:
       git_ref: ${{ needs.load-regions.outputs.git_ref }}
       workflow_run_id: ""
       image_tag: ${{ needs.load-regions.outputs.git_ref }}
+      image_platform: linux/arm64
       service: backend
 
   build-frontend-image:
@@ -124,6 +125,7 @@ jobs:
       git_ref: ${{ needs.load-regions.outputs.git_ref }}
       workflow_run_id: ""
       image_tag: ${{ needs.load-regions.outputs.git_ref }}
+      image_platform: linux/arm64
       service: frontend
 
   deploy-auth:

--- a/.github/workflows/manual-infra-sync.yml
+++ b/.github/workflows/manual-infra-sync.yml
@@ -170,6 +170,7 @@ jobs:
           urls = [
               "http://localhost:4000/auth/callback",
               "http://127.0.0.1:4000/auth/callback",
+              "https://ee.jonaskf.net/auth/callback",
           ]
           if root:
               urls.extend(
@@ -191,6 +192,7 @@ jobs:
           urls = [
               "http://localhost:4000/",
               "http://127.0.0.1:4000/",
+              "https://ee.jonaskf.net/",
           ]
           if root:
               urls.extend(
@@ -281,6 +283,6 @@ jobs:
       cognito_client_id: ${{ needs.deploy-auth.outputs.cognito_client_id }}
       cognito_hosted_ui_base_url: ${{ needs.deploy-auth.outputs.cognito_hosted_ui_base_url }}
       run_infra_phase: true
-      run_backend_rollout: ${{ inputs.run_app_rollout }}
-      run_frontend_rollout: ${{ inputs.run_app_rollout }}
+      run_backend_rollout: ${{ inputs.run_app_rollout && matrix.instance_enabled == 'true' }}
+      run_frontend_rollout: ${{ inputs.run_app_rollout && matrix.instance_enabled == 'true' }}
     secrets: inherit

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -22,6 +22,10 @@ on:
       service:
         required: true
         type: string
+      image_platform:
+        required: false
+        type: string
+        default: linux/amd64
     outputs:
       artifact_name:
         description: Uploaded Docker image artifact name
@@ -99,19 +103,19 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           WORKFLOW_RUN_ID: ${{ inputs.workflow_run_id }}
 
-      - name: Build ARM64 Docker image
+      - name: Build Docker image
         shell: bash
         run: |
           set -euo pipefail
           if [[ "$SERVICE" == "backend" ]]; then
             docker buildx build \
-              --platform linux/arm64 \
+              --platform "${IMAGE_PLATFORM}" \
               --tag "localbuild:${SERVICE}-${IMAGE_TAG}" \
               --load \
               backend
           elif [[ "$SERVICE" == "frontend" ]]; then
             docker buildx build \
-              --platform linux/arm64 \
+              --platform "${IMAGE_PLATFORM}" \
               --file frontend/Dockerfile \
               --tag "localbuild:${SERVICE}-${IMAGE_TAG}" \
               --load \
@@ -122,6 +126,7 @@ jobs:
           fi
         env:
           IMAGE_TAG: ${{ inputs.image_tag }}
+          IMAGE_PLATFORM: ${{ inputs.image_platform }}
           SERVICE: ${{ inputs.service }}
 
       - name: Export Docker image artifact

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/schedules/BlizzardMediaBackfillSchedule.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/schedules/BlizzardMediaBackfillSchedule.kt
@@ -1,7 +1,6 @@
 package net.jonasmf.auctionengine.schedules
 
 import net.jonasmf.auctionengine.config.BlizzardApiProperties
-import net.jonasmf.auctionengine.config.WaeS3Properties
 import net.jonasmf.auctionengine.service.BlizzardMediaBackfillService
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -12,10 +11,9 @@ import java.util.concurrent.atomic.AtomicBoolean
 @Component
 class BlizzardMediaBackfillSchedule(
     private val properties: BlizzardApiProperties,
-    private val s3Properties: WaeS3Properties,
     private val blizzardMediaBackfillService: BlizzardMediaBackfillService,
-    @Value("\${spring.cloud.aws.region.static}")
-    private val deploymentAwsRegion: String,
+    @Value("\${app.scheduling.static-data-sync-enabled:true}")
+    private val staticDataSyncEnabled: Boolean,
 ) {
     private val log = LoggerFactory.getLogger(BlizzardMediaBackfillSchedule::class.java)
     private val backfillRunning = AtomicBoolean(false)
@@ -25,7 +23,7 @@ class BlizzardMediaBackfillSchedule(
         zone = "\${app.scheduling.media-backfill-zone:GMT+1}",
     )
     fun backfillMediaOnSchedule() {
-        if (!shouldRunInCurrentDeploymentRegion("scheduled")) return
+        if (!shouldRunStaticDataSync("scheduled")) return
         runBackfill("scheduled")
     }
 
@@ -34,7 +32,7 @@ class BlizzardMediaBackfillSchedule(
         fixedDelayString = "\${app.scheduling.media-backfill-startup-repeat-delay:P3650D}",
     )
     fun backfillMediaAfterStartup() {
-        if (!shouldRunInCurrentDeploymentRegion("startup")) return
+        if (!shouldRunStaticDataSync("startup")) return
         runBackfill("startup")
     }
 
@@ -42,15 +40,11 @@ class BlizzardMediaBackfillSchedule(
         runBackfill("manual")
     }
 
-    private fun shouldRunInCurrentDeploymentRegion(trigger: String): Boolean {
-        val expectedAwsRegion = s3Properties.bucketFor(properties.staticDataRegion).bucketRegion
-        if (deploymentAwsRegion != expectedAwsRegion) {
+    private fun shouldRunStaticDataSync(trigger: String): Boolean {
+        if (!staticDataSyncEnabled) {
             log.info(
-                "Skipping {} media backfill because deployment AWS region {} does not match static data region {} bucket region {}.",
+                "Skipping {} media backfill because static data sync is disabled for this deployment.",
                 trigger,
-                deploymentAwsRegion,
-                properties.staticDataRegion,
-                expectedAwsRegion,
             )
             return false
         }

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/schedules/ItemSchedule.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/schedules/ItemSchedule.kt
@@ -1,7 +1,6 @@
 package net.jonasmf.auctionengine.schedules
 
 import net.jonasmf.auctionengine.config.BlizzardApiProperties
-import net.jonasmf.auctionengine.config.WaeS3Properties
 import net.jonasmf.auctionengine.service.ItemSyncService
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -12,10 +11,9 @@ import java.util.concurrent.atomic.AtomicBoolean
 @Component
 class ItemSchedule(
     private val properties: BlizzardApiProperties,
-    private val s3Properties: WaeS3Properties,
     private val itemSyncService: ItemSyncService,
-    @Value("\${spring.cloud.aws.region.static}")
-    private val deploymentAwsRegion: String,
+    @Value("\${app.scheduling.static-data-sync-enabled:true}")
+    private val staticDataSyncEnabled: Boolean,
 ) {
     private val log = LoggerFactory.getLogger(ItemSchedule::class.java)
     private val syncRunning = AtomicBoolean(false)
@@ -25,7 +23,7 @@ class ItemSchedule(
         zone = "\${app.scheduling.item-sync-zone:GMT+1}",
     )
     fun syncItemsOnSchedule() {
-        if (!shouldRunInCurrentDeploymentRegion("scheduled")) return
+        if (!shouldRunStaticDataSync("scheduled")) return
         runSync("scheduled")
     }
 
@@ -34,7 +32,7 @@ class ItemSchedule(
         fixedDelayString = "\${app.scheduling.item-sync-startup-repeat-delay:P3650D}",
     )
     fun syncItemsAfterStartup() {
-        if (!shouldRunInCurrentDeploymentRegion("startup")) return
+        if (!shouldRunStaticDataSync("startup")) return
         runSync("startup")
     }
 
@@ -42,15 +40,11 @@ class ItemSchedule(
         runSync("manual")
     }
 
-    private fun shouldRunInCurrentDeploymentRegion(trigger: String): Boolean {
-        val expectedAwsRegion = s3Properties.bucketFor(properties.staticDataRegion).bucketRegion
-        if (deploymentAwsRegion != expectedAwsRegion) {
+    private fun shouldRunStaticDataSync(trigger: String): Boolean {
+        if (!staticDataSyncEnabled) {
             log.info(
-                "Skipping {} item sync because deployment AWS region {} does not match static data region {} bucket region {}.",
+                "Skipping {} item sync because static data sync is disabled for this deployment.",
                 trigger,
-                deploymentAwsRegion,
-                properties.staticDataRegion,
-                expectedAwsRegion,
             )
             return false
         }

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/schedules/ProfessionRecipeSchedule.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/schedules/ProfessionRecipeSchedule.kt
@@ -1,7 +1,6 @@
 package net.jonasmf.auctionengine.schedules
 
 import net.jonasmf.auctionengine.config.BlizzardApiProperties
-import net.jonasmf.auctionengine.config.WaeS3Properties
 import net.jonasmf.auctionengine.service.ProfessionRecipeSyncService
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -12,10 +11,9 @@ import java.util.concurrent.atomic.AtomicBoolean
 @Component
 class ProfessionRecipeSchedule(
     private val properties: BlizzardApiProperties,
-    private val s3Properties: WaeS3Properties,
     private val professionRecipeSyncService: ProfessionRecipeSyncService,
-    @Value("\${spring.cloud.aws.region.static}")
-    private val deploymentAwsRegion: String,
+    @Value("\${app.scheduling.static-data-sync-enabled:true}")
+    private val staticDataSyncEnabled: Boolean,
 ) {
     private val log = LoggerFactory.getLogger(ProfessionRecipeSchedule::class.java)
     private val syncRunning = AtomicBoolean(false)
@@ -25,7 +23,7 @@ class ProfessionRecipeSchedule(
         zone = "\${app.scheduling.profession-recipe-sync-zone:GMT+1}",
     )
     fun syncProfessionRecipesOnSchedule() {
-        if (!shouldRunInCurrentDeploymentRegion("scheduled")) return
+        if (!shouldRunStaticDataSync("scheduled")) return
         runSync("scheduled")
     }
 
@@ -39,7 +37,7 @@ class ProfessionRecipeSchedule(
         // fixedDelayString = "\${app.scheduling.profession-recipe-sync-startup-repeat-delay:P3650D}",
     )
     fun syncProfessionRecipesAfterStartup() {
-        if (!shouldRunInCurrentDeploymentRegion("startup")) return
+        if (!shouldRunStaticDataSync("startup")) return
         if (!professionRecipeSyncService.shouldInitiallySync()) return
         runSync("startup")
     }
@@ -48,15 +46,11 @@ class ProfessionRecipeSchedule(
         runSync("manual")
     }
 
-    private fun shouldRunInCurrentDeploymentRegion(trigger: String): Boolean {
-        val expectedAwsRegion = s3Properties.bucketFor(properties.staticDataRegion).bucketRegion
-        if (deploymentAwsRegion != expectedAwsRegion) {
+    private fun shouldRunStaticDataSync(trigger: String): Boolean {
+        if (!staticDataSyncEnabled) {
             log.info(
-                "Skipping {} profession/recipe sync because deployment AWS region {} does not match static data region {} bucket region {}.",
+                "Skipping {} profession/recipe sync because static data sync is disabled for this deployment.",
                 trigger,
-                deploymentAwsRegion,
-                properties.staticDataRegion,
-                expectedAwsRegion,
             )
             return false
         }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -43,6 +43,7 @@ server:
 app:
   scheduling:
     enabled: true
+    static-data-sync-enabled: ${WAE_STATIC_DATA_SYNC_ENABLED:true}
     initial-delay: PT30S
     item-sync-cron: "0 0 * * * *"
     item-sync-zone: GMT+1

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/schedules/BlizzardMediaBackfillScheduleTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/schedules/BlizzardMediaBackfillScheduleTest.kt
@@ -7,8 +7,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import net.jonasmf.auctionengine.config.BlizzardApiProperties
-import net.jonasmf.auctionengine.config.BucketConfig
-import net.jonasmf.auctionengine.config.WaeS3Properties
 import net.jonasmf.auctionengine.constant.Region
 import net.jonasmf.auctionengine.service.BlizzardMediaBackfillResult
 import net.jonasmf.auctionengine.service.BlizzardMediaBackfillService
@@ -28,17 +26,6 @@ class BlizzardMediaBackfillScheduleTest {
             clientSecret = "secret",
             regions = listOf(Region.Europe, Region.Taiwan),
         )
-    private val s3Properties =
-        WaeS3Properties(
-            buckets =
-                mapOf(
-                    "europe" to BucketConfig("wah-data-eu", "eu-north-1"),
-                    "northamerica" to BucketConfig("wah-data-us", "us-west-1"),
-                    "korea" to BucketConfig("wah-data-as", "ap-northeast-2"),
-                    "taiwan" to BucketConfig("wah-data-as", "ap-northeast-2"),
-                ),
-        )
-
     @Test
     fun `backfillMedia skips and logs when backfill already running`() {
         val service = mockk<BlizzardMediaBackfillService>()
@@ -54,7 +41,7 @@ class BlizzardMediaBackfillScheduleTest {
         }
 
         try {
-            val schedule = BlizzardMediaBackfillSchedule(properties, s3Properties, service, "eu-north-1")
+            val schedule = BlizzardMediaBackfillSchedule(properties, service, true)
             val future = executor.submit<Unit> { schedule.backfillMedia() }
             assertTrue(started.await(5, TimeUnit.SECONDS))
 
@@ -74,10 +61,10 @@ class BlizzardMediaBackfillScheduleTest {
     }
 
     @Test
-    fun `scheduled backfill skips when deployment region does not match static data region`() {
+    fun `scheduled backfill skips when static data sync is disabled`() {
         val service = mockk<BlizzardMediaBackfillService>()
         val listAppender = attachAppender()
-        val schedule = BlizzardMediaBackfillSchedule(properties, s3Properties, service, "us-west-1")
+        val schedule = BlizzardMediaBackfillSchedule(properties, service, false)
 
         try {
             schedule.backfillMediaOnSchedule()
@@ -86,7 +73,7 @@ class BlizzardMediaBackfillScheduleTest {
             assertTrue(
                 messages.any {
                     it.contains(
-                        "Skipping scheduled media backfill because deployment AWS region us-west-1 does not match static data region Europe bucket region eu-north-1.",
+                        "Skipping scheduled media backfill because static data sync is disabled for this deployment.",
                     )
                 },
             )

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/schedules/ItemScheduleTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/schedules/ItemScheduleTest.kt
@@ -7,8 +7,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import net.jonasmf.auctionengine.config.BlizzardApiProperties
-import net.jonasmf.auctionengine.config.BucketConfig
-import net.jonasmf.auctionengine.config.WaeS3Properties
 import net.jonasmf.auctionengine.constant.Region
 import net.jonasmf.auctionengine.repository.rds.ItemPersistenceSummary
 import net.jonasmf.auctionengine.service.ItemSyncResult
@@ -29,17 +27,6 @@ class ItemScheduleTest {
             clientSecret = "secret",
             regions = listOf(Region.Europe, Region.Taiwan),
         )
-    private val s3Properties =
-        WaeS3Properties(
-            buckets =
-                mapOf(
-                    "europe" to BucketConfig("wah-data-eu", "eu-north-1"),
-                    "northamerica" to BucketConfig("wah-data-us", "us-west-1"),
-                    "korea" to BucketConfig("wah-data-as", "ap-northeast-2"),
-                    "taiwan" to BucketConfig("wah-data-as", "ap-northeast-2"),
-                ),
-        )
-
     @Test
     fun `syncItems skips and logs when sync already running`() {
         val service = mockk<ItemSyncService>()
@@ -55,7 +42,7 @@ class ItemScheduleTest {
         }
 
         try {
-            val schedule = ItemSchedule(properties, s3Properties, service, "eu-north-1")
+            val schedule = ItemSchedule(properties, service, true)
             val future = executor.submit<Unit> { schedule.syncItems() }
             assertTrue(started.await(5, TimeUnit.SECONDS))
 
@@ -75,10 +62,10 @@ class ItemScheduleTest {
     }
 
     @Test
-    fun `scheduled sync skips when deployment region does not match static data region`() {
+    fun `scheduled sync skips when static data sync is disabled`() {
         val service = mockk<ItemSyncService>()
         val listAppender = attachAppender()
-        val schedule = ItemSchedule(properties, s3Properties, service, "us-west-1")
+        val schedule = ItemSchedule(properties, service, false)
 
         try {
             schedule.syncItemsOnSchedule()
@@ -87,7 +74,7 @@ class ItemScheduleTest {
             assertTrue(
                 messages.any {
                     it.contains(
-                        "Skipping scheduled item sync because deployment AWS region us-west-1 does not match static data region Europe bucket region eu-north-1.",
+                        "Skipping scheduled item sync because static data sync is disabled for this deployment.",
                     )
                 },
             )

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/schedules/ProfessionRecipeScheduleTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/schedules/ProfessionRecipeScheduleTest.kt
@@ -7,8 +7,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import net.jonasmf.auctionengine.config.BlizzardApiProperties
-import net.jonasmf.auctionengine.config.BucketConfig
-import net.jonasmf.auctionengine.config.WaeS3Properties
 import net.jonasmf.auctionengine.constant.Region
 import net.jonasmf.auctionengine.service.ProfessionRecipeSyncResult
 import net.jonasmf.auctionengine.service.ProfessionRecipeSyncService
@@ -28,17 +26,6 @@ class ProfessionRecipeScheduleTest {
             clientSecret = "secret",
             regions = listOf(Region.Europe, Region.Taiwan),
         )
-    private val s3Properties =
-        WaeS3Properties(
-            buckets =
-                mapOf(
-                    "europe" to BucketConfig("wah-data-eu", "eu-north-1"),
-                    "northamerica" to BucketConfig("wah-data-us", "us-west-1"),
-                    "korea" to BucketConfig("wah-data-as", "ap-northeast-2"),
-                    "taiwan" to BucketConfig("wah-data-as", "ap-northeast-2"),
-                ),
-        )
-
     @Test
     fun `syncProfessionRecipes skips and logs when sync already running`() {
         val service = mockk<ProfessionRecipeSyncService>()
@@ -54,7 +41,7 @@ class ProfessionRecipeScheduleTest {
         }
 
         try {
-            val schedule = ProfessionRecipeSchedule(properties, s3Properties, service, "eu-north-1")
+            val schedule = ProfessionRecipeSchedule(properties, service, true)
             val future = executor.submit<Unit> { schedule.syncProfessionRecipes() }
             assertTrue(started.await(5, TimeUnit.SECONDS))
 
@@ -80,7 +67,7 @@ class ProfessionRecipeScheduleTest {
         val service = mockk<ProfessionRecipeSyncService>()
         every { service.syncConfiguredStaticDataRegion() } returns mockk<ProfessionRecipeSyncResult>(relaxed = true)
 
-        val schedule = ProfessionRecipeSchedule(properties, s3Properties, service, "eu-north-1")
+        val schedule = ProfessionRecipeSchedule(properties, service, true)
 
         schedule.syncProfessionRecipes()
         schedule.syncProfessionRecipes()
@@ -94,7 +81,7 @@ class ProfessionRecipeScheduleTest {
         every { service.syncConfiguredStaticDataRegion() } throws RuntimeException("boom") andThen
             mockk<ProfessionRecipeSyncResult>(relaxed = true)
 
-        val schedule = ProfessionRecipeSchedule(properties, s3Properties, service, "eu-north-1")
+        val schedule = ProfessionRecipeSchedule(properties, service, true)
 
         runCatching { schedule.syncProfessionRecipes() }
         schedule.syncProfessionRecipes()
@@ -103,10 +90,10 @@ class ProfessionRecipeScheduleTest {
     }
 
     @Test
-    fun `scheduled sync skips when deployment region does not match static data region`() {
+    fun `scheduled sync skips when static data sync is disabled`() {
         val service = mockk<ProfessionRecipeSyncService>()
         val listAppender = attachAppender()
-        val schedule = ProfessionRecipeSchedule(properties, s3Properties, service, "us-west-1")
+        val schedule = ProfessionRecipeSchedule(properties, service, false)
 
         try {
             schedule.syncProfessionRecipesOnSchedule()
@@ -115,7 +102,7 @@ class ProfessionRecipeScheduleTest {
             assertTrue(
                 messages.any {
                     it.contains(
-                        "Skipping scheduled profession/recipe sync because deployment AWS region us-west-1 does not match static data region Europe bucket region eu-north-1.",
+                        "Skipping scheduled profession/recipe sync because static data sync is disabled for this deployment.",
                     )
                 },
             )

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -47,7 +47,7 @@
             ],
             "styles": ["src/styles.css"],
             "security": {
-              "allowedHosts": ["localhost", "127.0.0.1"]
+              "allowedHosts": ["localhost", "127.0.0.1", "ee.jonaskf.net"]
             },
             "polyfills": ["@angular/localize/init"],
             "i18nMissingTranslation": "error"

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,27 +1,25 @@
-# AWS Deployment
+# Deployment
 
-This repository includes a minimal single-instance regional deployment path for the WoW Auction Engine.
+This repository supports two production deployment paths:
 
-It is intended for:
+- **AWS EC2** (legacy): one instance per region, Docker on EC2, SSM restarts
+- **VPS Kubernetes** (current): a single Kubernetes cluster on a VPS hosts the app at `ee.jonaskf.net`
 
-- one EC2 instance per region
-- Docker on EC2
-- GitHub Actions deployment from `master`
-- AWS Systems Manager for in-place restarts
-- SSM Parameter Store for runtime configuration
-
-It is not a Kubernetes or EKS deployment.
+EC2 app rollouts are disabled while `instance_enabled` is `"false"` in `infra/regions.json`. CloudFormation stacks can still be maintained for auth and shared AWS resources.
 
 ## Layout
 
 - `infra/regions.json`: enabled regions and per-region overrides
 - `infra/cloudformation/app-region.yaml`: reusable per-region CloudFormation stack
+- `infra/kubernetes/vps/`: Kubernetes manifests for the VPS deployment
 - `scripts/deploy/sync-ssm-parameters.sh`: writes runtime configuration to SSM Parameter Store
 - `scripts/deploy/restart-container.sh`: restarts backend and frontend containers on the EC2 instance through SSM
+- `scripts/deploy/deploy-vps-local.sh`: local VPS deploy script (build, push to GHCR, kubectl apply)
 - `.github/workflows/ci.yml`: verifies backend/frontend changes and uploads deployable artifacts on `master`
-- `.github/workflows/deploy-production.yml`: orchestrates production deployment from `master`
+- `.github/workflows/deploy-production.yml`: orchestrates EC2 production deployment from `master`
+- `.github/workflows/deploy-vps.yml`: orchestrates VPS Kubernetes deployment from `master`
 - `.github/workflows/reusable-build-image.yml`: builds backend or frontend runtime images from deployable artifacts
-- `.github/workflows/reusable-deploy-region.yml`: deploys one region at a time
+- `.github/workflows/reusable-deploy-region.yml`: deploys one EC2 region at a time
 
 ## What Happens On Push To `master`
 
@@ -103,6 +101,73 @@ Use it when you want to force CloudFormation without relying on changed-file det
 - one region or `all`
 - an option to skip the app rollout and perform infra-only sync
 
+## VPS Kubernetes Deployment
+
+Production app traffic is served from a VPS Kubernetes cluster at `https://ee.jonaskf.net`.
+
+### What Happens On Push To `master` (VPS)
+
+1. `App PR Checks` finishes successfully on `master`.
+2. `Deploy VPS` starts and classifies changed files.
+3. When app rollout is required, it builds `linux/amd64` images, pushes them to GHCR, applies manifests under `infra/kubernetes/vps/`, updates deployment images, and verifies `/` and `/api/health`.
+
+EC2 `Deploy Production` still runs for auth/infra work, but app rollouts to EC2 are skipped while every region has `instance_enabled: "false"`.
+
+### VPS Cluster Prerequisites
+
+The manifests assume the cluster already provides:
+
+- Traefik as the ingress controller (`ingressClassName: traefik`)
+- cert-manager with a `letsencrypt-http01` cluster issuer for TLS
+
+The VPS backend runs as a single deployment handling all Blizzard regions (`Europe`, `NorthAmerica`, `Korea`, `Taiwan`).
+
+### Local VPS Deploy
+
+Use `scripts/deploy/deploy-vps-local.sh` when you already have `kubectl` access to the cluster. It reads kubeconfig from the `KUBECONFIG` environment variable (the same file `kubectl` uses on your machine).
+
+Example:
+
+```bash
+export KUBECONFIG="$HOME/.kube/config"
+export GHCR_IMAGE_PREFIX="ghcr.io/<owner>/wow-auction-engine"
+export GHCR_PULL_TOKEN="<github-token-with-read:packages>"
+# plus BLIZZARD_*, DB_*, and WAE_AUTH_SESSION_SECRET
+
+bash scripts/deploy/deploy-vps-local.sh
+```
+
+### VPS GitHub Secrets
+
+Add these to the `production` GitHub Environment:
+
+- `KUBECONFIG_B64`: base64-encoded kubeconfig for the VPS cluster
+- `PROD_GHCR_PULL_TOKEN`: GitHub token that can pull (and push, for CI) images from GHCR
+
+The workflow also reuses the existing production secrets (`PROD_BLIZZARD_*`, `PROD_AUCTION_ENGINE_DB_*`, `PROD_AUTH_SESSION_SECRET`, optional Cognito/AWS overrides).
+
+#### Creating `KUBECONFIG_B64`
+
+GitHub Actions runners do not have your local kubeconfig. Locally, `kubectl` works because it reads `~/.kube/config` (or whatever `KUBECONFIG` points to). For CI, copy that same file into a secret:
+
+```bash
+# macOS / Linux — use the kubeconfig that already works for you:
+base64 < "${KUBECONFIG:-$HOME/.kube/config}" | tr -d '\n'
+```
+
+Paste the single-line output into a GitHub Environment secret named `KUBECONFIG_B64` under **Settings → Environments → production → Secrets**.
+
+To verify before saving:
+
+```bash
+printf '%s' "$KUBECONFIG_B64" | base64 -d > /tmp/ci-kubeconfig
+KUBECONFIG=/tmp/ci-kubeconfig kubectl cluster-info
+```
+
+#### Creating `PROD_GHCR_PULL_TOKEN`
+
+Create a fine-grained or classic GitHub personal access token with `read:packages` (and `write:packages` if CI should push images). The cluster uses this token for the `ghcr` image pull secret; the workflow uses it to push images during deploy.
+
 ## GitHub Setup
 
 ### Required GitHub Secrets
@@ -132,6 +197,8 @@ Optional secrets:
 - `PROD_WAE_DYNAMODB_ENDPOINT`
 - `PROD_WAE_S3_ENDPOINT`
 - `PROD_JAVA_TOOL_OPTIONS`
+- `PROD_GHCR_PULL_TOKEN` (required for VPS deploy; cluster image pulls and CI GHCR push)
+- `KUBECONFIG_B64` (required for VPS deploy; see [VPS Kubernetes Deployment](#vps-kubernetes-deployment))
 
 Notes:
 

--- a/infra/kubernetes/vps/backend-deployment.yaml
+++ b/infra/kubernetes/vps/backend-deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ee-backend
+  namespace: ee
+  labels:
+    app: ee-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ee-backend
+  template:
+    metadata:
+      labels:
+        app: ee-backend
+    spec:
+      imagePullSecrets:
+        - name: ghcr
+      containers:
+        - name: backend
+          image: ghcr.io/placeholder/ee-backend:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              name: http
+          envFrom:
+            - configMapRef:
+                name: wow-auction-engine-config
+            - secretRef:
+                name: wow-auction-engine-secrets
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 8
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 8080
+            initialDelaySeconds: 90
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 250m
+              memory: 1024Mi
+            limits:
+              cpu: "2"
+              memory: 3072Mi

--- a/infra/kubernetes/vps/backend-service.yaml
+++ b/infra/kubernetes/vps/backend-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ee-backend
+  namespace: ee
+  labels:
+    app: ee-backend
+spec:
+  selector:
+    app: ee-backend
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/infra/kubernetes/vps/configmap.yaml
+++ b/infra/kubernetes/vps/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: wow-auction-engine-config
+  namespace: ee
+data:
+  SPRING_PROFILES_ACTIVE: production
+  WAE_AWS_REGION: eu-north-1
+  WAE_BLIZZARD_REGIONS: Europe,NorthAmerica,Korea,Taiwan
+  WAE_BLIZZARD_REGION: Europe
+  WAE_STATIC_DATA_REGION: Europe
+  WAE_STATIC_DATA_SYNC_ENABLED: "true"
+  JVM_MAX_RAM_PERCENTAGE: "65.0"
+  BACKEND_ORIGIN: http://ee-backend:8080

--- a/infra/kubernetes/vps/frontend-deployment.yaml
+++ b/infra/kubernetes/vps/frontend-deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ee-frontend
+  namespace: ee
+  labels:
+    app: ee-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ee-frontend
+  template:
+    metadata:
+      labels:
+        app: ee-frontend
+    spec:
+      imagePullSecrets:
+        - name: ghcr
+      containers:
+        - name: frontend
+          image: ghcr.io/placeholder/ee-frontend:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 4000
+              name: http
+          env:
+            - name: PORT
+              value: "4000"
+          envFrom:
+            - configMapRef:
+                name: wow-auction-engine-config
+            - secretRef:
+                name: wow-auction-engine-secrets
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 4000
+              httpHeaders:
+                - name: Host
+                  value: ee.jonaskf.net
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 4000
+              httpHeaders:
+                - name: Host
+                  value: ee.jonaskf.net
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 750m
+              memory: 768Mi

--- a/infra/kubernetes/vps/frontend-deployment.yaml
+++ b/infra/kubernetes/vps/frontend-deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - configMapRef:
                 name: wow-auction-engine-config
             - secretRef:
-                name: wow-auction-engine-secrets
+                name: wow-auction-engine-frontend-secrets
           readinessProbe:
             httpGet:
               path: /

--- a/infra/kubernetes/vps/frontend-service.yaml
+++ b/infra/kubernetes/vps/frontend-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ee-frontend
+  namespace: ee
+  labels:
+    app: ee-frontend
+spec:
+  selector:
+    app: ee-frontend
+  ports:
+    - name: http
+      port: 80
+      targetPort: 4000

--- a/infra/kubernetes/vps/ingress.yaml
+++ b/infra/kubernetes/vps/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ee
+  namespace: ee
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-http01
+    traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - ee.jonaskf.net
+      secretName: ee-tls
+  rules:
+    - host: ee.jonaskf.net
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: ee-backend
+                port:
+                  number: 8080
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ee-frontend
+                port:
+                  number: 80

--- a/infra/kubernetes/vps/namespace.yaml
+++ b/infra/kubernetes/vps/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ee

--- a/infra/regions.json
+++ b/infra/regions.json
@@ -18,7 +18,7 @@
         "jvm_max_ram_percentage": "65.0",
         "container_port": 8080,
         "health_check_path": "/api/health",
-        "instance_enabled": "true",
+        "instance_enabled": "false",
         "stack_name": "wah-wow-auction-engine-prod-eu-north-1"
     },
     {
@@ -31,7 +31,7 @@
       "jvm_max_ram_percentage": "65.0",
       "container_port": 8080,
       "health_check_path": "/api/health",
-      "instance_enabled": "true",
+      "instance_enabled": "false",
       "stack_name": "wah-wow-auction-engine-prod-us-west-1"
     },
     {
@@ -44,7 +44,7 @@
       "jvm_max_ram_percentage": "65.0",
       "container_port": 8080,
       "health_check_path": "/api/health",
-      "instance_enabled": "true",
+      "instance_enabled": "false",
       "stack_name": "wah-wow-auction-engine-prod-ap-northeast-2"
     }
   ]

--- a/scripts/deploy/classify_changes.py
+++ b/scripts/deploy/classify_changes.py
@@ -58,17 +58,21 @@ def main() -> int:
     ]
     deploy_patterns = [
         ".github/workflows/deploy-production.yml",
+        ".github/workflows/deploy-vps.yml",
         ".github/workflows/reusable-build-image.yml",
         ".github/workflows/reusable-deploy-region.yml",
         ".github/workflows/manual-infra-sync.yml",
         ".github/actions/**",
         "scripts/deploy/**",
         "infra/regions.json",
+        "infra/kubernetes/**",
     ]
     infra_patterns = [
         "infra/cloudformation/**",
+        "infra/kubernetes/**",
         "infra/regions.json",
         ".github/workflows/deploy-production.yml",
+        ".github/workflows/deploy-vps.yml",
         ".github/workflows/reusable-deploy-region.yml",
         ".github/workflows/manual-infra-sync.yml",
         ".github/actions/**",

--- a/scripts/deploy/deploy-vps-local.sh
+++ b/scripts/deploy/deploy-vps-local.sh
@@ -13,6 +13,7 @@ APP_HOST="${APP_HOST:-ee.jonaskf.net}"
 HEALTH_PATH="${HEALTH_PATH:-/api/health}"
 GHCR_IMAGE_PREFIX="${GHCR_IMAGE_PREFIX:-}"
 GHCR_USERNAME="${GHCR_USERNAME:-}"
+GHCR_PULL_TOKEN="${GHCR_PULL_TOKEN:-}"
 IMAGE_PLATFORM="${IMAGE_PLATFORM:-linux/amd64}"
 
 required_commands=(kubectl docker git curl)
@@ -25,6 +26,7 @@ required_env=(
   AUCTION_ENGINE_DB_USERNAME
   AUCTION_ENGINE_DB_PASSWORD
   WAE_AUTH_SESSION_SECRET
+  GHCR_PULL_TOKEN
 )
 
 for command_name in "${required_commands[@]}"; do
@@ -57,12 +59,12 @@ fi
 
 docker_config="${DOCKER_CONFIG:-${HOME}/.docker}/config.json"
 if [[ ! -r "$docker_config" ]] || ! grep -q '"ghcr.io"' "$docker_config"; then
-  if [[ -z "${GITHUB_PERSONAL_ACCESS_TOKEN:-}" ]]; then
+  if [[ -z "$GHCR_PULL_TOKEN" ]]; then
     echo "Docker does not appear to be logged in to ghcr.io. Run: docker login ghcr.io" >&2
     exit 1
   fi
   echo "Logging in to ghcr.io as ${GHCR_USERNAME}"
-  printf '%s' "$GITHUB_PERSONAL_ACCESS_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
+  printf '%s' "$GHCR_PULL_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 fi
 
 short_sha="$(git -C "$ROOT_DIR" rev-parse --short=12 HEAD)"
@@ -106,12 +108,12 @@ echo "Applying Kubernetes manifests"
 kubectl apply -f "${K8S_DIR}/namespace.yaml"
 kubectl apply -f "$K8S_DIR"
 
-if [[ -n "${GITHUB_PERSONAL_ACCESS_TOKEN:-}" ]]; then
+if [[ -n "$GHCR_PULL_TOKEN" ]]; then
   echo "Applying GHCR image pull secret"
   kubectl -n "$APP_NAMESPACE" create secret docker-registry ghcr \
     --docker-server=ghcr.io \
     --docker-username="$GHCR_USERNAME" \
-    --docker-password="$GITHUB_PERSONAL_ACCESS_TOKEN" \
+    --docker-password="$GHCR_PULL_TOKEN" \
     --docker-email="${GHCR_USERNAME}@users.noreply.github.com" \
     --dry-run=client \
     -o yaml | kubectl apply -f -
@@ -134,6 +136,7 @@ optional_secret_vars=(
   WAE_COGNITO_ISSUER_URI
   WAE_COGNITO_CLIENT_ID
   WAE_COGNITO_HOSTED_UI_BASE_URL
+  WAE_COGNITO_USER_POOL_ID
   JAVA_TOOL_OPTIONS
 )
 

--- a/scripts/deploy/deploy-vps-local.sh
+++ b/scripts/deploy/deploy-vps-local.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+K8S_DIR="${ROOT_DIR}/infra/kubernetes/vps"
+
+APP_NAMESPACE="${APP_NAMESPACE:-ee}"
+BACKEND_DEPLOYMENT="${BACKEND_DEPLOYMENT:-ee-backend}"
+FRONTEND_DEPLOYMENT="${FRONTEND_DEPLOYMENT:-ee-frontend}"
+BACKEND_CONTAINER="${BACKEND_CONTAINER:-backend}"
+FRONTEND_CONTAINER="${FRONTEND_CONTAINER:-frontend}"
+APP_HOST="${APP_HOST:-ee.jonaskf.net}"
+HEALTH_PATH="${HEALTH_PATH:-/api/health}"
+GHCR_IMAGE_PREFIX="${GHCR_IMAGE_PREFIX:-}"
+GHCR_USERNAME="${GHCR_USERNAME:-}"
+IMAGE_PLATFORM="${IMAGE_PLATFORM:-linux/amd64}"
+
+required_commands=(kubectl docker git curl)
+required_env=(
+  KUBECONFIG
+  GHCR_IMAGE_PREFIX
+  BLIZZARD_CLIENT_ID
+  BLIZZARD_CLIENT_SECRET
+  AUCTION_ENGINE_DB_URL
+  AUCTION_ENGINE_DB_USERNAME
+  AUCTION_ENGINE_DB_PASSWORD
+  WAE_AUTH_SESSION_SECRET
+)
+
+for command_name in "${required_commands[@]}"; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "Missing required command: ${command_name}" >&2
+    exit 1
+  fi
+done
+
+for var_name in "${required_env[@]}"; do
+  if [[ -z "${!var_name:-}" ]]; then
+    echo "Missing required environment variable: ${var_name}" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -r "$KUBECONFIG" ]]; then
+  echo "KUBECONFIG does not point to a readable file: ${KUBECONFIG}" >&2
+  exit 1
+fi
+
+if [[ ! -d "$K8S_DIR" ]]; then
+  echo "Kubernetes manifest directory not found: ${K8S_DIR}" >&2
+  exit 1
+fi
+
+if [[ -z "$GHCR_USERNAME" ]]; then
+  GHCR_USERNAME="$(printf '%s' "${GHCR_IMAGE_PREFIX#ghcr.io/}" | cut -d/ -f1)"
+fi
+
+docker_config="${DOCKER_CONFIG:-${HOME}/.docker}/config.json"
+if [[ ! -r "$docker_config" ]] || ! grep -q '"ghcr.io"' "$docker_config"; then
+  if [[ -z "${GITHUB_PERSONAL_ACCESS_TOKEN:-}" ]]; then
+    echo "Docker does not appear to be logged in to ghcr.io. Run: docker login ghcr.io" >&2
+    exit 1
+  fi
+  echo "Logging in to ghcr.io as ${GHCR_USERNAME}"
+  printf '%s' "$GITHUB_PERSONAL_ACCESS_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
+fi
+
+short_sha="$(git -C "$ROOT_DIR" rev-parse --short=12 HEAD)"
+timestamp="$(date -u +%Y%m%d%H%M%S)"
+image_tag="${IMAGE_TAG:-local-${short_sha}-${timestamp}}"
+backend_image="${GHCR_IMAGE_PREFIX%/}/backend:${image_tag}"
+frontend_image="${GHCR_IMAGE_PREFIX%/}/frontend:${image_tag}"
+
+cleanup() {
+  rm -f "${ROOT_DIR}/backend/app.war" "${ROOT_DIR}/frontend/app-dist.tar.gz"
+}
+trap cleanup EXIT
+
+echo "Preparing deploy artifacts for ${image_tag}"
+(
+  cd "$ROOT_DIR"
+  WORKFLOW_RUN_ID="" bash scripts/deploy/ensure-war.sh
+  WORKFLOW_RUN_ID="" bash scripts/deploy/ensure-frontend-dist.sh
+)
+
+echo "Checking Kubernetes access"
+kubectl -n "$APP_NAMESPACE" get namespace "$APP_NAMESPACE" >/dev/null 2>&1 || true
+kubectl cluster-info >/dev/null
+
+echo "Building and pushing backend image: ${backend_image}"
+docker build \
+  --platform "$IMAGE_PLATFORM" \
+  --tag "$backend_image" \
+  "${ROOT_DIR}/backend"
+docker push "$backend_image"
+
+echo "Building and pushing frontend image: ${frontend_image}"
+docker build \
+  --platform "$IMAGE_PLATFORM" \
+  --file "${ROOT_DIR}/frontend/Dockerfile" \
+  --tag "$frontend_image" \
+  "$ROOT_DIR"
+docker push "$frontend_image"
+
+echo "Applying Kubernetes manifests"
+kubectl apply -f "${K8S_DIR}/namespace.yaml"
+kubectl apply -f "$K8S_DIR"
+
+if [[ -n "${GITHUB_PERSONAL_ACCESS_TOKEN:-}" ]]; then
+  echo "Applying GHCR image pull secret"
+  kubectl -n "$APP_NAMESPACE" create secret docker-registry ghcr \
+    --docker-server=ghcr.io \
+    --docker-username="$GHCR_USERNAME" \
+    --docker-password="$GITHUB_PERSONAL_ACCESS_TOKEN" \
+    --docker-email="${GHCR_USERNAME}@users.noreply.github.com" \
+    --dry-run=client \
+    -o yaml | kubectl apply -f -
+fi
+
+secret_args=(
+  --from-literal=BLIZZARD_CLIENT_ID="${BLIZZARD_CLIENT_ID}"
+  --from-literal=BLIZZARD_CLIENT_SECRET="${BLIZZARD_CLIENT_SECRET}"
+  --from-literal=AUCTION_ENGINE_DB_URL="${AUCTION_ENGINE_DB_URL}"
+  --from-literal=AUCTION_ENGINE_DB_USERNAME="${AUCTION_ENGINE_DB_USERNAME}"
+  --from-literal=AUCTION_ENGINE_DB_PASSWORD="${AUCTION_ENGINE_DB_PASSWORD}"
+  --from-literal=WAE_AUTH_SESSION_SECRET="${WAE_AUTH_SESSION_SECRET}"
+)
+
+optional_secret_vars=(
+  AWS_ACCESS_KEY
+  AWS_SECRET_KEY
+  WAE_DYNAMODB_ENDPOINT
+  WAE_S3_ENDPOINT
+  WAE_COGNITO_ISSUER_URI
+  WAE_COGNITO_CLIENT_ID
+  WAE_COGNITO_HOSTED_UI_BASE_URL
+  JAVA_TOOL_OPTIONS
+)
+
+for var_name in "${optional_secret_vars[@]}"; do
+  if [[ -n "${!var_name:-}" ]]; then
+    secret_args+=("--from-literal=${var_name}=${!var_name}")
+  fi
+done
+
+echo "Applying runtime secret"
+kubectl -n "$APP_NAMESPACE" create secret generic wow-auction-engine-secrets \
+  "${secret_args[@]}" \
+  --dry-run=client \
+  -o yaml | kubectl apply -f -
+
+echo "Updating deployment images"
+kubectl -n "$APP_NAMESPACE" set image "deployment/${BACKEND_DEPLOYMENT}" \
+  "${BACKEND_CONTAINER}=${backend_image}"
+kubectl -n "$APP_NAMESPACE" set image "deployment/${FRONTEND_DEPLOYMENT}" \
+  "${FRONTEND_CONTAINER}=${frontend_image}"
+
+echo "Waiting for rollouts"
+kubectl -n "$APP_NAMESPACE" rollout status "deployment/${BACKEND_DEPLOYMENT}" --timeout=300s
+kubectl -n "$APP_NAMESPACE" rollout status "deployment/${FRONTEND_DEPLOYMENT}" --timeout=180s
+
+echo "Verifying public endpoints"
+for _ in $(seq 1 30); do
+  if curl --fail --silent --show-error --connect-timeout 5 --max-time 10 "https://${APP_HOST}/" >/dev/null; then
+    break
+  fi
+  sleep 10
+done
+curl --fail --silent --show-error --connect-timeout 5 --max-time 10 "https://${APP_HOST}/" >/dev/null
+
+for _ in $(seq 1 30); do
+  if curl --fail --silent --show-error --connect-timeout 5 --max-time 10 "https://${APP_HOST}${HEALTH_PATH}" >/dev/null; then
+    break
+  fi
+  sleep 10
+done
+curl --fail --silent --show-error --connect-timeout 5 --max-time 10 "https://${APP_HOST}${HEALTH_PATH}" >/dev/null
+
+echo "VPS deploy succeeded: ${image_tag}"

--- a/scripts/deploy/deploy-vps-local.sh
+++ b/scripts/deploy/deploy-vps-local.sh
@@ -152,6 +152,26 @@ kubectl -n "$APP_NAMESPACE" create secret generic wow-auction-engine-secrets \
   --dry-run=client \
   -o yaml | kubectl apply -f -
 
+frontend_secret_args=(
+  --from-literal=WAE_AUTH_SESSION_SECRET="${WAE_AUTH_SESSION_SECRET}"
+)
+frontend_optional_secret_vars=(
+  WAE_COGNITO_CLIENT_ID
+  WAE_COGNITO_HOSTED_UI_BASE_URL
+)
+
+for var_name in "${frontend_optional_secret_vars[@]}"; do
+  if [[ -n "${!var_name:-}" ]]; then
+    frontend_secret_args+=("--from-literal=${var_name}=${!var_name}")
+  fi
+done
+
+echo "Applying frontend secret"
+kubectl -n "$APP_NAMESPACE" create secret generic wow-auction-engine-frontend-secrets \
+  "${frontend_secret_args[@]}" \
+  --dry-run=client \
+  -o yaml | kubectl apply -f -
+
 echo "Updating deployment images"
 kubectl -n "$APP_NAMESPACE" set image "deployment/${BACKEND_DEPLOYMENT}" \
   "${BACKEND_CONTAINER}=${backend_image}"


### PR DESCRIPTION
## Summary
Establishes a new deployment pipeline targeting a Virtual Private Server (VPS) running Kubernetes, transitioning from the existing AWS EC2-based infrastructure.

## Type of change
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [x] 🧹 Code refactor
- [ ] 🧪 Tests
- [ ] 📚 Documentation
- [x] 🔧 Build/CI
- [x] 🔄 Other (Infrastructure change)

## What has been done?
*   **New VPS Deployment Workflow:** Implemented `deploy-vps.yml` GitHub Actions workflow to build and deploy backend/frontend Docker images to a Kubernetes cluster on a VPS, including artifact download, GHCR login, image publishing, `kubectl` configuration, and endpoint verification.
*   **Kubernetes Manifests:** Added a comprehensive set of Kubernetes manifests in `infra/kubernetes/vps` to define namespaces, deployments, services, config maps, and ingress for the backend and frontend components.
*   **Local Deployment Script:** Created `deploy-vps-local.sh` to enable local deployment to a VPS Kubernetes cluster, mirroring the CI/CD pipeline's functionality.
*   **Backend Static Data Sync Flexibility:** Refactored backend schedules (`BlizzardMediaBackfillSchedule`, `ItemSchedule`, `ProfessionRecipeSchedule`) to use a new `static-data-sync-enabled` configuration property, decoupling static data synchronization from AWS region specifics and allowing flexible control in different deployment environments.
*   **Frontend Host Configuration:** Updated `angular.json` to include `ee.jonaskf.net` in allowed hosts, supporting the new VPS domain.
*   **Deployment Workflow Adjustments:** Modified `deploy-production.yml` and `manual-infra-sync.yml` to include the new VPS host in authentication callbacks and to conditionally run application rollouts based on an `instance_enabled` matrix variable.
*   **Infrastructure Classification Updates:** Updated `classify_changes.py` to include the new VPS deployment workflow and Kubernetes manifests in change classification.
*   **AWS Region Instance Disablement:** Updated `infra/regions.json` to disable existing AWS EC2 instances, indicating a transition towards the VPS deployment.

## Motivation / Context
This change introduces the necessary infrastructure and automation to transition the application's deployment target from AWS EC2 instances to a Kubernetes cluster hosted on a Virtual Private Server. This move aims to leverage Kubernetes for improved orchestration and potentially reduce operational overhead or costs associated with managing dedicated EC2 instances.

## Screenshots (if applicable)


## Checklist
- [ ] I’ve tested this manually
- [ ] I’ve added tests if applicable
- [ ] I’ve updated docs if needed
- [ ] I’ve followed the coding conventions

## Related Issues