### PR TITLE
Improvements to the fixture setup

### DIFF
--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/config/BlizzardFixtureIntegrationConfig.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/config/BlizzardFixtureIntegrationConfig.kt
@@ -1,0 +1,33 @@
+package net.jonasmf.auctionengine.config
+
+import net.jonasmf.auctionengine.integration.blizzard.BlizzardApiSupport
+import net.jonasmf.auctionengine.interceptor.authHeaderFilterFunction
+import net.jonasmf.auctionengine.service.AuthService
+import net.jonasmf.auctionengine.testsupport.BlizzardApiCallSupport.Companion.buildFilteredWebClient
+import net.jonasmf.auctionengine.testsupport.BlizzardFixtures
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+
+/**
+ * Keeps Spring integration tests from opening real Blizzard HTTP connections.
+ *
+ * Add or refresh files under src/test/resources/blizzard when a test needs another endpoint.
+ */
+@TestConfiguration(proxyBeanMethods = false)
+class BlizzardFixtureIntegrationConfig {
+    @Bean
+    @Primary
+    fun blizzardApiSupport(
+        blizzardApiProperties: BlizzardApiProperties,
+        authService: AuthService,
+    ): BlizzardApiSupport =
+        BlizzardApiSupport(
+            properties = blizzardApiProperties,
+            webClientWithAuth =
+                buildFilteredWebClient(
+                    BlizzardFixtures::handleRequest,
+                    authHeaderFilterFunction(authService, blizzardApiProperties),
+                ),
+        )
+}

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/config/IntegrationTestBase.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/config/IntegrationTestBase.kt
@@ -12,7 +12,10 @@ import org.springframework.test.context.DynamicPropertySource
 
 @SpringBootTest
 @ActiveProfiles("test")
