### PR TITLE
Optimizes branch database cloning performance

### DIFF
--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/config/BranchDatabaseCloner.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/config/BranchDatabaseCloner.kt
@@ -17,13 +17,18 @@ class BranchDatabaseCloner {
     ) {
         if (!selectedDatabase.shouldCloneFromTemplate) return
 
+        val startedAt = System.nanoTime()
         DriverManager.getConnection(jdbcUrl.withoutDatabase(), username, password).use { connection ->
             connection.autoCommit = false
             try {
                 connection.lockBranchDatabase(selectedDatabase.name)
                 if (connection.databaseExists(selectedDatabase.name)) {
                     connection.commit()
-                    logger.info("Using existing local dev database {}", selectedDatabase.name)
+                    logger.info(
+                        "Using existing local dev database {} after {} ms",
+                        selectedDatabase.name,
+                        elapsedMillis(startedAt),
+                    )
                     return
                 }
 
@@ -41,13 +46,27 @@ class BranchDatabaseCloner {
                     targetDatabase = selectedDatabase.name,
                 )
                 connection.commit()
+                logger.info(
+                    "Created local dev database {} from {} in {} ms",
+                    selectedDatabase.name,
+                    selectedDatabase.cloneSourceDatabase,
+                    elapsedMillis(startedAt),
+                )
             } catch (ex: Exception) {
                 connection.rollback()
+                logger.warn(
+                    "Failed preparing local dev database {} from {} after {} ms",
+                    selectedDatabase.name,
+                    selectedDatabase.cloneSourceDatabase,
+                    elapsedMillis(startedAt),
+                )
                 throw ex
             }
         }
     }
 }
+
+private fun elapsedMillis(startedAt: Long): Long = (System.nanoTime() - startedAt) / 1_000_000
 
 private val SKIP_DATA_TABLES =
     setOf(
@@ -153,16 +172,18 @@ private fun Connection.cloneTablesAndSequences(
     objects: List<DatabaseObject>,
 ) {
     objects.forEach { databaseObject ->
-        val tableName = databaseObject.name
-        val createTableSql =
-            showCreateTable(sourceDatabase, tableName)
-                .qualifyCreateTableOrSequence(targetDatabase, tableName)
-        executeSql(createTableSql)
+        val objectName = databaseObject.name
+        val createObjectSql =
+            when (databaseObject.type) {
+                DatabaseObjectType.SEQUENCE -> showCreateSequence(sourceDatabase, objectName)
+                DatabaseObjectType.TABLE -> showCreateTable(sourceDatabase, objectName)
+            }.qualifyCreateTableOrSequence(targetDatabase, objectName)
+        executeSql(createObjectSql)
         if (databaseObject.type == DatabaseObjectType.TABLE) {
             cloneData(
                 sourceDatabase = sourceDatabase,
                 targetDatabase = targetDatabase,
-                tableName = tableName,
+                tableName = objectName,
             )
         }
     }
@@ -311,6 +332,17 @@ private fun Connection.showCreateTable(
         }
     }
 
+private fun Connection.showCreateSequence(
+    database: String,
+    sequenceName: String,
+): String =
+    createStatement().use { statement ->
+        statement.executeQuery("SHOW CREATE SEQUENCE ${quoteIdentifier(database)}.${quoteIdentifier(sequenceName)}").use { result ->
+            result.next()
+            result.getString(2)
+        }
+    }
+
 private fun Connection.showCreateView(
     database: String,
     viewName: String,
@@ -327,7 +359,7 @@ internal fun String.qualifyCreateTableOrSequence(
     objectName: String,
 ): String =
     replaceFirst(
-        Regex("""(?i)^CREATE\s+(TABLE|SEQUENCE)\s+`${Regex.escape(objectName)}`"""),
+        Regex("""(?i)^CREATE\s+((?:OR\s+REPLACE\s+)?(?:TABLE|SEQUENCE))\s+(?:`[^`]+`\.)?`${Regex.escape(objectName)}`"""),
         "CREATE $1 ${qualifiedIdentifier(database, objectName)}",
     )
 

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/config/BranchDatabaseCloner.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/config/BranchDatabaseCloner.kt
@@ -49,6 +49,19 @@ class BranchDatabaseCloner {
     }
 }
 
+private val SKIP_DATA_TABLES =
+    setOf(
+        "admin_job",
+        "auction",
+        "auction_house_file_log",
+        "auction_update_history",
+        "auction_price",
+        "blizzard_media_fetch_failure",
+        "connected_realm_update_history",
+        "file_reference",
+        "item_fetch_failure",
+    )
+
 private val BOUNDED_HISTORY_TABLES =
     setOf(
         "auction_stats_daily",
@@ -160,20 +173,32 @@ private fun Connection.cloneData(
     targetDatabase: String,
     tableName: String,
 ) {
-    val datePredicate =
-        if (tableName in BOUNDED_HISTORY_TABLES) {
-            " WHERE `date` >= DATE_SUB(CURDATE(), INTERVAL 6 DAY)"
-        } else {
-            ""
-        }
-    executeSql(
+    dataCopySql(
+        sourceDatabase = sourceDatabase,
+        targetDatabase = targetDatabase,
+        tableName = tableName,
+    )?.let(::executeSql)
+}
+
+internal fun dataCopySql(
+    sourceDatabase: String,
+    targetDatabase: String,
+    tableName: String,
+): String? {
+    if (tableName in SKIP_DATA_TABLES) return null
+
+    val sql =
         """
         INSERT INTO ${quoteIdentifier(targetDatabase)}.${quoteIdentifier(tableName)}
         SELECT *
         FROM ${quoteIdentifier(sourceDatabase)}.${quoteIdentifier(tableName)}
-        $datePredicate
-        """.trimIndent(),
-    )
+        """.trimIndent()
+
+    return if (tableName in BOUNDED_HISTORY_TABLES) {
+        "$sql\nWHERE `date` >= DATE_SUB(CURDATE(), INTERVAL 6 DAY)"
+    } else {
+        sql
+    }
 }
 
 private fun Connection.resetCopiedSequences(

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/config/BranchDatabaseConfigTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/config/BranchDatabaseConfigTest.kt
@@ -56,6 +56,15 @@ class BranchDatabaseConfigTest {
     }
 
     @Test
+    fun `branch database clone requalifies schema-qualified sequence DDL with target database`() {
+        assertEquals(
+            "CREATE SEQUENCE `branch_feature`.`auction_house_seq` start with 1 increment by 50",
+            "CREATE SEQUENCE `dbo`.`auction_house_seq` start with 1 increment by 50"
+                .qualifyCreateTableOrSequence("branch_feature", "auction_house_seq"),
+        )
+    }
+
+    @Test
     fun `branch database clone qualifies copied table DDL with target database`() {
         assertEquals(
             "CREATE TABLE `branch_feature`.`auction_house` (`id` int not null)",

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/config/BranchDatabaseConfigTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/config/BranchDatabaseConfigTest.kt
@@ -1,6 +1,7 @@
 package net.jonasmf.auctionengine.config
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
 class BranchDatabaseConfigTest {
@@ -60,6 +61,50 @@ class BranchDatabaseConfigTest {
             "CREATE TABLE `branch_feature`.`auction_house` (`id` int not null)",
             "CREATE TABLE `auction_house` (`id` int not null)"
                 .qualifyCreateTableOrSequence("branch_feature", "auction_house"),
+        )
+    }
+
+    @Test
+    fun `branch database clone skips volatile runtime table data`() {
+        assertNull(
+            dataCopySql(
+                sourceDatabase = "dbo",
+                targetDatabase = "branch_feature",
+                tableName = "auction_price",
+            ),
+        )
+    }
+
+    @Test
+    fun `branch database clone bounds historical stats data`() {
+        assertEquals(
+            """
+            INSERT INTO `branch_feature`.`auction_stats_hourly`
+            SELECT *
+            FROM `dbo`.`auction_stats_hourly`
+            WHERE `date` >= DATE_SUB(CURDATE(), INTERVAL 6 DAY)
+            """.trimIndent(),
+            dataCopySql(
+                sourceDatabase = "dbo",
+                targetDatabase = "branch_feature",
+                tableName = "auction_stats_hourly",
+            ),
+        )
+    }
+
+    @Test
+    fun `branch database clone keeps reference data`() {
+        assertEquals(
+            """
+            INSERT INTO `branch_feature`.`item`
+            SELECT *
+            FROM `dbo`.`item`
+            """.trimIndent(),
+            dataCopySql(
+                sourceDatabase = "dbo",
+                targetDatabase = "branch_feature",
+                tableName = "item",
+            ),
         )
     }
 }


### PR DESCRIPTION
## Summary
Improves the performance and reliability of the local development database cloning process by skipping data for large, volatile tables and ensuring correct handling of sequence DDL.

## Type of change
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [x] 🧹 Code refactor
- [x] 🧪 Tests
- [ ] 📚 Documentation
- [ ] 🔧 Build/CI
- [ ] 🔄 Other (describe below)

## What has been done?
- Introduces a new set of `SKIP_DATA_TABLES` to prevent copying large, runtime-specific data tables (e.g., `auction_price`, `admin_job`) during the cloning process, significantly speeding up database creation.
- Extracts the data copying logic into a dedicated `dataCopySql` function for improved readability and maintainability.
- Adds specific logic to extract and qualify sequence DDL (`showCreateSequence`), ensuring sequences are correctly replicated in the cloned database.
- Updates the regex for DDL qualification to properly handle existing schema-qualified object names and `CREATE OR REPLACE` syntax.
- Implements elapsed time logging during database creation and usage, providing better observability into cloning performance.
- Adds new unit tests to validate the data skipping mechanism and the correct qualification of sequence DDL.

## Motivation / Context
The previous branch database cloning process was inefficient, copying unnecessary and often large amounts of volatile runtime data that are not relevant for a fresh development environment. This led to prolonged setup times for local development databases. Additionally, sequences were not being handled with full fidelity, leading to potential issues in cloned environments. This change addresses these performance bottlenecks and correctness issues, streamlining the local development workflow.

## Screenshots (if applicable)


## Checklist
- [ ] I’ve tested this manually
- [x] I’ve added tests if applicable
- [ ] I’ve updated docs if needed
- [ ] I’ve followed the coding conventions

## Related Issues
Closes #[issue_number], Fixes #[issue_number]