-@Import(StubAuthWebClientConfig::class)
+@Import(
+    StubAuthWebClientConfig::class,
+    BlizzardFixtureIntegrationConfig::class,
+)
 abstract class IntegrationTestBase {
     @Autowired
     lateinit var testDataCleaner: TestDataCleaner
@@ -27,6 +30,7 @@ abstract class IntegrationTestBase {
         @DynamicPropertySource
         fun registerMariaDbProperties(registry: DynamicPropertyRegistry) {
             SharedTestContainers.registerMariaDbProperties(registry)
+            registry.add("blizzard.base-url") { "api.blizzard.test/data/wow/" }
         }
     }
 }

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/testsupport/BlizzardApiCallSupport.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/testsupport/BlizzardApiCallSupport.kt
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.client.ClientRequest
 import org.springframework.web.reactive.function.client.ClientResponse
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction
 import org.springframework.web.reactive.function.client.ExchangeFunction
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
@@ -15,11 +16,30 @@ import reactor.core.publisher.Mono
 class BlizzardApiCallSupport {
     companion object {
         @JvmStatic
-        fun okJson(body: String) =
+        fun okJson(
+            body: String,
+            lastModified: String? = null,
+        ) = jsonResponse(
+            body = body,
+            mediaType = MediaType.APPLICATION_JSON_VALUE,
+            lastModified = lastModified,
+        )
+
+        @JvmStatic
+        fun jsonResponse(
+            body: String,
+            mediaType: String,
+            lastModified: String? = null,
+        ) =
             Mono.just(
                 ClientResponse
                     .create(HttpStatus.OK)
-                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .header(HttpHeaders.CONTENT_TYPE, mediaType)
+                    .apply {
+                        if (lastModified != null) {
+                            header(HttpHeaders.LAST_MODIFIED, lastModified)
+                        }
+                    }
                     .body(body)
                     .build(),
             )
@@ -42,6 +62,16 @@ class BlizzardApiCallSupport {
         fun buildWebClient(handler: (ClientRequest) -> Mono<ClientResponse>): WebClient =
             WebClient
                 .builder()
+                .exchangeFunction(ExchangeFunction(handler))
+                .build()
+
+        @JvmStatic
+        fun buildFilteredWebClient(
+            handler: (ClientRequest) -> Mono<ClientResponse>,
+            vararg filters: ExchangeFilterFunction,
+        ): WebClient =
+            filters
+                .fold(WebClient.builder()) { builder, filter -> builder.filter(filter) }
                 .exchangeFunction(ExchangeFunction(handler))
                 .build()
     }

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/testsupport/BlizzardFixtures.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/testsupport/BlizzardFixtures.kt
@@ -1,0 +1,125 @@
+package net.jonasmf.auctionengine.testsupport
+
+import net.jonasmf.auctionengine.testsupport.BlizzardApiCallSupport.Companion.okJson
+import org.springframework.http.HttpHeaders
+import org.springframework.web.reactive.function.client.ClientRequest
+import org.springframework.web.reactive.function.client.ClientResponse
+import reactor.core.publisher.Mono
+import java.net.URI
+
+object BlizzardFixtures {
+    fun handleRequest(request: ClientRequest): Mono<ClientResponse> {
+        validateBlizzardRequest(request.url())
+
+        if (request.url().path.endsWith("/connected-realm/index")) {
+            return okJson(connectedRealmIndex())
+        }
+
+        val fixturePath = fixturePathFor(request)
+        val body = loadFixture(this, fixturePath)
+        return okJson(
+            body = body,
+            lastModified = AUCTION_LAST_MODIFIED.takeIf { fixturePath == AUCTION_METADATA_FIXTURE },
+        )
+    }
+
+    private fun fixturePathFor(request: ClientRequest): String {
+        val uri = request.url()
+        val blizzardPath =
+            uri.path
+                .substringAfter("/data/wow/", missingDelimiterValue = uri.path.trimStart('/'))
+                .trim('/')
+
+        val resourcePath =
+            when {
+                blizzardPath == "profession" || blizzardPath == "profession/index" -> {
+                    "profession/index"
+                }
+
+                blizzardPath == "modified-crafting" || blizzardPath == "modified-crafting/index" -> {
+                    "modified-crafting/index"
+                }
+
+                blizzardPath == "modified-crafting/category" || blizzardPath == "modified-crafting/category/index" -> {
+                    "modified-crafting/category/index"
+                }
+
+                blizzardPath == "modified-crafting/reagent-slot-type" ||
+                    blizzardPath == "modified-crafting/reagent-slot-type/index" -> {
+                    "modified-crafting/reagent-slot-type/index"
+                }
+
+                blizzardPath == "connected-realm/index" -> {
+                    "connected-realm/index"
+                }
+
+                blizzardPath.matches(Regex("connected-realm/\\d+")) -> {
+                    "connected-realm/connected-realm"
+                }
+
+                blizzardPath.matches(Regex("connected-realm/\\d+/auctions(/index)?")) -> {
+                    auctionFixturePath(request)
+                }
+
+                blizzardPath == "auctions/commodities" -> {
+                    auctionFixturePath(request)
+                }
+
+                blizzardPath.startsWith("media/") -> error("Unsupported Blizzard media fixture route: $uri")
+                blizzardPath.matches(Regex("item/\\d+")) -> blizzardPath
+                blizzardPath.matches(Regex("item-class/\\d+")) -> blizzardPath
+                blizzardPath.matches(Regex("item-class/\\d+/item-subclass/\\d+")) -> blizzardPath
+                blizzardPath.matches(Regex("item-appearance/\\d+")) -> blizzardPath
+                blizzardPath.matches(Regex("profession/\\d+")) -> blizzardPath
+                blizzardPath.matches(Regex("profession/\\d+/skill-tier/\\d+")) -> blizzardPath
+                blizzardPath.matches(Regex("recipe/\\d+")) -> blizzardPath
+                blizzardPath.matches(Regex("modified-crafting/category/\\d+")) -> blizzardPath
+                blizzardPath.matches(Regex("modified-crafting/reagent-slot-type/\\d+")) -> blizzardPath
+                else -> error("Unexpected Blizzard request path: $uri")
+            }
+
+        return "/blizzard/$resourcePath-response.json"
+    }
+
+    private fun auctionFixturePath(request: ClientRequest): String =
+        if (request.headers().containsHeader(HttpHeaders.IF_MODIFIED_SINCE)) {
+            "auction/auction-dump-metadata"
+        } else {
+            "auction/auction-data"
+        }
+
+    private fun validateBlizzardRequest(uri: URI) {
+        require(uri.scheme == "https") {
+            "Unexpected Blizzard request scheme: $uri"
+        }
+        require(uri.host in ALLOWED_BLIZZARD_HOSTS) {
+            "Unexpected Blizzard request host: $uri"
+        }
+    }
+
+    private fun connectedRealmIndex(): String =
+        """
+        {
+          "connected_realms": [
+            {
+              "href": "https://eu.api.blizzard.test/data/wow/connected-realm/42?namespace=dynamic-eu"
+            }
+          ]
+        }
+        """.trimIndent()
+
+    private val ALLOWED_BLIZZARD_HOSTS =
+        setOf(
+            "us.api.blizzard.com",
+            "eu.api.blizzard.com",
+            "kr.api.blizzard.com",
+            "tw.api.blizzard.com",
+            "us.api.blizzard.test",
+            "eu.api.blizzard.test",
+            "kr.api.blizzard.test",
+            "tw.api.blizzard.test",
+        )
+
+    private const val AUCTION_METADATA_FIXTURE = "/blizzard/auction/auction-dump-metadata-response.json"
+    private const val AUCTION_LAST_MODIFIED = "Wed, 01 Jan 2025 00:00:00 GMT"
+}

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/testsupport/BlizzardFixturesTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/testsupport/BlizzardFixturesTest.kt
@@ -1,0 +1,85 @@
+package net.jonasmf.auctionengine.testsupport
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.web.reactive.function.client.ClientRequest
+import java.net.URI
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class BlizzardFixturesTest {
+    @Test
+    fun `returns auction metadata with deterministic last modified when conditional header is present`() {
+        val response =
+            BlizzardFixtures
+                .handleRequest(
+                    request(
+                        "https://eu.api.blizzard.test/data/wow/connected-realm/123/auctions",
+                        HttpHeaders.IF_MODIFIED_SINCE to "Sat, 14 Mar 3000 20:07:10 GMT",
+                    ),
+                ).block()!!
+
+        assertEquals(1_735_689_600_000, response.headers().asHttpHeaders().lastModified)
+    }
+
+    @Test
+    fun `returns auction payload fixture when conditional metadata header is absent`() {
+        val response =
+            BlizzardFixtures
+                .handleRequest(
+                    request("https://eu.api.blizzard.test/data/wow/connected-realm/123/auctions"),
+                ).block()!!
+
+        val body = response.bodyToMono(String::class.java).block()!!
+
+        assertTrue(body.contains("\"auctions\""))
+        assertTrue(body.contains("19019"))
+    }
+
+    @Test
+    fun `rejects non Blizzard hosts before serving fixtures`() {
+        val error =
+            assertFailsWith<IllegalArgumentException> {
+                BlizzardFixtures
+                    .handleRequest(request("https://example.test/data/wow/item/171374"))
+                    .block()
+            }
+
+        assertTrue(error.message!!.contains("Unexpected Blizzard request host"))
+    }
+
+    @Test
+    fun `rejects non https Blizzard requests before serving fixtures`() {
+        val error =
+            assertFailsWith<IllegalArgumentException> {
+                BlizzardFixtures
+                    .handleRequest(request("http://eu.api.blizzard.test/data/wow/item/171374"))
+                    .block()
+            }
+
+        assertTrue(error.message!!.contains("Unexpected Blizzard request scheme"))
+    }
+
+    @Test
+    fun `rejects unsupported media routes with explicit error`() {
+        val error =
+            assertFailsWith<IllegalStateException> {
+                BlizzardFixtures
+                    .handleRequest(request("https://eu.api.blizzard.test/data/wow/media/item/171374"))
+                    .block()
+            }
+
+        assertTrue(error.message!!.contains("Unsupported Blizzard media fixture route"))
+    }
+
+    private fun request(
+        url: String,
+        vararg headers: Pair<String, String>,
+    ): ClientRequest {
+        val builder = ClientRequest.create(HttpMethod.GET, URI.create(url))
+        headers.forEach { (name, value) -> builder.header(name, value) }
+        return builder.build()
+    }
+}


### PR DESCRIPTION
Should imrpove the DX running tests that use the blizzard integrations. This should help avoid calling the real API in tests.