### PR TITLE
feat: add admin item editing interface (#58)

### DIFF
--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/controller/AdminController.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/controller/AdminController.kt
@@ -5,6 +5,12 @@ import net.jonasmf.auctionengine.generated.model.AdminExpansion1
 import net.jonasmf.auctionengine.generated.model.AdminExpansionItemRange
 import net.jonasmf.auctionengine.generated.model.AdminExpansionItemRangeRequest
 import net.jonasmf.auctionengine.generated.model.AdminExpansionRequest
+import net.jonasmf.auctionengine.generated.model.AdminItem1
+import net.jonasmf.auctionengine.generated.model.AdminItemBulkOverrideRequest
+import net.jonasmf.auctionengine.generated.model.AdminItemCompareResponse
+import net.jonasmf.auctionengine.generated.model.AdminItemCreateRequest
+import net.jonasmf.auctionengine.generated.model.AdminItemOverrideRequest
+import net.jonasmf.auctionengine.generated.model.AdminItemPage
 import net.jonasmf.auctionengine.generated.model.AdminJob
 import net.jonasmf.auctionengine.generated.model.AdminSqlExecuteRequest
 import net.jonasmf.auctionengine.generated.model.AdminSqlMetadata
@@ -12,6 +18,7 @@ import net.jonasmf.auctionengine.generated.model.AdminSqlResult
 import net.jonasmf.auctionengine.generated.model.AdminStatus
 import net.jonasmf.auctionengine.generated.model.User
 import net.jonasmf.auctionengine.service.admin.AdminExpansionService
+import net.jonasmf.auctionengine.service.admin.AdminItemService
 import net.jonasmf.auctionengine.service.admin.AdminJobService
 import net.jonasmf.auctionengine.service.admin.AdminSqlService
 import net.jonasmf.auctionengine.service.admin.AdminStatusService
@@ -29,6 +36,7 @@ class AdminController(
     private val adminSqlService: AdminSqlService,
     private val adminExpansionService: AdminExpansionService,
     private val adminJobService: AdminJobService,
+    private val adminItemService: AdminItemService,
 ) : AdminApi {
     @PreAuthorize("hasAuthority('admin')")
     override suspend fun getAdminStatus(): ResponseEntity<AdminStatus> = ResponseEntity.ok(adminStatusService.getStatus())
@@ -96,6 +104,50 @@ class AdminController(
     @PreAuthorize("hasAuthority('admin')")
     override suspend fun getAdminJob(id: Long): ResponseEntity<AdminJob> =
         ResponseEntity.ok(adminJobService.getJob(id))
+
+    @PreAuthorize("hasAuthority('admin')")
+    override suspend fun searchAdminItems(
+        query: String?,
+        locale: String?,
+        hasBase: Boolean?,
+        hasOverride: Boolean?,
+        page: Int,
+        pageSize: Int,
+    ): ResponseEntity<AdminItemPage> =
+        ResponseEntity.ok(adminItemService.searchItems(query, locale, hasBase, hasOverride, page, pageSize))
+
+    @PreAuthorize("hasAuthority('admin')")
+    override suspend fun getAdminItem(
+        id: Int,
+        locale: String?,
+        includeBase: Boolean,
+        includeOverride: Boolean,
+    ): ResponseEntity<AdminItem1> =
+        ResponseEntity.ok(adminItemService.getItem(id, locale, includeBase, includeOverride))
+
+    @PreAuthorize("hasAuthority('admin')")
+    override suspend fun upsertAdminItemOverride(
+        id: Int,
+        body: AdminItemOverrideRequest,
+    ): ResponseEntity<AdminItem1> = ResponseEntity.ok(adminItemService.upsertOverride(id, body))
+
+    @PreAuthorize("hasAuthority('admin')")
+    override suspend fun deleteAdminItemOverride(id: Int): ResponseEntity<Unit> {
+        adminItemService.deleteOverride(id)
+        return ResponseEntity.noContent().build()
+    }
+
+    @PreAuthorize("hasAuthority('admin')")
+    override suspend fun createAdminItem(body: AdminItemCreateRequest): ResponseEntity<AdminItem1> =
+        ResponseEntity.ok(adminItemService.createOverrideOnly(body))
+
+    @PreAuthorize("hasAuthority('admin')")
+    override suspend fun compareAdminItemWithApi(id: Int): ResponseEntity<AdminItemCompareResponse> =
+        ResponseEntity.ok(adminItemService.compareWithApi(id))
+
+    @PreAuthorize("hasAuthority('admin')")
+    override suspend fun bulkUpsertAdminItemOverrides(body: AdminItemBulkOverrideRequest): ResponseEntity<List<AdminItem1>> =
+        ResponseEntity.ok(adminItemService.bulkUpsertOverrides(body))
 
     // TODO: Need a paginated response - Update openApi as well
     @PreAuthorize("hasAuthority('admin')")

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/controller/AdminController.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/controller/AdminController.kt
@@ -113,10 +113,14 @@ class AdminController(
         locale: String?,
         hasBase: Boolean?,
         hasOverride: Boolean?,
+        itemClassId: Int?,
+        itemSubclassId: Int?,
         page: Int,
         pageSize: Int,
     ): ResponseEntity<AdminItemPage> =
-        ResponseEntity.ok(adminItemService.searchItems(query, locale, hasBase, hasOverride, page, pageSize))
+        ResponseEntity.ok(
+            adminItemService.searchItems(query, locale, hasBase, hasOverride, itemClassId, itemSubclassId, page, pageSize),
+        )
 
     @PreAuthorize("hasAuthority('admin')")
     override suspend fun getAdminItem(

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/controller/AdminController.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/controller/AdminController.kt
@@ -115,11 +115,24 @@ class AdminController(
         hasOverride: Boolean?,
         itemClassId: Int?,
         itemSubclassId: Int?,
+        expansionId: Int?,
+        hasRecipe: Boolean?,
         page: Int,
         pageSize: Int,
     ): ResponseEntity<AdminItemPage> =
         ResponseEntity.ok(
-            adminItemService.searchItems(query, locale, hasBase, hasOverride, itemClassId, itemSubclassId, page, pageSize),
+            adminItemService.searchItems(
+                query,
+                locale,
+                hasBase,
+                hasOverride,
+                itemClassId,
+                itemSubclassId,
+                expansionId,
+                hasRecipe,
+                page,
+                pageSize,
+            ),
         )
 
     @PreAuthorize("hasAuthority('admin')")

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/controller/AdminController.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/controller/AdminController.kt
@@ -12,6 +12,8 @@ import net.jonasmf.auctionengine.generated.model.AdminItemCreateRequest
 import net.jonasmf.auctionengine.generated.model.AdminItemOverrideRequest
 import net.jonasmf.auctionengine.generated.model.AdminItemPage
 import net.jonasmf.auctionengine.generated.model.AdminJob
+import net.jonasmf.auctionengine.generated.model.AdminRecipeAssociationRequest
+import net.jonasmf.auctionengine.generated.model.AdminRecipeSearchResult
 import net.jonasmf.auctionengine.generated.model.AdminSqlExecuteRequest
 import net.jonasmf.auctionengine.generated.model.AdminSqlMetadata
 import net.jonasmf.auctionengine.generated.model.AdminSqlResult
@@ -126,10 +128,25 @@ class AdminController(
         ResponseEntity.ok(adminItemService.getItem(id, locale, includeBase, includeOverride))
 
     @PreAuthorize("hasAuthority('admin')")
+    override suspend fun searchAdminRecipes(
+        query: String?,
+        locale: String?,
+        limit: Int,
+    ): ResponseEntity<List<AdminRecipeSearchResult>> =
+        ResponseEntity.ok(adminItemService.searchRecipes(query, locale, limit))
+
+    @PreAuthorize("hasAuthority('admin')")
     override suspend fun upsertAdminItemOverride(
         id: Int,
         body: AdminItemOverrideRequest,
     ): ResponseEntity<AdminItem1> = ResponseEntity.ok(adminItemService.upsertOverride(id, body))
+
+    @PreAuthorize("hasAuthority('admin')")
+    override suspend fun upsertAdminItemRecipeAssociation(
+        id: Int,
+        recipeId: Int,
+        body: AdminRecipeAssociationRequest,
+    ): ResponseEntity<AdminItem1> = ResponseEntity.ok(adminItemService.upsertRecipeAssociation(id, recipeId, body))
 
     @PreAuthorize("hasAuthority('admin')")
     override suspend fun deleteAdminItemOverride(id: Int): ResponseEntity<Unit> {

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/integration/blizzard/ItemApiClient.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/integration/blizzard/ItemApiClient.kt
@@ -14,13 +14,17 @@ private val ITEM_API_RETRY_BACKOFF: Duration = Duration.ofSeconds(2)
 
 const val ITEM_BASE_PATH = "/data/wow/item"
 
+interface ItemApiLookup {
+    fun getById(id: Int): Item
+}
+
 @Component
 class ItemApiClient(
     private val blizzardApiSupport: BlizzardApiSupport,
-) {
+) : ItemApiLookup {
     private val logger: Logger = LoggerFactory.getLogger(ItemApiClient::class.java)
 
-    fun getById(id: Int): Item = getById(id, blizzardApiSupport.defaultRegion())
+    override fun getById(id: Int): Item = getById(id, blizzardApiSupport.defaultRegion())
 
     fun getById(
         id: Int,

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AdminExpansionRepository.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AdminExpansionRepository.kt
@@ -282,6 +282,7 @@ class AdminExpansionRepository(
                         INNER JOIN expansion_item_range r
                             ON r.enabled = TRUE
                             AND i.id BETWEEN r.start_item_id AND r.end_item_id
+                    WHERE i.is_override = FALSE
                     GROUP BY i.id
                     HAVING COUNT(DISTINCT r.expansion_id) > 1
                 ) conflicts
@@ -298,6 +299,7 @@ class AdminExpansionRepository(
                         INNER JOIN expansion_item_range r
                             ON r.enabled = TRUE
                             AND i.id BETWEEN r.start_item_id AND r.end_item_id
+                    WHERE i.is_override = FALSE
                     GROUP BY i.id
                     HAVING COUNT(DISTINCT r.expansion_id) = 1
                 ) matched
@@ -314,9 +316,11 @@ class AdminExpansionRepository(
                             INNER JOIN expansion_item_range r
                                 ON r.enabled = TRUE
                                 AND i2.id BETWEEN r.start_item_id AND r.end_item_id
+                        WHERE i2.is_override = FALSE
                         GROUP BY i2.id
                         HAVING COUNT(DISTINCT r.expansion_id) = 1
                     ) matched ON matched.item_id = i.id
+                        AND i.is_override = FALSE
                 SET i.expansion_id = matched.expansion_id
                 """.trimIndent(),
             )

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AdminItemRepository.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AdminItemRepository.kt
@@ -8,6 +8,7 @@ import net.jonasmf.auctionengine.generated.model.AdminItemFields
 import net.jonasmf.auctionengine.generated.model.AdminItemOverrideRequest
 import net.jonasmf.auctionengine.generated.model.AdminItemReference
 import net.jonasmf.auctionengine.generated.model.AdminItemRecipe
+import net.jonasmf.auctionengine.generated.model.AdminRecipeSearchResult
 import net.jonasmf.auctionengine.generated.model.GameLocale
 import net.jonasmf.auctionengine.generated.model.PageMetadata
 import net.jonasmf.auctionengine.mapper.toGameLocale
@@ -98,6 +99,20 @@ interface AdminItemRepositoryPort {
     )
 
     fun deleteOverride(id: Int): Boolean
+
+    fun recipeExists(recipeId: Int): Boolean
+
+    fun searchRecipes(
+        query: String?,
+        limit: Int,
+        localeColumnSuffix: String,
+    ): List<AdminRecipeSearchResult>
+
+    fun updateRecipeCraftedItem(
+        recipeId: Int,
+        craftedItemId: Int?,
+        craftedQuantity: Int?,
+    ): Boolean
 }
 
 @Repository
@@ -350,6 +365,78 @@ class AdminItemRepository(
     override fun deleteOverride(id: Int): Boolean =
         jdbcTemplate.update("DELETE FROM `item` WHERE id = ? AND is_override = TRUE", id) > 0
 
+    override fun recipeExists(recipeId: Int): Boolean =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM recipe WHERE id = ?",
+            Long::class.java,
+            recipeId,
+        )!! > 0
+
+    override fun searchRecipes(
+        query: String?,
+        limit: Int,
+        localeColumnSuffix: String,
+    ): List<AdminRecipeSearchResult> {
+        val params = mutableListOf<Any?>()
+        val whereSql = recipeSearchWhereSql(query, localeColumnSuffix, params)
+        params += limit
+        return jdbcTemplate.query(
+            """
+            SELECT
+                r.id AS recipe_id,
+                COALESCE(r_l.$localeColumnSuffix, r_l.en_gb, r_l.en_us, CAST(r.id AS CHAR)) AS recipe_name,
+                COALESCE(p_l.$localeColumnSuffix, p_l.en_gb, p_l.en_us, CAST(p.id AS CHAR), 'Unknown profession') AS profession_name,
+                COALESCE(st_l.$localeColumnSuffix, st_l.en_gb, st_l.en_us, CAST(st.id AS CHAR), 'Unknown skill tier') AS skill_tier_name,
+                COALESCE(pc_l.$localeColumnSuffix, pc_l.en_gb, pc_l.en_us, CAST(pc.internal_id AS CHAR), 'Unknown category') AS profession_category_name,
+                r.crafted_item_id,
+                COALESCE(item_l.$localeColumnSuffix, item_l.en_gb, item_l.en_us, CAST(r.crafted_item_id AS CHAR)) AS crafted_item_name,
+                r.crafted_quantity
+            FROM recipe r
+                LEFT JOIN locale r_l ON r_l.id = r.name_id
+                LEFT JOIN profession_category pc ON pc.internal_id = r.profession_category_id
+                LEFT JOIN locale pc_l ON pc_l.id = pc.name_id
+                LEFT JOIN skill_tier st ON st.id = pc.skill_tier_id
+                LEFT JOIN locale st_l ON st_l.id = st.name_id
+                LEFT JOIN profession p ON p.id = st.profession_id
+                LEFT JOIN locale p_l ON p_l.id = p.name_id
+                LEFT JOIN v_item crafted_item ON crafted_item.id = r.crafted_item_id
+                LEFT JOIN locale item_l ON item_l.id = crafted_item.name_id
+            $whereSql
+            ORDER BY profession_name, skill_tier_name, profession_category_name, recipe_name, r.id
+            LIMIT ?
+            """.trimIndent(),
+            { rs, _ ->
+                AdminRecipeSearchResult(
+                    recipeId = rs.getInt("recipe_id"),
+                    name = rs.getString("recipe_name"),
+                    professionName = rs.getString("profession_name"),
+                    skillTierName = rs.getString("skill_tier_name"),
+                    professionCategoryName = rs.getString("profession_category_name"),
+                    craftedItemId = rs.nullableInt("crafted_item_id"),
+                    craftedItemName = rs.getString("crafted_item_name"),
+                    craftedQuantity = rs.nullableInt("crafted_quantity"),
+                )
+            },
+            *params.toTypedArray(),
+        )
+    }
+
+    override fun updateRecipeCraftedItem(
+        recipeId: Int,
+        craftedItemId: Int?,
+        craftedQuantity: Int?,
+    ): Boolean =
+        jdbcTemplate.update(
+            """
+            UPDATE recipe
+            SET crafted_item_id = ?, crafted_quantity = ?
+            WHERE id = ?
+            """.trimIndent(),
+            craftedItemId,
+            craftedQuantity,
+            recipeId,
+        ) > 0
+
     private fun lookupIdByType(
         tableName: String,
         type: String,
@@ -457,6 +544,30 @@ class AdminItemRepository(
             clauses += if (hasOverride) "override_item.id IS NOT NULL" else "override_item.id IS NULL"
         }
         return if (clauses.isEmpty()) "" else "WHERE ${clauses.joinToString(" AND ")}"
+    }
+
+    private fun recipeSearchWhereSql(
+        query: String?,
+        localeColumnSuffix: String,
+        params: MutableList<Any?>,
+    ): String {
+        val normalizedQuery = query?.trim().orEmpty()
+        if (normalizedQuery.isEmpty()) return ""
+        normalizedQuery.toIntOrNull()?.let { recipeId ->
+            params += recipeId
+            return "WHERE r.id = ?"
+        }
+        val likeQuery = "%$normalizedQuery%"
+        params += likeQuery
+        params += likeQuery
+        params += likeQuery
+        return """
+            WHERE (
+                r_l.$localeColumnSuffix LIKE ?
+                OR r_l.en_gb LIKE ?
+                OR r_l.en_us LIKE ?
+            )
+        """.trimIndent()
     }
 
     private fun itemSelectSql(

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AdminItemRepository.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AdminItemRepository.kt
@@ -7,6 +7,7 @@ import net.jonasmf.auctionengine.generated.model.AdminItemCreateRequest
 import net.jonasmf.auctionengine.generated.model.AdminItemFields
 import net.jonasmf.auctionengine.generated.model.AdminItemOverrideRequest
 import net.jonasmf.auctionengine.generated.model.AdminItemReference
+import net.jonasmf.auctionengine.generated.model.AdminItemRecipe
 import net.jonasmf.auctionengine.generated.model.GameLocale
 import net.jonasmf.auctionengine.generated.model.PageMetadata
 import net.jonasmf.auctionengine.mapper.toGameLocale
@@ -150,7 +151,10 @@ class AdminItemRepository(
                 },
                 *itemParams.toTypedArray(),
             )
-        return AdminItemSearchResult(items = items, totalItems = count)
+        return AdminItemSearchResult(
+            items = items.withRecipes(localeColumnSuffix),
+            totalItems = count,
+        )
     }
 
     override fun pageMetadata(
@@ -169,7 +173,10 @@ class AdminItemRepository(
         id: Int,
         localeColumnSuffix: String,
     ): AdminItemRows? {
-        val effective = findFields("v_item", "i.id = ?", localeColumnSuffix, id) ?: return null
+        val effective =
+            findFields("v_item", "i.id = ?", localeColumnSuffix, id)
+                ?.withRecipes(localeColumnSuffix)
+                ?: return null
         return AdminItemRows(
             effective = effective,
             base = findFields("`item`", "i.id = ? AND i.is_override = FALSE", localeColumnSuffix, id),
@@ -367,8 +374,53 @@ class AdminItemRepository(
                 WHERE $whereSql
                 """.trimIndent(),
                 { rs, _ -> rs.toAdminItemFields() },
-                *params,
-            ).firstOrNull()
+            *params,
+        ).firstOrNull()
+
+    private fun AdminItemFields.withRecipes(localeColumnSuffix: String): AdminItemFields =
+        copy(recipes = recipesByItemId(listOf(id ?: return this), localeColumnSuffix)[id].orEmpty())
+
+    private fun List<AdminItem1>.withRecipes(localeColumnSuffix: String): List<AdminItem1> {
+        val recipesByItemId = recipesByItemId(map { it.id }, localeColumnSuffix)
+        return map { item ->
+            item.copy(effective = item.effective.copy(recipes = recipesByItemId[item.id].orEmpty()))
+        }
+    }
+
+    private fun recipesByItemId(
+        itemIds: List<Int>,
+        localeColumnSuffix: String,
+    ): Map<Int, List<AdminItemRecipe>> {
+        if (itemIds.isEmpty()) return emptyMap()
+        val placeholders = itemIds.joinToString(",") { "?" }
+        return jdbcTemplate
+            .query(
+                """
+                SELECT
+                    r.crafted_item_id,
+                    r.id AS recipe_id,
+                    COALESCE(r_l.$localeColumnSuffix, r_l.en_gb, r_l.en_us, CAST(r.id AS CHAR)) AS recipe_name,
+                    COALESCE(p_l.$localeColumnSuffix, p_l.en_gb, p_l.en_us, CAST(p.id AS CHAR), 'Unknown profession') AS profession_name
+                FROM recipe r
+                    LEFT JOIN locale r_l ON r_l.id = r.name_id
+                    LEFT JOIN profession_category pc ON pc.internal_id = r.profession_category_id
+                    LEFT JOIN skill_tier st ON st.id = pc.skill_tier_id
+                    LEFT JOIN profession p ON p.id = st.profession_id
+                    LEFT JOIN locale p_l ON p_l.id = p.name_id
+                WHERE r.crafted_item_id IN ($placeholders)
+                ORDER BY r.crafted_item_id, profession_name, recipe_name, r.id
+                """.trimIndent(),
+                { rs, _ ->
+                    rs.getInt("crafted_item_id") to
+                        AdminItemRecipe(
+                            recipeId = rs.getInt("recipe_id"),
+                            name = rs.getString("recipe_name"),
+                            professionName = rs.getString("profession_name"),
+                        )
+                },
+                *itemIds.toTypedArray(),
+            ).groupBy({ it.first }, { it.second })
+    }
 
     private fun itemSearchWhereSql(
         query: String?,

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AdminItemRepository.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AdminItemRepository.kt
@@ -52,6 +52,8 @@ interface AdminItemRepositoryPort {
         hasOverride: Boolean?,
         itemClassId: Int?,
         itemSubclassId: Int?,
+        expansionId: Int?,
+        hasRecipe: Boolean?,
         page: Int,
         pageSize: Int,
         localeColumnSuffix: String,
@@ -128,13 +130,25 @@ class AdminItemRepository(
         hasOverride: Boolean?,
         itemClassId: Int?,
         itemSubclassId: Int?,
+        expansionId: Int?,
+        hasRecipe: Boolean?,
         page: Int,
         pageSize: Int,
         localeColumnSuffix: String,
     ): AdminItemSearchResult {
         val params = mutableListOf<Any?>()
         val whereSql =
-            itemSearchWhereSql(query, hasBase, hasOverride, itemClassId, itemSubclassId, localeColumnSuffix, params)
+            itemSearchWhereSql(
+                query,
+                hasBase,
+                hasOverride,
+                itemClassId,
+                itemSubclassId,
+                expansionId,
+                hasRecipe,
+                localeColumnSuffix,
+                params,
+            )
         val count =
             jdbcTemplate.queryForObject(
                 """
@@ -520,6 +534,8 @@ class AdminItemRepository(
         hasOverride: Boolean?,
         itemClassId: Int?,
         itemSubclassId: Int?,
+        expansionId: Int?,
+        hasRecipe: Boolean?,
         localeColumnSuffix: String,
         params: MutableList<Any?>,
     ): String {
@@ -566,6 +582,18 @@ class AdminItemRepository(
                 )
                 """.trimIndent()
             params += it
+        }
+        expansionId?.let {
+            clauses += "i.expansion_id = ?"
+            params += it
+        }
+        if (hasRecipe != null) {
+            clauses +=
+                if (hasRecipe) {
+                    "EXISTS (SELECT 1 FROM recipe r WHERE r.crafted_item_id = i.id)"
+                } else {
+                    "NOT EXISTS (SELECT 1 FROM recipe r WHERE r.crafted_item_id = i.id)"
+                }
         }
         return if (clauses.isEmpty()) "" else "WHERE ${clauses.joinToString(" AND ")}"
     }

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AdminItemRepository.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AdminItemRepository.kt
@@ -50,6 +50,8 @@ interface AdminItemRepositoryPort {
         query: String?,
         hasBase: Boolean?,
         hasOverride: Boolean?,
+        itemClassId: Int?,
+        itemSubclassId: Int?,
         page: Int,
         pageSize: Int,
         localeColumnSuffix: String,
@@ -124,12 +126,15 @@ class AdminItemRepository(
         query: String?,
         hasBase: Boolean?,
         hasOverride: Boolean?,
+        itemClassId: Int?,
+        itemSubclassId: Int?,
         page: Int,
         pageSize: Int,
         localeColumnSuffix: String,
     ): AdminItemSearchResult {
         val params = mutableListOf<Any?>()
-        val whereSql = itemSearchWhereSql(query, hasBase, hasOverride, localeColumnSuffix, params)
+        val whereSql =
+            itemSearchWhereSql(query, hasBase, hasOverride, itemClassId, itemSubclassId, localeColumnSuffix, params)
         val count =
             jdbcTemplate.queryForObject(
                 """
@@ -513,6 +518,8 @@ class AdminItemRepository(
         query: String?,
         hasBase: Boolean?,
         hasOverride: Boolean?,
+        itemClassId: Int?,
+        itemSubclassId: Int?,
         localeColumnSuffix: String,
         params: MutableList<Any?>,
     ): String {
@@ -542,6 +549,23 @@ class AdminItemRepository(
         }
         if (hasOverride != null) {
             clauses += if (hasOverride) "override_item.id IS NOT NULL" else "override_item.id IS NULL"
+        }
+        itemClassId?.let {
+            clauses += "i.item_class_id = ?"
+            params += it
+        }
+        itemSubclassId?.let {
+            clauses +=
+                """
+                EXISTS (
+                    SELECT 1
+                    FROM item_subclass isc
+                    WHERE isc.internal_id = i.item_subclass_id
+                      AND isc.class_id <=> i.item_class_id
+                      AND isc.subclass_id = ?
+                )
+                """.trimIndent()
+            params += it
         }
         return if (clauses.isEmpty()) "" else "WHERE ${clauses.joinToString(" AND ")}"
     }

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AdminItemRepository.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AdminItemRepository.kt
@@ -1,0 +1,583 @@
+package net.jonasmf.auctionengine.repository.rds
+
+import net.jonasmf.auctionengine.dbo.rds.LocaleSourceType
+import net.jonasmf.auctionengine.generated.model.AdminExpansion1
+import net.jonasmf.auctionengine.generated.model.AdminItem1
+import net.jonasmf.auctionengine.generated.model.AdminItemCreateRequest
+import net.jonasmf.auctionengine.generated.model.AdminItemFields
+import net.jonasmf.auctionengine.generated.model.AdminItemOverrideRequest
+import net.jonasmf.auctionengine.generated.model.AdminItemReference
+import net.jonasmf.auctionengine.generated.model.GameLocale
+import net.jonasmf.auctionengine.generated.model.PageMetadata
+import net.jonasmf.auctionengine.mapper.toGameLocale
+import net.jonasmf.auctionengine.mapper.toLocaleDTO
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+import java.sql.ResultSet
+import java.sql.Timestamp
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import kotlin.math.ceil
+
+data class AdminItemSearchResult(
+    val items: List<AdminItem1>,
+    val totalItems: Long,
+)
+
+data class AdminItemRows(
+    val effective: AdminItemFields,
+    val base: AdminItemFields?,
+    val override: AdminItemFields?,
+) {
+    fun toAdminItem(
+        includeBase: Boolean,
+        includeOverride: Boolean,
+    ): AdminItem1 =
+        AdminItem1(
+            id = effective.id ?: error("Effective item id is missing"),
+            hasBase = base != null,
+            hasOverride = override != null,
+            effective = effective,
+            base = base.takeIf { includeBase },
+            `override` = override.takeIf { includeOverride },
+        )
+}
+
+interface AdminItemRepositoryPort {
+    fun searchItems(
+        query: String?,
+        hasBase: Boolean?,
+        hasOverride: Boolean?,
+        page: Int,
+        pageSize: Int,
+        localeColumnSuffix: String,
+    ): AdminItemSearchResult
+
+    fun pageMetadata(
+        page: Int,
+        pageSize: Int,
+        totalItems: Long,
+    ): PageMetadata
+
+    fun findItemRows(
+        id: Int,
+        localeColumnSuffix: String,
+    ): AdminItemRows?
+
+    fun hasAnyItemRow(id: Int): Boolean
+
+    fun hasBaseItem(id: Int): Boolean
+
+    fun hasOverrideItem(id: Int): Boolean
+
+    fun qualityId(type: String): Long?
+
+    fun inventoryTypeId(type: String): Long?
+
+    fun bindingId(type: String): Long?
+
+    fun itemClassExists(id: Int): Boolean
+
+    fun itemSubclassInternalId(
+        classId: Int,
+        subclassId: Int,
+    ): Long?
+
+    fun expansionExists(expansionId: Int): Boolean
+
+    fun upsertOverride(
+        id: Int,
+        request: AdminItemOverrideRequest,
+        itemSubclassInternalId: Long?,
+    )
+
+    fun createOverrideOnly(
+        request: AdminItemCreateRequest,
+        itemSubclassInternalId: Long,
+    )
+
+    fun deleteOverride(id: Int): Boolean
+}
+
+@Repository
+class AdminItemRepository(
+    private val jdbcTemplate: JdbcTemplate,
+    private val localeJdbcRepository: LocaleJdbcRepository,
+) : AdminItemRepositoryPort {
+    override fun searchItems(
+        query: String?,
+        hasBase: Boolean?,
+        hasOverride: Boolean?,
+        page: Int,
+        pageSize: Int,
+        localeColumnSuffix: String,
+    ): AdminItemSearchResult {
+        val params = mutableListOf<Any?>()
+        val whereSql = itemSearchWhereSql(query, hasBase, hasOverride, localeColumnSuffix, params)
+        val count =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM v_item i
+                    LEFT JOIN `item` base_item ON base_item.id = i.id AND base_item.is_override = FALSE
+                    LEFT JOIN `item` override_item ON override_item.id = i.id AND override_item.is_override = TRUE
+                    LEFT JOIN locale name_l ON name_l.id = i.name_id
+                $whereSql
+                """.trimIndent(),
+                Long::class.java,
+                *params.toTypedArray(),
+            ) ?: 0
+
+        val offset = (page - 1) * pageSize
+        val itemParams = params.toMutableList()
+        itemParams += pageSize
+        itemParams += offset
+        val items =
+            jdbcTemplate.query(
+                """
+                ${itemSelectSql("v_item", localeColumnSuffix)}
+                $whereSql
+                ORDER BY i.id
+                LIMIT ? OFFSET ?
+                """.trimIndent(),
+                { rs, _ ->
+                    AdminItem1(
+                        id = rs.getInt("id"),
+                        hasBase = rs.getBoolean("has_base"),
+                        hasOverride = rs.getBoolean("has_override"),
+                        effective = rs.toAdminItemFields(),
+                    )
+                },
+                *itemParams.toTypedArray(),
+            )
+        return AdminItemSearchResult(items = items, totalItems = count)
+    }
+
+    override fun pageMetadata(
+        page: Int,
+        pageSize: Int,
+        totalItems: Long,
+    ): PageMetadata =
+        PageMetadata(
+            page = page,
+            pageSize = pageSize,
+            totalItems = totalItems,
+            totalPages = if (totalItems == 0L) 0 else ceil(totalItems.toDouble() / pageSize).toInt(),
+        )
+
+    override fun findItemRows(
+        id: Int,
+        localeColumnSuffix: String,
+    ): AdminItemRows? {
+        val effective = findFields("v_item", "i.id = ?", localeColumnSuffix, id) ?: return null
+        return AdminItemRows(
+            effective = effective,
+            base = findFields("`item`", "i.id = ? AND i.is_override = FALSE", localeColumnSuffix, id),
+            override = findFields("`item`", "i.id = ? AND i.is_override = TRUE", localeColumnSuffix, id),
+        )
+    }
+
+    override fun hasAnyItemRow(id: Int): Boolean =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM `item` WHERE id = ?",
+            Long::class.java,
+            id,
+        )!! > 0
+
+    override fun hasBaseItem(id: Int): Boolean =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM `item` WHERE id = ? AND is_override = FALSE",
+            Long::class.java,
+            id,
+        )!! > 0
+
+    override fun hasOverrideItem(id: Int): Boolean =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM `item` WHERE id = ? AND is_override = TRUE",
+            Long::class.java,
+            id,
+        )!! > 0
+
+    override fun qualityId(type: String): Long? = lookupIdByType("item_quality", type)
+
+    override fun inventoryTypeId(type: String): Long? = lookupIdByType("inventory_type", type)
+
+    override fun bindingId(type: String): Long? = lookupIdByType("item_binding", type)
+
+    override fun itemClassExists(id: Int): Boolean =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM item_class WHERE id = ?",
+            Long::class.java,
+            id,
+        )!! > 0
+
+    override fun itemSubclassInternalId(
+        classId: Int,
+        subclassId: Int,
+    ): Long? =
+        jdbcTemplate
+            .query(
+                "SELECT internal_id FROM item_subclass WHERE class_id = ? AND subclass_id = ?",
+                { rs, _ -> rs.getLong("internal_id") },
+                classId,
+                subclassId,
+            ).firstOrNull()
+
+    override fun expansionExists(expansionId: Int): Boolean =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM expansion WHERE id = ?",
+            Long::class.java,
+            expansionId,
+        )!! > 0
+
+    override fun upsertOverride(
+        id: Int,
+        request: AdminItemOverrideRequest,
+        itemSubclassInternalId: Long?,
+    ) {
+        val nameId =
+            request.nameLocales?.let {
+                localeJdbcRepository.upsert(
+                    LocaleSourceType.ITEM,
+                    overrideLocaleSourceKey(id),
+                    "name",
+                    it.toLocaleDTO(),
+                )
+            }
+        jdbcTemplate.update(
+            """
+            INSERT INTO `item` (
+                id,
+                is_override,
+                name_id,
+                quality_id,
+                level,
+                required_level,
+                media_url,
+                media_source_url,
+                item_class_id,
+                item_subclass_id,
+                inventory_type_id,
+                binding_id,
+                purchase_price,
+                sell_price,
+                max_count,
+                is_equippable,
+                is_stackable,
+                purchase_quantity,
+                expansion_id,
+                override_note
+            ) VALUES (?, TRUE, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE
+                name_id = VALUES(name_id),
+                quality_id = VALUES(quality_id),
+                level = VALUES(level),
+                required_level = VALUES(required_level),
+                media_url = VALUES(media_url),
+                media_source_url = VALUES(media_source_url),
+                item_class_id = VALUES(item_class_id),
+                item_subclass_id = VALUES(item_subclass_id),
+                inventory_type_id = VALUES(inventory_type_id),
+                binding_id = VALUES(binding_id),
+                purchase_price = VALUES(purchase_price),
+                sell_price = VALUES(sell_price),
+                max_count = VALUES(max_count),
+                is_equippable = VALUES(is_equippable),
+                is_stackable = VALUES(is_stackable),
+                purchase_quantity = VALUES(purchase_quantity),
+                expansion_id = VALUES(expansion_id),
+                override_note = VALUES(override_note)
+            """.trimIndent(),
+            id,
+            nameId,
+            request.qualityType?.let { qualityId(it) },
+            request.level,
+            request.requiredLevel,
+            request.mediaUrl,
+            request.mediaSourceUrl,
+            request.itemClassId,
+            itemSubclassInternalId,
+            request.inventoryType?.let { inventoryTypeId(it) },
+            request.bindingType?.let { bindingId(it) },
+            request.purchasePrice,
+            request.sellPrice,
+            request.maxCount,
+            request.isEquippable,
+            request.isStackable,
+            request.purchaseQuantity,
+            request.expansionId,
+            request.overrideNote,
+        )
+    }
+
+    override fun createOverrideOnly(
+        request: AdminItemCreateRequest,
+        itemSubclassInternalId: Long,
+    ) {
+        upsertOverride(
+            request.id,
+            AdminItemOverrideRequest(
+                nameLocales = request.nameLocales,
+                qualityType = request.qualityType,
+                level = request.level,
+                requiredLevel = request.requiredLevel,
+                mediaUrl = request.mediaUrl,
+                mediaSourceUrl = request.mediaSourceUrl,
+                itemClassId = request.itemClassId,
+                itemSubclassId = request.itemSubclassId,
+                inventoryType = request.inventoryType,
+                bindingType = request.bindingType,
+                purchasePrice = request.purchasePrice,
+                sellPrice = request.sellPrice,
+                maxCount = request.maxCount,
+                isEquippable = request.isEquippable,
+                isStackable = request.isStackable,
+                purchaseQuantity = request.purchaseQuantity,
+                expansionId = request.expansionId,
+                overrideNote = request.overrideNote,
+            ),
+            itemSubclassInternalId,
+        )
+    }
+
+    override fun deleteOverride(id: Int): Boolean =
+        jdbcTemplate.update("DELETE FROM `item` WHERE id = ? AND is_override = TRUE", id) > 0
+
+    private fun lookupIdByType(
+        tableName: String,
+        type: String,
+    ): Long? =
+        jdbcTemplate
+            .query(
+                "SELECT internal_id FROM $tableName WHERE type = ?",
+                { rs, _ -> rs.getLong("internal_id") },
+                type,
+            ).firstOrNull()
+
+    private fun findFields(
+        tableName: String,
+        whereSql: String,
+        localeColumnSuffix: String,
+        vararg params: Any?,
+    ): AdminItemFields? =
+        jdbcTemplate
+            .query(
+                """
+                ${itemSelectSql(tableName, localeColumnSuffix)}
+                WHERE $whereSql
+                """.trimIndent(),
+                { rs, _ -> rs.toAdminItemFields() },
+                *params,
+            ).firstOrNull()
+
+    private fun itemSearchWhereSql(
+        query: String?,
+        hasBase: Boolean?,
+        hasOverride: Boolean?,
+        localeColumnSuffix: String,
+        params: MutableList<Any?>,
+    ): String {
+        val clauses = mutableListOf<String>()
+        val normalizedQuery = query?.trim().orEmpty()
+        if (normalizedQuery.isNotEmpty()) {
+            normalizedQuery.toIntOrNull()?.let { itemId ->
+                clauses += "i.id = ?"
+                params += itemId
+            } ?: run {
+                val likeQuery = "%$normalizedQuery%"
+                clauses +=
+                    """
+                    (
+                        name_l.$localeColumnSuffix LIKE ?
+                        OR name_l.en_gb LIKE ?
+                        OR name_l.en_us LIKE ?
+                    )
+                    """.trimIndent()
+                params += likeQuery
+                params += likeQuery
+                params += likeQuery
+            }
+        }
+        if (hasBase != null) {
+            clauses += if (hasBase) "base_item.id IS NOT NULL" else "base_item.id IS NULL"
+        }
+        if (hasOverride != null) {
+            clauses += if (hasOverride) "override_item.id IS NOT NULL" else "override_item.id IS NULL"
+        }
+        return if (clauses.isEmpty()) "" else "WHERE ${clauses.joinToString(" AND ")}"
+    }
+
+    private fun itemSelectSql(
+        tableName: String,
+        localeColumnSuffix: String,
+    ): String =
+        """
+        SELECT
+            i.id,
+            base_item.id IS NOT NULL AS has_base,
+            override_item.id IS NOT NULL AS has_override,
+            i.name_id,
+            COALESCE(name_l.$localeColumnSuffix, name_l.en_gb, name_l.en_us) AS item_name,
+            name_l.en_us,
+            name_l.en_gb,
+            name_l.de_de,
+            name_l.es_es,
+            name_l.es_mx,
+            name_l.fr_fr,
+            name_l.it_it,
+            name_l.ko_kr,
+            name_l.pt_br,
+            name_l.pt_pt,
+            name_l.ru_ru,
+            name_l.zh_cn,
+            name_l.zh_tw,
+            q.internal_id AS quality_id,
+            q.type AS quality_type,
+            COALESCE(q_l.$localeColumnSuffix, q_l.en_gb, q_l.en_us, q.type) AS quality_name,
+            i.level,
+            i.required_level,
+            i.media_url,
+            i.media_source_url,
+            c.id AS item_class_id,
+            COALESCE(c_l.$localeColumnSuffix, c_l.en_gb, c_l.en_us) AS item_class_name,
+            sc.internal_id AS item_subclass_internal_id,
+            sc.subclass_id AS item_subclass_id,
+            COALESCE(sc_l.$localeColumnSuffix, sc_l.en_gb, sc_l.en_us) AS item_subclass_name,
+            inv.internal_id AS inventory_type_id,
+            inv.type AS inventory_type,
+            COALESCE(inv_l.$localeColumnSuffix, inv_l.en_gb, inv_l.en_us, inv.type) AS inventory_type_name,
+            b.internal_id AS binding_id,
+            b.type AS binding_type,
+            COALESCE(b_l.$localeColumnSuffix, b_l.en_gb, b_l.en_us, b.type) AS binding_name,
+            i.purchase_price,
+            i.sell_price,
+            i.max_count,
+            i.is_equippable,
+            i.is_stackable,
+            i.purchase_quantity,
+            e.id AS expansion_id,
+            e.slug AS expansion_slug,
+            e.major_version AS expansion_major_version,
+            e.display_order AS expansion_display_order,
+            COALESCE(e_l.$localeColumnSuffix, e_l.en_gb, e_l.en_us, e.slug) AS expansion_name,
+            e_l.en_us AS expansion_en_us,
+            e_l.en_gb AS expansion_en_gb,
+            e_l.de_de AS expansion_de_de,
+            e_l.es_es AS expansion_es_es,
+            e_l.es_mx AS expansion_es_mx,
+            e_l.fr_fr AS expansion_fr_fr,
+            e_l.it_it AS expansion_it_it,
+            e_l.ko_kr AS expansion_ko_kr,
+            e_l.pt_br AS expansion_pt_br,
+            e_l.pt_pt AS expansion_pt_pt,
+            e_l.ru_ru AS expansion_ru_ru,
+            e_l.zh_cn AS expansion_zh_cn,
+            e_l.zh_tw AS expansion_zh_tw,
+            i.override_note,
+            i.created_at,
+            i.updated_at
+        FROM $tableName i
+            LEFT JOIN `item` base_item ON base_item.id = i.id AND base_item.is_override = FALSE
+            LEFT JOIN `item` override_item ON override_item.id = i.id AND override_item.is_override = TRUE
+            LEFT JOIN locale name_l ON name_l.id = i.name_id
+            LEFT JOIN item_quality q ON q.internal_id = i.quality_id
+            LEFT JOIN locale q_l ON q_l.id = q.name_id
+            LEFT JOIN item_class c ON c.id = i.item_class_id
+            LEFT JOIN locale c_l ON c_l.id = c.name_id
+            LEFT JOIN item_subclass sc ON sc.internal_id = i.item_subclass_id
+            LEFT JOIN locale sc_l ON sc_l.id = sc.display_name_id
+            LEFT JOIN inventory_type inv ON inv.internal_id = i.inventory_type_id
+            LEFT JOIN locale inv_l ON inv_l.id = inv.name_id
+            LEFT JOIN item_binding b ON b.internal_id = i.binding_id
+            LEFT JOIN locale b_l ON b_l.id = b.name_id
+            LEFT JOIN expansion e ON e.id = i.expansion_id
+            LEFT JOIN locale e_l ON e_l.id = e.name_id
+        """.trimIndent()
+}
+
+fun overrideLocaleSourceKey(id: Int): String = "override:$id"
+
+private fun ResultSet.toAdminItemFields(): AdminItemFields =
+    AdminItemFields(
+        id = getInt("id"),
+        name = getString("item_name"),
+        nameLocales = nullableLong("name_id")?.let { toLocaleDTO().toGameLocale() },
+        quality = reference("quality_id", "quality_name", "quality_type"),
+        level = nullableInt("level"),
+        requiredLevel = nullableInt("required_level"),
+        mediaUrl = getString("media_url"),
+        mediaSourceUrl = getString("media_source_url"),
+        itemClass = reference("item_class_id", "item_class_name"),
+        itemSubclass = reference("item_subclass_id", "item_subclass_name"),
+        inventoryType = reference("inventory_type_id", "inventory_type_name", "inventory_type"),
+        binding = reference("binding_id", "binding_name", "binding_type"),
+        purchasePrice = nullableInt("purchase_price"),
+        sellPrice = nullableInt("sell_price"),
+        maxCount = nullableInt("max_count"),
+        isEquippable = nullableBoolean("is_equippable"),
+        isStackable = nullableBoolean("is_stackable"),
+        purchaseQuantity = nullableInt("purchase_quantity"),
+        expansion = expansion(),
+        overrideNote = getString("override_note"),
+        createdAt = nullableTimestamp("created_at")?.toOffsetDateTime(),
+        updatedAt = nullableTimestamp("updated_at")?.toOffsetDateTime(),
+    )
+
+private fun ResultSet.reference(
+    idColumn: String,
+    nameColumn: String,
+    typeColumn: String? = null,
+): AdminItemReference? {
+    val id = nullableLong(idColumn) ?: return null
+    return AdminItemReference(
+        id = id,
+        name = getString(nameColumn),
+        type = typeColumn?.let { getString(it) },
+    )
+}
+
+private fun ResultSet.expansion(): AdminExpansion1? {
+    val id = nullableInt("expansion_id") ?: return null
+    return AdminExpansion1(
+        id = id,
+        slug = getString("expansion_slug"),
+        name = getString("expansion_name"),
+        nameLocales =
+            GameLocale(
+                enUS = getString("expansion_en_us"),
+                enGB = getString("expansion_en_gb"),
+                deDE = getString("expansion_de_de"),
+                esES = getString("expansion_es_es"),
+                esMX = getString("expansion_es_mx"),
+                frFR = getString("expansion_fr_fr"),
+                itIT = getString("expansion_it_it"),
+                koKR = getString("expansion_ko_kr"),
+                ptBR = getString("expansion_pt_br"),
+                ptPT = getString("expansion_pt_pt"),
+                ruRU = getString("expansion_ru_ru"),
+                zhCN = getString("expansion_zh_cn"),
+                zhTW = getString("expansion_zh_tw"),
+            ),
+        majorVersion = getInt("expansion_major_version"),
+        displayOrder = getInt("expansion_display_order"),
+    )
+}
+
+private fun ResultSet.nullableInt(column: String): Int? {
+    val value = getInt(column)
+    return if (wasNull()) null else value
+}
+
+private fun ResultSet.nullableLong(column: String): Long? {
+    val value = getLong(column)
+    return if (wasNull()) null else value
+}
+
+private fun ResultSet.nullableBoolean(column: String): Boolean? {
+    val value = getBoolean(column)
+    return if (wasNull()) null else value
+}
+
+private fun ResultSet.nullableTimestamp(column: String): Timestamp? = getTimestamp(column)
+
+private fun Timestamp.toOffsetDateTime(): OffsetDateTime = toInstant().atOffset(ZoneOffset.UTC)

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketItemDetailRepository.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketItemDetailRepository.kt
@@ -276,7 +276,7 @@ class AuctionMarketItemDetailRepository(
                 CASE WHEN rp.price IS NULL THEN NULL ELSE rp.price * rr.quantity END AS line_total
             FROM recipe_reagent rr
             LEFT JOIN reagent_price rp ON rp.item_id = rr.item_id
-            LEFT JOIN item i ON i.id = rr.item_id
+            LEFT JOIN v_item i ON i.id = rr.item_id
             LEFT JOIN locale i_l ON i_l.id = i.name_id
             WHERE rr.recipe_id IN ($placeholders)
             ORDER BY rr.recipe_id, name, rr.item_id

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketSearchRepository.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/AuctionMarketSearchRepository.kt
@@ -297,7 +297,7 @@ class AuctionMarketSearchRepository(
     }
 
     /**
-     * When set, quality/class/subclass/recipe filters are applied inside this subquery (via `item`)
+     * When set, quality/class/subclass/recipe filters are applied inside this subquery (via `v_item`)
      * so ranking touches fewer auction rows before joining the heavy view.
      */
     private fun pushesItemDimensionFiltersIntoAuctionSnapshot(request: AuctionMarketSearchRequest): Boolean =
@@ -314,7 +314,7 @@ class AuctionMarketSearchRepository(
         val useItemJoin = pushesItemDimensionFiltersIntoAuctionSnapshot(request)
         val itemJoin =
             if (useItemJoin) {
-                "INNER JOIN item i ON i.id = a.item_id\n                "
+                "INNER JOIN v_item i ON i.id = a.item_id\n                "
             } else {
                 ""
             }

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/ItemJdbcRepository.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/repository/rds/ItemJdbcRepository.kt
@@ -239,9 +239,12 @@ class ItemJdbcRepository(
                     aggregated.from_auction,
                     aggregated.from_crafted,
                     aggregated.from_reagent,
-                    CASE WHEN item.id IS NULL THEN 1 ELSE 0 END AS is_missing
+                    CASE WHEN existing_item.id IS NULL THEN 1 ELSE 0 END AS is_missing
                 FROM aggregated
-                LEFT JOIN `item` item ON item.id = aggregated.item_id
+                LEFT JOIN (
+                    SELECT DISTINCT id
+                    FROM `item`
+                ) existing_item ON existing_item.id = aggregated.item_id
             ),
             summary AS (
                 SELECT
@@ -319,7 +322,7 @@ class ItemJdbcRepository(
             .chunked(ITEM_JDBC_CHUNK_SIZE)
             .flatMap { chunk ->
                 jdbcTemplate.query(
-                    "SELECT id FROM `item` WHERE id IN (${placeholders(chunk.size)})",
+                    "SELECT DISTINCT id FROM `item` WHERE id IN (${placeholders(chunk.size)})",
                     { rs, _ -> rs.getInt("id") },
                     *chunk.toTypedArray(),
                 )
@@ -767,6 +770,7 @@ class ItemJdbcRepository(
                 """
                 INSERT INTO `item` (
                     id,
+                    is_override,
                     name_id,
                     quality_id,
                     level,
@@ -783,7 +787,7 @@ class ItemJdbcRepository(
                     is_equippable,
                     is_stackable,
                     purchase_quantity
-                ) VALUES ${chunk.joinToString(",") { "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)" }}
+                ) VALUES ${chunk.joinToString(",") { "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)" }}
                 ON DUPLICATE KEY UPDATE
                     name_id = VALUES(name_id),
                     quality_id = VALUES(quality_id),
@@ -806,6 +810,7 @@ class ItemJdbcRepository(
                 chunk.flatMap { item ->
                     listOf<Any?>(
                         item.id,
+                        false,
                         localeIds.getValue(LocaleNaturalKey(LocaleSourceType.ITEM, localeSourceKey(item.id), "name")),
                         qualityIds.getValue(item.quality.type),
                         item.level,

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/service/admin/AdminItemService.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/service/admin/AdminItemService.kt
@@ -37,6 +37,8 @@ class AdminItemService(
         hasOverride: Boolean?,
         itemClassId: Int?,
         itemSubclassId: Int?,
+        expansionId: Int?,
+        hasRecipe: Boolean?,
         page: Int,
         pageSize: Int,
     ): AdminItemPage {
@@ -44,6 +46,7 @@ class AdminItemService(
         if (itemSubclassId != null && itemClassId == null) {
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "itemClassId is required when itemSubclassId is set")
         }
+        expansionId?.let { requireExpansion(it) }
         val result =
             adminItemRepository.searchItems(
                 query = query,
@@ -51,6 +54,8 @@ class AdminItemService(
                 hasOverride = hasOverride,
                 itemClassId = itemClassId,
                 itemSubclassId = itemSubclassId,
+                expansionId = expansionId,
+                hasRecipe = hasRecipe,
                 page = page,
                 pageSize = pageSize,
                 localeColumnSuffix = AdminExpansionRepository.resolveLocaleColumnSuffix(locale),

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/service/admin/AdminItemService.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/service/admin/AdminItemService.kt
@@ -35,15 +35,22 @@ class AdminItemService(
         locale: String?,
         hasBase: Boolean?,
         hasOverride: Boolean?,
+        itemClassId: Int?,
+        itemSubclassId: Int?,
         page: Int,
         pageSize: Int,
     ): AdminItemPage {
         validatePagination(page, pageSize)
+        if (itemSubclassId != null && itemClassId == null) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "itemClassId is required when itemSubclassId is set")
+        }
         val result =
             adminItemRepository.searchItems(
                 query = query,
                 hasBase = hasBase,
                 hasOverride = hasOverride,
+                itemClassId = itemClassId,
+                itemSubclassId = itemSubclassId,
                 page = page,
                 pageSize = pageSize,
                 localeColumnSuffix = AdminExpansionRepository.resolveLocaleColumnSuffix(locale),

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/service/admin/AdminItemService.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/service/admin/AdminItemService.kt
@@ -1,0 +1,383 @@
+package net.jonasmf.auctionengine.service.admin
+
+import net.jonasmf.auctionengine.domain.item.Item
+import net.jonasmf.auctionengine.generated.model.AdminItem1
+import net.jonasmf.auctionengine.generated.model.AdminItemBulkOverrideRequest
+import net.jonasmf.auctionengine.generated.model.AdminItemCompareField
+import net.jonasmf.auctionengine.generated.model.AdminItemCompareResponse
+import net.jonasmf.auctionengine.generated.model.AdminItemCreateRequest
+import net.jonasmf.auctionengine.generated.model.AdminItemFields
+import net.jonasmf.auctionengine.generated.model.AdminItemOverrideRequest
+import net.jonasmf.auctionengine.generated.model.AdminItemPage
+import net.jonasmf.auctionengine.integration.blizzard.ItemApiLookup
+import net.jonasmf.auctionengine.mapper.hasEnglishName
+import net.jonasmf.auctionengine.mapper.toGameLocale
+import net.jonasmf.auctionengine.mapper.toLocaleDTO
+import net.jonasmf.auctionengine.repository.rds.AdminExpansionRepository
+import net.jonasmf.auctionengine.repository.rds.AdminItemRepositoryPort
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.server.ResponseStatusException
+
+private const val MAX_ADMIN_ITEM_PAGE_SIZE = 100
+
+@Service
+class AdminItemService(
+    private val adminItemRepository: AdminItemRepositoryPort,
+    private val itemApiClient: ItemApiLookup,
+) {
+    fun searchItems(
+        query: String?,
+        locale: String?,
+        hasBase: Boolean?,
+        hasOverride: Boolean?,
+        page: Int,
+        pageSize: Int,
+    ): AdminItemPage {
+        validatePagination(page, pageSize)
+        val result =
+            adminItemRepository.searchItems(
+                query = query,
+                hasBase = hasBase,
+                hasOverride = hasOverride,
+                page = page,
+                pageSize = pageSize,
+                localeColumnSuffix = AdminExpansionRepository.resolveLocaleColumnSuffix(locale),
+            )
+        return AdminItemPage(
+            items = result.items,
+            page = adminItemRepository.pageMetadata(page, pageSize, result.totalItems),
+        )
+    }
+
+    fun getItem(
+        id: Int,
+        locale: String?,
+        includeBase: Boolean,
+        includeOverride: Boolean,
+    ): AdminItem1 =
+        findItem(id, locale)
+            .toAdminItem(includeBase = includeBase, includeOverride = includeOverride)
+
+    @Transactional
+    fun upsertOverride(
+        id: Int,
+        request: AdminItemOverrideRequest,
+    ): AdminItem1 {
+        if (!adminItemRepository.hasAnyItemRow(id)) {
+            throw ResponseStatusException(HttpStatus.NOT_FOUND, "Item not found: $id")
+        }
+        validateOverrideRequest(id, request)
+        if (!adminItemRepository.hasBaseItem(id)) {
+            validateOverrideOnlyRequest(request)
+        }
+        val subclassInternalId = resolveOverrideSubclassId(request)
+        adminItemRepository.upsertOverride(id, request, subclassInternalId)
+        return getItem(id, locale = null, includeBase = true, includeOverride = true)
+    }
+
+    @Transactional
+    fun bulkUpsertOverrides(request: AdminItemBulkOverrideRequest): List<AdminItem1> {
+        if (request.overrides.size > MAX_ADMIN_ITEM_PAGE_SIZE) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Bulk override request cannot exceed 100 items")
+        }
+        val seenIds = mutableSetOf<Int>()
+        request.overrides.forEach { override ->
+            if (!seenIds.add(override.id)) {
+                throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Duplicate item override id: ${override.id}")
+            }
+            if (!adminItemRepository.hasBaseItem(override.id)) {
+                throw ResponseStatusException(HttpStatus.NOT_FOUND, "Base item not found: ${override.id}")
+            }
+            validateOverrideRequest(override.id, override.`override`)
+        }
+        request.overrides.forEach { override ->
+            adminItemRepository.upsertOverride(
+                override.id,
+                override.`override`,
+                resolveOverrideSubclassId(override.`override`),
+            )
+        }
+        return request.overrides.map { getItem(it.id, locale = null, includeBase = true, includeOverride = true) }
+    }
+
+    @Transactional
+    fun deleteOverride(id: Int) {
+        if (!adminItemRepository.deleteOverride(id)) {
+            throw ResponseStatusException(HttpStatus.NOT_FOUND, "Override item not found: $id")
+        }
+    }
+
+    @Transactional
+    fun createOverrideOnly(request: AdminItemCreateRequest): AdminItem1 {
+        validateCreateRequest(request)
+        if (adminItemRepository.hasAnyItemRow(request.id)) {
+            throw ResponseStatusException(HttpStatus.CONFLICT, "Item already exists: ${request.id}")
+        }
+        val subclassInternalId = requireItemSubclass(request.itemClassId, request.itemSubclassId)
+        adminItemRepository.createOverrideOnly(request, subclassInternalId)
+        return getItem(request.id, locale = null, includeBase = true, includeOverride = true)
+    }
+
+    fun compareWithApi(id: Int): AdminItemCompareResponse {
+        val local = findItem(id, locale = null)
+        val apiItem =
+            runCatching { itemApiClient.getById(id) }
+                .getOrElse { error ->
+                    throw ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "Blizzard API item not found or unavailable: $id",
+                        error,
+                    )
+                }
+        val baseValues = local.base?.toCompareValues().orEmpty()
+        val overrideValues = local.override?.toCompareValues().orEmpty()
+        val effectiveValues = local.effective.toCompareValues()
+        val apiValues = apiItem.toCompareValues()
+        val fieldNames = baseValues.keys + overrideValues.keys + effectiveValues.keys + apiValues.keys
+        return AdminItemCompareResponse(
+            itemId = id,
+            fields =
+                fieldNames.associateWith { field ->
+                    AdminItemCompareField(
+                        base = baseValues[field],
+                        `override` = overrideValues[field],
+                        api = apiValues[field],
+                        effective = effectiveValues[field],
+                    )
+                },
+        )
+    }
+
+    private fun findItem(
+        id: Int,
+        locale: String?,
+    ) = adminItemRepository.findItemRows(
+        id = id,
+        localeColumnSuffix = AdminExpansionRepository.resolveLocaleColumnSuffix(locale),
+    ) ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Item not found: $id")
+
+    private fun validatePagination(
+        page: Int,
+        pageSize: Int,
+    ) {
+        if (page < 1) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "page must be at least 1")
+        }
+        if (pageSize !in 1..MAX_ADMIN_ITEM_PAGE_SIZE) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "pageSize must be between 1 and 100")
+        }
+    }
+
+    private fun validateOverrideRequest(
+        id: Int,
+        request: AdminItemOverrideRequest,
+    ) {
+        request.nameLocales?.let { nameLocales ->
+            if (!nameLocales.toLocaleDTO().hasEnglishName()) {
+                throw ResponseStatusException(HttpStatus.BAD_REQUEST, "At least one English item name is required")
+            }
+        }
+        request.qualityType?.let { requireQuality(it) }
+        request.inventoryType?.let { requireInventoryType(it) }
+        request.bindingType?.let { requireBindingType(it) }
+        validateOptionalNonNegative("level", request.level)
+        validateOptionalNonNegative("requiredLevel", request.requiredLevel)
+        validateOptionalNonNegative("purchasePrice", request.purchasePrice)
+        validateOptionalNonNegative("sellPrice", request.sellPrice)
+        validateOptionalNonNegative("maxCount", request.maxCount)
+        validateOptionalNonNegative("purchaseQuantity", request.purchaseQuantity)
+        request.itemClassId?.let { requireItemClass(it) }
+        if ((request.itemClassId == null) != (request.itemSubclassId == null)) {
+            throw ResponseStatusException(
+                HttpStatus.BAD_REQUEST,
+                "itemClassId and itemSubclassId must be provided together",
+            )
+        }
+        if (request.itemClassId != null && request.itemSubclassId != null) {
+            requireItemSubclass(request.itemClassId, request.itemSubclassId)
+        }
+        request.expansionId?.let { requireExpansion(it) }
+        if (request.mediaUrl?.isBlank() == true) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "mediaUrl cannot be blank")
+        }
+    }
+
+    private fun validateOverrideOnlyRequest(request: AdminItemOverrideRequest) {
+        val nameLocales =
+            request.nameLocales
+                ?: throw ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Override-only items require localized names",
+                )
+        if (!nameLocales.toLocaleDTO().hasEnglishName()) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "At least one English item name is required")
+        }
+        requireQuality(request.qualityType ?: missingOverrideOnlyField("qualityType"))
+        validateRequiredNonNegative("level", request.level)
+        validateRequiredNonNegative("requiredLevel", request.requiredLevel)
+        val mediaUrl = request.mediaUrl ?: missingOverrideOnlyField("mediaUrl")
+        if (mediaUrl.isBlank()) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "mediaUrl is required")
+        }
+        val classId = request.itemClassId ?: missingOverrideOnlyField("itemClassId")
+        val subclassId = request.itemSubclassId ?: missingOverrideOnlyField("itemSubclassId")
+        requireItemClass(classId)
+        requireItemSubclass(classId, subclassId)
+        requireInventoryType(request.inventoryType ?: missingOverrideOnlyField("inventoryType"))
+        request.bindingType?.let { requireBindingType(it) }
+        validateRequiredNonNegative("purchasePrice", request.purchasePrice)
+        validateRequiredNonNegative("sellPrice", request.sellPrice)
+        validateRequiredNonNegative("maxCount", request.maxCount)
+        if (request.isEquippable == null) {
+            missingOverrideOnlyField("isEquippable")
+        }
+        if (request.isStackable == null) {
+            missingOverrideOnlyField("isStackable")
+        }
+        validateRequiredNonNegative("purchaseQuantity", request.purchaseQuantity)
+        request.expansionId?.let { requireExpansion(it) }
+    }
+
+    private fun validateCreateRequest(request: AdminItemCreateRequest) {
+        if (!request.nameLocales.toLocaleDTO().hasEnglishName()) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "At least one English item name is required")
+        }
+        if (request.mediaUrl.isBlank()) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "mediaUrl is required")
+        }
+        validateNonNegative("level", request.level)
+        validateNonNegative("requiredLevel", request.requiredLevel)
+        validateNonNegative("purchasePrice", request.purchasePrice)
+        validateNonNegative("sellPrice", request.sellPrice)
+        validateNonNegative("maxCount", request.maxCount)
+        validateNonNegative("purchaseQuantity", request.purchaseQuantity)
+        requireQuality(request.qualityType)
+        requireInventoryType(request.inventoryType)
+        request.bindingType?.let { requireBindingType(it) }
+        requireItemClass(request.itemClassId)
+        requireItemSubclass(request.itemClassId, request.itemSubclassId)
+        request.expansionId?.let { requireExpansion(it) }
+    }
+
+    private fun resolveOverrideSubclassId(request: AdminItemOverrideRequest): Long? {
+        if (request.itemClassId == null || request.itemSubclassId == null) return null
+        return requireItemSubclass(request.itemClassId, request.itemSubclassId)
+    }
+
+    private fun requireQuality(type: String): Long {
+        if (type.isBlank()) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "qualityType is required")
+        }
+        return adminItemRepository.qualityId(type)
+            ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Item quality not found: $type")
+    }
+
+    private fun requireInventoryType(type: String): Long {
+        if (type.isBlank()) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "inventoryType is required")
+        }
+        return adminItemRepository.inventoryTypeId(type)
+            ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Inventory type not found: $type")
+    }
+
+    private fun requireBindingType(type: String): Long {
+        if (type.isBlank()) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "bindingType cannot be blank")
+        }
+        return adminItemRepository.bindingId(type)
+            ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Item binding not found: $type")
+    }
+
+    private fun requireItemClass(id: Int) {
+        if (!adminItemRepository.itemClassExists(id)) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Item class not found: $id")
+        }
+    }
+
+    private fun requireItemSubclass(
+        classId: Int,
+        subclassId: Int,
+    ): Long =
+        adminItemRepository.itemSubclassInternalId(classId, subclassId)
+            ?: throw ResponseStatusException(
+                HttpStatus.BAD_REQUEST,
+                "Item subclass not found: classId=$classId subclassId=$subclassId",
+            )
+
+    private fun requireExpansion(id: Int) {
+        if (!adminItemRepository.expansionExists(id)) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Expansion not found: $id")
+        }
+    }
+
+    private fun validateOptionalNonNegative(
+        field: String,
+        value: Int?,
+    ) {
+        value?.let { validateNonNegative(field, it) }
+    }
+
+    private fun validateNonNegative(
+        field: String,
+        value: Int,
+    ) {
+        if (value < 0) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "$field must be non-negative")
+        }
+    }
+
+    private fun validateRequiredNonNegative(
+        field: String,
+        value: Int?,
+    ) {
+        validateNonNegative(field, value ?: missingOverrideOnlyField(field))
+    }
+
+    private fun missingOverrideOnlyField(field: String): Nothing {
+        throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Override-only items require $field")
+    }
+}
+
+private fun AdminItemFields.toCompareValues(): Map<String, Any?> =
+    mapOf(
+        "nameLocales" to nameLocales,
+        "qualityType" to quality?.type,
+        "level" to level,
+        "requiredLevel" to requiredLevel,
+        "mediaUrl" to mediaUrl,
+        "mediaSourceUrl" to mediaSourceUrl,
+        "itemClassId" to itemClass?.id?.toInt(),
+        "itemSubclassId" to itemSubclass?.id?.toInt(),
+        "inventoryType" to inventoryType?.type,
+        "bindingType" to binding?.type,
+        "purchasePrice" to purchasePrice,
+        "sellPrice" to sellPrice,
+        "maxCount" to maxCount,
+        "isEquippable" to isEquippable,
+        "isStackable" to isStackable,
+        "purchaseQuantity" to purchaseQuantity,
+        "expansionId" to expansion?.id,
+        "overrideNote" to overrideNote,
+    )
+
+private fun Item.toCompareValues(): Map<String, Any?> =
+    mapOf(
+        "nameLocales" to name.toGameLocale(),
+        "qualityType" to quality.type,
+        "level" to level,
+        "requiredLevel" to requiredLevel,
+        "mediaUrl" to mediaUrl,
+        "mediaSourceUrl" to mediaSourceUrl,
+        "itemClassId" to itemClass.id,
+        "itemSubclassId" to itemSubclass.subclassId,
+        "inventoryType" to inventoryType.type,
+        "bindingType" to binding?.type,
+        "purchasePrice" to purchasePrice,
+        "sellPrice" to sellPrice,
+        "maxCount" to maxCount,
+        "isEquippable" to isEquippable,
+        "isStackable" to isStackable,
+        "purchaseQuantity" to purchaseQuantity,
+    )

--- a/backend/src/main/kotlin/net/jonasmf/auctionengine/service/admin/AdminItemService.kt
+++ b/backend/src/main/kotlin/net/jonasmf/auctionengine/service/admin/AdminItemService.kt
@@ -9,6 +9,8 @@ import net.jonasmf.auctionengine.generated.model.AdminItemCreateRequest
 import net.jonasmf.auctionengine.generated.model.AdminItemFields
 import net.jonasmf.auctionengine.generated.model.AdminItemOverrideRequest
 import net.jonasmf.auctionengine.generated.model.AdminItemPage
+import net.jonasmf.auctionengine.generated.model.AdminRecipeAssociationRequest
+import net.jonasmf.auctionengine.generated.model.AdminRecipeSearchResult
 import net.jonasmf.auctionengine.integration.blizzard.ItemApiLookup
 import net.jonasmf.auctionengine.mapper.hasEnglishName
 import net.jonasmf.auctionengine.mapper.toGameLocale
@@ -21,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.server.ResponseStatusException
 
 private const val MAX_ADMIN_ITEM_PAGE_SIZE = 100
+private const val MAX_ADMIN_RECIPE_SEARCH_LIMIT = 50
 
 @Service
 class AdminItemService(
@@ -60,6 +63,21 @@ class AdminItemService(
         findItem(id, locale)
             .toAdminItem(includeBase = includeBase, includeOverride = includeOverride)
 
+    fun searchRecipes(
+        query: String?,
+        locale: String?,
+        limit: Int,
+    ): List<AdminRecipeSearchResult> {
+        if (limit !in 1..MAX_ADMIN_RECIPE_SEARCH_LIMIT) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "limit must be between 1 and 50")
+        }
+        return adminItemRepository.searchRecipes(
+            query = query,
+            limit = limit,
+            localeColumnSuffix = AdminExpansionRepository.resolveLocaleColumnSuffix(locale),
+        )
+    }
+
     @Transactional
     fun upsertOverride(
         id: Int,
@@ -74,6 +92,38 @@ class AdminItemService(
         }
         val subclassInternalId = resolveOverrideSubclassId(request)
         adminItemRepository.upsertOverride(id, request, subclassInternalId)
+        return getItem(id, locale = null, includeBase = true, includeOverride = true)
+    }
+
+    @Transactional
+    fun upsertRecipeAssociation(
+        id: Int,
+        recipeId: Int,
+        request: AdminRecipeAssociationRequest,
+    ): AdminItem1 {
+        if (!adminItemRepository.hasAnyItemRow(id)) {
+            throw ResponseStatusException(HttpStatus.NOT_FOUND, "Item not found: $id")
+        }
+        if (!adminItemRepository.recipeExists(recipeId)) {
+            throw ResponseStatusException(HttpStatus.NOT_FOUND, "Recipe not found: $recipeId")
+        }
+
+        val craftedItemId = request.craftedItemId
+        if (craftedItemId != null && craftedItemId != id) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "craftedItemId must match path item id")
+        }
+        if (craftedItemId == null) {
+            adminItemRepository.updateRecipeCraftedItem(recipeId, craftedItemId = null, craftedQuantity = null)
+        } else {
+            val craftedQuantity =
+                request.craftedQuantity
+                    ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST, "craftedQuantity is required")
+            if (craftedQuantity < 1) {
+                throw ResponseStatusException(HttpStatus.BAD_REQUEST, "craftedQuantity must be at least 1")
+            }
+            adminItemRepository.updateRecipeCraftedItem(recipeId, craftedItemId = id, craftedQuantity = craftedQuantity)
+        }
+
         return getItem(id, locale = null, includeBase = true, includeOverride = true)
     }
 

--- a/backend/src/main/resources/db/migration/R__create_v_auction_market_item_details.sql
+++ b/backend/src/main/resources/db/migration/R__create_v_auction_market_item_details.sql
@@ -75,7 +75,7 @@ SELECT
     reci_l.ru_ru AS recipe_name_ru_ru,
     reci_l.zh_cn AS recipe_name_zh_cn,
     reci_l.zh_tw AS recipe_name_zh_tw
-FROM item i
+FROM v_item i
          LEFT JOIN locale i_l ON i.name_id = i_l.id
          LEFT JOIN item_quality iq ON iq.internal_id = i.quality_id
          LEFT JOIN locale iq_l ON iq_l.id = iq.name_id

--- a/backend/src/main/resources/db/migration/R__create_v_item.sql
+++ b/backend/src/main/resources/db/migration/R__create_v_item.sql
@@ -1,0 +1,34 @@
+CREATE OR REPLACE VIEW v_item AS
+SELECT
+    item_ids.id,
+    override_item.id IS NOT NULL AS is_override,
+    COALESCE(override_item.is_equippable, base_item.is_equippable) AS is_equippable,
+    COALESCE(override_item.is_stackable, base_item.is_stackable) AS is_stackable,
+    COALESCE(override_item.level, base_item.level) AS level,
+    COALESCE(override_item.max_count, base_item.max_count) AS max_count,
+    COALESCE(override_item.media_url, base_item.media_url) AS media_url,
+    COALESCE(override_item.media_source_url, base_item.media_source_url) AS media_source_url,
+    COALESCE(override_item.purchase_price, base_item.purchase_price) AS purchase_price,
+    COALESCE(override_item.purchase_quantity, base_item.purchase_quantity) AS purchase_quantity,
+    COALESCE(override_item.required_level, base_item.required_level) AS required_level,
+    COALESCE(override_item.sell_price, base_item.sell_price) AS sell_price,
+    COALESCE(override_item.binding_id, base_item.binding_id) AS binding_id,
+    COALESCE(override_item.inventory_type_id, base_item.inventory_type_id) AS inventory_type_id,
+    COALESCE(override_item.item_class_id, base_item.item_class_id) AS item_class_id,
+    COALESCE(override_item.item_subclass_id, base_item.item_subclass_id) AS item_subclass_id,
+    COALESCE(override_item.name_id, base_item.name_id) AS name_id,
+    COALESCE(override_item.quality_id, base_item.quality_id) AS quality_id,
+    COALESCE(override_item.expansion_id, base_item.expansion_id) AS expansion_id,
+    override_item.override_note,
+    COALESCE(override_item.created_at, base_item.created_at) AS created_at,
+    COALESCE(override_item.updated_at, base_item.updated_at) AS updated_at
+FROM (
+    SELECT DISTINCT id
+    FROM `item`
+) item_ids
+    LEFT JOIN `item` base_item
+        ON base_item.id = item_ids.id
+        AND base_item.is_override = FALSE
+    LEFT JOIN `item` override_item
+        ON override_item.id = item_ids.id
+        AND override_item.is_override = TRUE;

--- a/backend/src/main/resources/db/migration/V16__item_overrides.sql
+++ b/backend/src/main/resources/db/migration/V16__item_overrides.sql
@@ -1,0 +1,74 @@
+ALTER TABLE `item`
+    ADD COLUMN is_override BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN override_note VARCHAR(512) DEFAULT NULL,
+    ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ADD COLUMN updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+
+ALTER TABLE `item`
+    MODIFY COLUMN is_equippable BIT(1) DEFAULT NULL,
+    MODIFY COLUMN is_stackable BIT(1) DEFAULT NULL,
+    MODIFY COLUMN level INT(11) DEFAULT NULL,
+    MODIFY COLUMN max_count INT(11) DEFAULT NULL,
+    MODIFY COLUMN purchase_price INT(11) DEFAULT NULL,
+    MODIFY COLUMN purchase_quantity INT(11) DEFAULT NULL,
+    MODIFY COLUMN required_level INT(11) DEFAULT NULL,
+    MODIFY COLUMN sell_price INT(11) DEFAULT NULL;
+
+ALTER TABLE `item`
+    ADD UNIQUE KEY uk_item_name_id_override (name_id, is_override);
+
+ALTER TABLE `item`
+    DROP INDEX UKcgrg884xedtb5d2ysbg4qis7d,
+    DROP PRIMARY KEY,
+    ADD PRIMARY KEY (id, is_override),
+    ADD KEY idx_item_override_updated_at (is_override, updated_at),
+    ADD KEY idx_item_override_expansion_id (is_override, expansion_id),
+    ADD CONSTRAINT chk_item_base_required_fields
+        CHECK (
+            is_override = TRUE
+            OR (
+                is_equippable IS NOT NULL
+                AND is_stackable IS NOT NULL
+                AND level IS NOT NULL
+                AND max_count IS NOT NULL
+                AND purchase_price IS NOT NULL
+                AND purchase_quantity IS NOT NULL
+                AND required_level IS NOT NULL
+                AND sell_price IS NOT NULL
+            )
+        );
+
+CREATE OR REPLACE VIEW v_item AS
+SELECT
+    item_ids.id,
+    override_item.id IS NOT NULL AS is_override,
+    COALESCE(override_item.is_equippable, base_item.is_equippable) AS is_equippable,
+    COALESCE(override_item.is_stackable, base_item.is_stackable) AS is_stackable,
+    COALESCE(override_item.level, base_item.level) AS level,
+    COALESCE(override_item.max_count, base_item.max_count) AS max_count,
+    COALESCE(override_item.media_url, base_item.media_url) AS media_url,
+    COALESCE(override_item.media_source_url, base_item.media_source_url) AS media_source_url,
+    COALESCE(override_item.purchase_price, base_item.purchase_price) AS purchase_price,
+    COALESCE(override_item.purchase_quantity, base_item.purchase_quantity) AS purchase_quantity,
+    COALESCE(override_item.required_level, base_item.required_level) AS required_level,
+    COALESCE(override_item.sell_price, base_item.sell_price) AS sell_price,
+    COALESCE(override_item.binding_id, base_item.binding_id) AS binding_id,
+    COALESCE(override_item.inventory_type_id, base_item.inventory_type_id) AS inventory_type_id,
+    COALESCE(override_item.item_class_id, base_item.item_class_id) AS item_class_id,
+    COALESCE(override_item.item_subclass_id, base_item.item_subclass_id) AS item_subclass_id,
+    COALESCE(override_item.name_id, base_item.name_id) AS name_id,
+    COALESCE(override_item.quality_id, base_item.quality_id) AS quality_id,
+    COALESCE(override_item.expansion_id, base_item.expansion_id) AS expansion_id,
+    override_item.override_note,
+    COALESCE(override_item.created_at, base_item.created_at) AS created_at,
+    COALESCE(override_item.updated_at, base_item.updated_at) AS updated_at
+FROM (
+    SELECT DISTINCT id
+    FROM `item`
+) item_ids
+    LEFT JOIN `item` base_item
+        ON base_item.id = item_ids.id
+        AND base_item.is_override = FALSE
+    LEFT JOIN `item` override_item
+        ON override_item.id = item_ids.id
+        AND override_item.is_override = TRUE;

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/config/SecurityConfigTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/config/SecurityConfigTest.kt
@@ -5,6 +5,7 @@ import net.jonasmf.auctionengine.controller.HealthController
 import net.jonasmf.auctionengine.service.RuntimeHealthSnapshot
 import net.jonasmf.auctionengine.service.RuntimeHealthTracker
 import net.jonasmf.auctionengine.service.admin.AdminExpansionService
+import net.jonasmf.auctionengine.service.admin.AdminItemService
 import net.jonasmf.auctionengine.service.admin.AdminJobService
 import net.jonasmf.auctionengine.service.admin.AdminSqlService
 import net.jonasmf.auctionengine.service.admin.AdminStatusService
@@ -64,6 +65,9 @@ class SecurityConfigTest {
 
     @MockitoBean
     private lateinit var adminJobService: AdminJobService
+
+    @MockitoBean
+    private lateinit var adminItemService: AdminItemService
 
     @MockitoBean
     private lateinit var jwtDecoder: JwtDecoder

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/controller/AdminControllerTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/controller/AdminControllerTest.kt
@@ -541,7 +541,7 @@ class AdminControllerTest {
 
         @Test
         fun `should search admin items if Cognito Admin group`() {
-            `when`(adminItemService.searchItems("cloth", null, null, true, 7, 1, 1, 25)).thenReturn(
+            `when`(adminItemService.searchItems("cloth", null, null, true, 7, 1, null, null, 1, 25)).thenReturn(
                 AdminItemPage(
                     items =
                         listOf(

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/controller/AdminControllerTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/controller/AdminControllerTest.kt
@@ -7,6 +7,10 @@ import net.jonasmf.auctionengine.generated.model.GameLocale
 import net.jonasmf.auctionengine.generated.model.AdminJob
 import net.jonasmf.auctionengine.generated.model.AdminConnectionStatus
 import net.jonasmf.auctionengine.generated.model.AdminServerStatus
+import net.jonasmf.auctionengine.generated.model.AdminItem1
+import net.jonasmf.auctionengine.generated.model.AdminItemFields
+import net.jonasmf.auctionengine.generated.model.AdminItemOverrideRequest
+import net.jonasmf.auctionengine.generated.model.AdminItemPage
 import net.jonasmf.auctionengine.generated.model.AdminSqlColumn
 import net.jonasmf.auctionengine.generated.model.AdminSqlExecuteRequest
 import net.jonasmf.auctionengine.generated.model.AdminSqlIndex
@@ -14,8 +18,10 @@ import net.jonasmf.auctionengine.generated.model.AdminSqlMetadata
 import net.jonasmf.auctionengine.generated.model.AdminSqlResult
 import net.jonasmf.auctionengine.generated.model.AdminStatus
 import net.jonasmf.auctionengine.generated.model.AdminSqlTable
+import net.jonasmf.auctionengine.generated.model.PageMetadata
 import net.jonasmf.auctionengine.generated.model.User
 import net.jonasmf.auctionengine.service.admin.AdminExpansionService
+import net.jonasmf.auctionengine.service.admin.AdminItemService
 import net.jonasmf.auctionengine.service.admin.AdminJobService
 import net.jonasmf.auctionengine.service.admin.AdminSqlService
 import net.jonasmf.auctionengine.service.admin.AdminStatusService
@@ -38,8 +44,10 @@ import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.request
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -72,6 +80,9 @@ class AdminControllerTest {
 
     @MockitoBean
     private lateinit var adminJobService: AdminJobService
+
+    @MockitoBean
+    private lateinit var adminItemService: AdminItemService
 
     @MockitoBean
     private lateinit var jwtDecoder: JwtDecoder
@@ -520,6 +531,115 @@ class AdminControllerTest {
             mockMvc
                 .perform(asyncDispatch(result))
                 .andExpect(status().isForbidden)
+        }
+    }
+
+    @Nested
+    inner class ItemAdmin {
+        @Autowired
+        private lateinit var mockMvc: MockMvc
+
+        @Test
+        fun `should search admin items if Cognito Admin group`() {
+            `when`(adminItemService.searchItems("cloth", null, null, true, 1, 25)).thenReturn(
+                AdminItemPage(
+                    items =
+                        listOf(
+                            AdminItem1(
+                                id = 171374,
+                                hasBase = true,
+                                hasOverride = true,
+                                effective =
+                                    AdminItemFields(
+                                        id = 171374,
+                                        name = "Override cloth",
+                                    ),
+                            ),
+                        ),
+                    page = PageMetadata(page = 1, pageSize = 25, totalItems = 1, totalPages = 1),
+                ),
+            )
+
+            val result =
+                mockMvc
+                    .perform(
+                        get("/api/admin/items")
+                            .contextPath("/api")
+                            .param("query", "cloth")
+                            .param("hasOverride", "true")
+                            .with(
+                                jwt()
+                                    .jwt { token ->
+                                        token.claim("cognito:groups", listOf("admin"))
+                                    }.authorities(cognitoGroupsGrantedAuthoritiesConverter),
+                            ),
+                    ).andExpect(request().asyncStarted())
+                    .andReturn()
+
+            mockMvc
+                .perform(asyncDispatch(result))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.items[0].id").value(171374))
+                .andExpect(jsonPath("$.items[0].hasOverride").value(true))
+        }
+
+        @Test
+        fun `should upsert sparse item override if Cognito Admin group`() {
+            val response =
+                AdminItem1(
+                    id = 171374,
+                    hasBase = true,
+                    hasOverride = true,
+                    effective = AdminItemFields(id = 171374, mediaUrl = "https://example.test/icon.png"),
+                )
+            `when`(
+                adminItemService.upsertOverride(
+                    171374,
+                    AdminItemOverrideRequest(mediaUrl = "https://example.test/icon.png"),
+                ),
+            ).thenReturn(response)
+
+            val result =
+                mockMvc
+                    .perform(
+                        put("/api/admin/items/171374/override")
+                            .contextPath("/api")
+                            .contentType("application/json")
+                            .content("""{"mediaUrl":"https://example.test/icon.png"}""")
+                            .with(
+                                jwt()
+                                    .jwt { token ->
+                                        token.claim("cognito:groups", listOf("admin"))
+                                    }.authorities(cognitoGroupsGrantedAuthoritiesConverter),
+                            ),
+                    ).andExpect(request().asyncStarted())
+                    .andReturn()
+
+            mockMvc
+                .perform(asyncDispatch(result))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.effective.mediaUrl").value("https://example.test/icon.png"))
+        }
+
+        @Test
+        fun `should delete item override if Cognito Admin group`() {
+            val result =
+                mockMvc
+                    .perform(
+                        delete("/api/admin/items/171374/override")
+                            .contextPath("/api")
+                            .with(
+                                jwt()
+                                    .jwt { token ->
+                                        token.claim("cognito:groups", listOf("admin"))
+                                    }.authorities(cognitoGroupsGrantedAuthoritiesConverter),
+                            ),
+                    ).andExpect(request().asyncStarted())
+                    .andReturn()
+
+            mockMvc
+                .perform(asyncDispatch(result))
+                .andExpect(status().isNoContent)
         }
     }
 }

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/controller/AdminControllerTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/controller/AdminControllerTest.kt
@@ -541,7 +541,7 @@ class AdminControllerTest {
 
         @Test
         fun `should search admin items if Cognito Admin group`() {
-            `when`(adminItemService.searchItems("cloth", null, null, true, 1, 25)).thenReturn(
+            `when`(adminItemService.searchItems("cloth", null, null, true, 7, 1, 1, 25)).thenReturn(
                 AdminItemPage(
                     items =
                         listOf(
@@ -567,6 +567,8 @@ class AdminControllerTest {
                             .contextPath("/api")
                             .param("query", "cloth")
                             .param("hasOverride", "true")
+                            .param("itemClassId", "7")
+                            .param("itemSubclassId", "1")
                             .with(
                                 jwt()
                                     .jwt { token ->

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/AdminExpansionRepositoryTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/AdminExpansionRepositoryTest.kt
@@ -116,6 +116,14 @@ class AdminExpansionRepositoryTest : IntegrationTestBase() {
     @Test
     fun `applyEnabledRanges updates matched items and reports conflicts`() {
         itemJdbcRepository.syncItems(listOf(loadItem(171374), loadItem(171391)))
+        jdbcTemplate.update(
+            """
+            INSERT INTO `item` (id, is_override, override_note)
+            VALUES (?, TRUE, ?)
+            """.trimIndent(),
+            171374,
+            "manual override",
+        )
         adminExpansionRepository.createRange(rangeRequest(expansionId = 1, startItemId = 171374, endItemId = 171374))
         adminExpansionRepository.createRange(rangeRequest(expansionId = 2, startItemId = 171391, endItemId = 171391))
         adminExpansionRepository.createRange(rangeRequest(expansionId = 3, startItemId = 171391, endItemId = 171391))
@@ -124,18 +132,23 @@ class AdminExpansionRepositoryTest : IntegrationTestBase() {
 
         assertEquals(1, summary.matchedItemCount)
         assertEquals(1, summary.conflictItemCount)
-        assertEquals(1, itemExpansionId(171374))
-        assertEquals(null, itemExpansionId(171391))
+        assertEquals(1, itemExpansionId(171374, isOverride = false))
+        assertEquals(null, itemExpansionId(171374, isOverride = true))
+        assertEquals(null, itemExpansionId(171391, isOverride = false))
     }
 
     private fun loadItem(itemId: Int) =
         mapper.readValue<ItemDTO>(loadFixture(this, "/blizzard/item/$itemId-response.json")).toDomain()
 
-    private fun itemExpansionId(itemId: Int): Int? =
+    private fun itemExpansionId(
+        itemId: Int,
+        isOverride: Boolean,
+    ): Int? =
         jdbcTemplate.queryForObject(
-            "SELECT expansion_id FROM `item` WHERE id = ?",
+            "SELECT expansion_id FROM `item` WHERE id = ? AND is_override = ?",
             Int::class.java,
             itemId,
+            isOverride,
         )
 
     @Test

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/ItemJdbcRepositoryTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/repository/rds/ItemJdbcRepositoryTest.kt
@@ -186,6 +186,82 @@ class ItemJdbcRepositoryTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `findExistingItemIds treats override only rows as existing`() {
+        jdbcTemplate.update(
+            """
+            INSERT INTO `item` (id, is_override, override_note)
+            VALUES (?, TRUE, ?)
+            """.trimIndent(),
+            999999,
+            "placeholder override",
+        )
+
+        val existingIds = itemJdbcRepository.findExistingItemIds(listOf(999999, 1000000))
+
+        assertEquals(setOf(999999), existingIds)
+    }
+
+    @Test
+    fun `v_item returns sparse override values over base item and sync only updates base row`() {
+        val item = loadItem(171374)
+        itemJdbcRepository.syncItems(listOf(item))
+        val overrideNameId =
+            insertLocale(
+                id = 900001,
+                enGb = "Corrected Laestrite Ore",
+                deDe = "Korrigiertes Laestriterz",
+                sourceType = "item_override",
+                sourceKey = "171374",
+                sourceField = "name",
+            )
+        jdbcTemplate.update(
+            """
+            INSERT INTO `item` (id, is_override, name_id, media_url, override_note)
+            VALUES (?, TRUE, ?, ?, ?)
+            """.trimIndent(),
+            171374,
+            overrideNameId,
+            "https://media.example/corrected.png",
+            "manual correction",
+        )
+
+        val effective =
+            jdbcTemplate.queryForMap(
+                """
+                SELECT
+                    v.media_url,
+                    v.quality_id,
+                    l.en_gb AS item_name
+                FROM v_item v
+                    LEFT JOIN locale l ON l.id = v.name_id
+                WHERE v.id = ?
+                """.trimIndent(),
+                171374,
+            )
+        val marketDetail =
+            jdbcTemplate.queryForMap(
+                """
+                SELECT item_media_url, item_name_en_gb, quality_id
+                FROM v_auction_market_item_details
+                WHERE item_id = ?
+                """.trimIndent(),
+                171374,
+            )
+
+        assertEquals("Corrected Laestrite Ore", effective["item_name"])
+        assertEquals("https://media.example/corrected.png", effective["media_url"])
+        assertEquals(baseItemQualityId(171374), effective["quality_id"])
+        assertEquals("Corrected Laestrite Ore", marketDetail["item_name_en_gb"])
+        assertEquals("https://media.example/corrected.png", marketDetail["item_media_url"])
+        assertEquals(baseItemQualityId(171374), marketDetail["quality_id"])
+
+        itemJdbcRepository.syncItems(listOf(item.copy(mediaUrl = "https://media.example/base-updated.png")))
+
+        assertEquals("https://media.example/base-updated.png", itemMediaUrl(171374, isOverride = false))
+        assertEquals("https://media.example/corrected.png", itemMediaUrl(171374, isOverride = true))
+    }
+
+    @Test
     fun `findMissingItemIdsForEnabledExpansionRanges returns missing ids covered by ranges`() {
         itemJdbcRepository.syncItems(listOf(loadItem(171374)))
         ensureExpansionExists(
@@ -263,4 +339,46 @@ class ItemJdbcRepositoryTest : IntegrationTestBase() {
         tableName: String,
         condition: String,
     ): Int = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM $tableName WHERE $condition", Int::class.java)!!
+
+    private fun insertLocale(
+        id: Long,
+        enGb: String,
+        deDe: String,
+        sourceType: String,
+        sourceKey: String,
+        sourceField: String,
+    ): Long {
+        jdbcTemplate.update(
+            """
+            INSERT INTO locale (id, en_gb, en_us, de_de, source_type, source_key, source_field)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """.trimIndent(),
+            id,
+            enGb,
+            enGb,
+            deDe,
+            sourceType,
+            sourceKey,
+            sourceField,
+        )
+        return id
+    }
+
+    private fun baseItemQualityId(itemId: Int): Long? =
+        jdbcTemplate.queryForObject(
+            "SELECT quality_id FROM `item` WHERE id = ? AND is_override = FALSE",
+            Long::class.java,
+            itemId,
+        )
+
+    private fun itemMediaUrl(
+        itemId: Int,
+        isOverride: Boolean,
+    ): String? =
+        jdbcTemplate.queryForObject(
+            "SELECT media_url FROM `item` WHERE id = ? AND is_override = ?",
+            String::class.java,
+            itemId,
+            isOverride,
+        )
 }

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/service/admin/AdminItemServiceTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/service/admin/AdminItemServiceTest.kt
@@ -155,6 +155,28 @@ class AdminItemServiceTest {
     }
 
     @Test
+    fun `search items accepts class and subclass filters without reference lookup`() {
+        repository.itemSubclassExists = false
+
+        val result = service.searchItems(null, null, null, null, 1, 1, 1, 25)
+
+        assertEquals(0, result.items.size)
+        assertEquals(1, repository.lastSearch?.itemClassId)
+        assertEquals(1, repository.lastSearch?.itemSubclassId)
+    }
+
+    @Test
+    fun `search items requires class when subclass filter is set`() {
+        val error =
+            assertThrows(ResponseStatusException::class.java) {
+                service.searchItems(null, null, null, null, null, 1, 1, 25)
+            }
+
+        assertEquals(400, error.statusCode.value())
+        assertEquals("itemClassId is required when itemSubclassId is set", error.reason)
+    }
+
+    @Test
     fun `recipe association rejects mismatched crafted item id`() {
         repository.itemRows[171374] =
             AdminItemRows(
@@ -197,6 +219,17 @@ class AdminItemServiceTest {
         )
 }
 
+private data class AdminItemSearchCall(
+    val query: String?,
+    val hasBase: Boolean?,
+    val hasOverride: Boolean?,
+    val itemClassId: Int?,
+    val itemSubclassId: Int?,
+    val page: Int,
+    val pageSize: Int,
+    val localeColumnSuffix: String,
+)
+
 private class FakeItemApiLookup : ItemApiLookup {
     val items = mutableMapOf<Int, Item>()
 
@@ -211,15 +244,32 @@ private class FakeAdminItemRepository : AdminItemRepositoryPort {
     var lastUpsert: Pair<Int, AdminItemOverrideRequest>? = null
     var lastRecipeSearch: Triple<String?, Int, String>? = null
     var lastRecipeCraftedItemUpdate: Triple<Int, Int?, Int?>? = null
+    var lastSearch: AdminItemSearchCall? = null
+    var itemSubclassExists = true
 
     override fun searchItems(
         query: String?,
         hasBase: Boolean?,
         hasOverride: Boolean?,
+        itemClassId: Int?,
+        itemSubclassId: Int?,
         page: Int,
         pageSize: Int,
         localeColumnSuffix: String,
-    ): AdminItemSearchResult = AdminItemSearchResult(items = emptyList(), totalItems = 0)
+    ): AdminItemSearchResult {
+        lastSearch =
+            AdminItemSearchCall(
+                query = query,
+                hasBase = hasBase,
+                hasOverride = hasOverride,
+                itemClassId = itemClassId,
+                itemSubclassId = itemSubclassId,
+                page = page,
+                pageSize = pageSize,
+                localeColumnSuffix = localeColumnSuffix,
+            )
+        return AdminItemSearchResult(items = emptyList(), totalItems = 0)
+    }
 
     override fun pageMetadata(
         page: Int,
@@ -249,7 +299,7 @@ private class FakeAdminItemRepository : AdminItemRepositoryPort {
     override fun itemSubclassInternalId(
         classId: Int,
         subclassId: Int,
-    ): Long? = 1
+    ): Long? = if (itemSubclassExists) 1 else null
 
     override fun expansionExists(expansionId: Int): Boolean = true
 

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/service/admin/AdminItemServiceTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/service/admin/AdminItemServiceTest.kt
@@ -10,6 +10,8 @@ import net.jonasmf.auctionengine.generated.model.AdminItemCreateRequest
 import net.jonasmf.auctionengine.generated.model.AdminItemFields
 import net.jonasmf.auctionengine.generated.model.AdminItemOverrideRequest
 import net.jonasmf.auctionengine.generated.model.AdminItemReference
+import net.jonasmf.auctionengine.generated.model.AdminRecipeAssociationRequest
+import net.jonasmf.auctionengine.generated.model.AdminRecipeSearchResult
 import net.jonasmf.auctionengine.generated.model.GameLocale
 import net.jonasmf.auctionengine.generated.model.PageMetadata
 import net.jonasmf.auctionengine.integration.blizzard.ItemApiLookup
@@ -133,6 +135,48 @@ class AdminItemServiceTest {
         assertEquals("https://example.test/base.png", result.fields.getValue("mediaUrl").effective)
     }
 
+    @Test
+    fun `recipe association updates crafted item and quantity`() {
+        repository.itemRows[171374] =
+            AdminItemRows(
+                base = AdminItemFields(id = 171374),
+                override = null,
+                effective = AdminItemFields(id = 171374),
+            )
+        repository.recipeIds += 338995
+
+        service.upsertRecipeAssociation(
+            171374,
+            338995,
+            AdminRecipeAssociationRequest(craftedItemId = 171374, craftedQuantity = 2),
+        )
+
+        assertEquals(Triple(338995, 171374, 2), repository.lastRecipeCraftedItemUpdate)
+    }
+
+    @Test
+    fun `recipe association rejects mismatched crafted item id`() {
+        repository.itemRows[171374] =
+            AdminItemRows(
+                base = AdminItemFields(id = 171374),
+                override = null,
+                effective = AdminItemFields(id = 171374),
+            )
+        repository.recipeIds += 338995
+
+        val error =
+            assertThrows(ResponseStatusException::class.java) {
+                service.upsertRecipeAssociation(
+                    171374,
+                    338995,
+                    AdminRecipeAssociationRequest(craftedItemId = 19019, craftedQuantity = 1),
+                )
+            }
+
+        assertEquals(400, error.statusCode.value())
+        assertEquals("craftedItemId must match path item id", error.reason)
+    }
+
     private fun item(id: Int) =
         Item(
             id = id,
@@ -162,7 +206,11 @@ private class FakeItemApiLookup : ItemApiLookup {
 private class FakeAdminItemRepository : AdminItemRepositoryPort {
     val baseItemIds = mutableSetOf<Int>()
     val itemRows = mutableMapOf<Int, AdminItemRows>()
+    val recipeIds = mutableSetOf<Int>()
+    val recipeSearchResults = mutableListOf<AdminRecipeSearchResult>()
     var lastUpsert: Pair<Int, AdminItemOverrideRequest>? = null
+    var lastRecipeSearch: Triple<String?, Int, String>? = null
+    var lastRecipeCraftedItemUpdate: Triple<Int, Int?, Int?>? = null
 
     override fun searchItems(
         query: String?,
@@ -219,4 +267,24 @@ private class FakeAdminItemRepository : AdminItemRepositoryPort {
     ) = Unit
 
     override fun deleteOverride(id: Int): Boolean = itemRows.remove(id) != null
+
+    override fun recipeExists(recipeId: Int): Boolean = recipeId in recipeIds
+
+    override fun searchRecipes(
+        query: String?,
+        limit: Int,
+        localeColumnSuffix: String,
+    ): List<AdminRecipeSearchResult> {
+        lastRecipeSearch = Triple(query, limit, localeColumnSuffix)
+        return recipeSearchResults
+    }
+
+    override fun updateRecipeCraftedItem(
+        recipeId: Int,
+        craftedItemId: Int?,
+        craftedQuantity: Int?,
+    ): Boolean {
+        lastRecipeCraftedItemUpdate = Triple(recipeId, craftedItemId, craftedQuantity)
+        return recipeId in recipeIds
+    }
 }

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/service/admin/AdminItemServiceTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/service/admin/AdminItemServiceTest.kt
@@ -1,0 +1,222 @@
+package net.jonasmf.auctionengine.service.admin
+
+import net.jonasmf.auctionengine.domain.item.InventoryType
+import net.jonasmf.auctionengine.domain.item.Item
+import net.jonasmf.auctionengine.domain.item.ItemClass
+import net.jonasmf.auctionengine.domain.item.ItemQuality
+import net.jonasmf.auctionengine.domain.item.ItemSubclass
+import net.jonasmf.auctionengine.dto.LocaleDTO
+import net.jonasmf.auctionengine.generated.model.AdminItemCreateRequest
+import net.jonasmf.auctionengine.generated.model.AdminItemFields
+import net.jonasmf.auctionengine.generated.model.AdminItemOverrideRequest
+import net.jonasmf.auctionengine.generated.model.AdminItemReference
+import net.jonasmf.auctionengine.generated.model.GameLocale
+import net.jonasmf.auctionengine.generated.model.PageMetadata
+import net.jonasmf.auctionengine.integration.blizzard.ItemApiLookup
+import net.jonasmf.auctionengine.repository.rds.AdminItemRepositoryPort
+import net.jonasmf.auctionengine.repository.rds.AdminItemRows
+import net.jonasmf.auctionengine.repository.rds.AdminItemSearchResult
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.springframework.web.server.ResponseStatusException
+
+class AdminItemServiceTest {
+    private val repository = FakeAdminItemRepository()
+    private val itemApiClient = FakeItemApiLookup()
+    private val service = AdminItemService(repository, itemApiClient)
+
+    @Test
+    fun `upsert override rejects missing item`() {
+        repository.itemRows -= 42
+
+        val error =
+            assertThrows(ResponseStatusException::class.java) {
+                service.upsertOverride(42, AdminItemOverrideRequest(mediaUrl = "https://example.test/icon.png"))
+            }
+
+        assertEquals(404, error.statusCode.value())
+        assertEquals("Item not found: 42", error.reason)
+    }
+
+    @Test
+    fun `upsert override allows override-only item when full effective fields remain present`() {
+        repository.itemRows[500000] =
+            AdminItemRows(
+                base = null,
+                override = AdminItemFields(id = 500000),
+                effective = AdminItemFields(id = 500000),
+            )
+
+        service.upsertOverride(
+            500000,
+            AdminItemOverrideRequest(
+                nameLocales = GameLocale(enUS = "Manual item"),
+                qualityType = "COMMON",
+                level = 1,
+                requiredLevel = 1,
+                mediaUrl = "https://example.test/icon.png",
+                itemClassId = 7,
+                itemSubclassId = 1,
+                inventoryType = "NON_EQUIP",
+                purchasePrice = 0,
+                sellPrice = 0,
+                maxCount = 1,
+                isEquippable = false,
+                isStackable = true,
+                purchaseQuantity = 1,
+            ),
+        )
+
+        assertEquals(500000, repository.lastUpsert?.first)
+    }
+
+    @Test
+    fun `create override-only requires localized English name`() {
+        val error =
+            assertThrows(ResponseStatusException::class.java) {
+                service.createOverrideOnly(
+                    AdminItemCreateRequest(
+                        id = 500000,
+                        nameLocales = GameLocale(),
+                        qualityType = "COMMON",
+                        level = 1,
+                        requiredLevel = 1,
+                        mediaUrl = "https://example.test/icon.png",
+                        itemClassId = 7,
+                        itemSubclassId = 1,
+                        inventoryType = "NON_EQUIP",
+                        purchasePrice = 0,
+                        sellPrice = 0,
+                        maxCount = 1,
+                        isEquippable = false,
+                        isStackable = true,
+                        purchaseQuantity = 1,
+                    ),
+                )
+            }
+
+        assertEquals(400, error.statusCode.value())
+        assertEquals("At least one English item name is required", error.reason)
+    }
+
+    @Test
+    fun `compare returns field level base override api and effective values`() {
+        repository.itemRows[171374] =
+            AdminItemRows(
+                base =
+                    AdminItemFields(
+                        id = 171374,
+                        quality = AdminItemReference(id = 1, type = "COMMON", name = "Common"),
+                        mediaUrl = "https://example.test/base.png",
+                    ),
+                override =
+                    AdminItemFields(
+                        id = 171374,
+                        quality = AdminItemReference(id = 3, type = "RARE", name = "Rare"),
+                    ),
+                effective =
+                    AdminItemFields(
+                        id = 171374,
+                        quality = AdminItemReference(id = 3, type = "RARE", name = "Rare"),
+                        mediaUrl = "https://example.test/base.png",
+                    ),
+            )
+        itemApiClient.items[171374] = item(171374)
+
+        val result = service.compareWithApi(171374)
+
+        assertEquals("COMMON", result.fields.getValue("qualityType").base)
+        assertEquals("RARE", result.fields.getValue("qualityType").`override`)
+        assertEquals("UNCOMMON", result.fields.getValue("qualityType").api)
+        assertEquals("RARE", result.fields.getValue("qualityType").effective)
+        assertEquals("https://example.test/base.png", result.fields.getValue("mediaUrl").effective)
+    }
+
+    private fun item(id: Int) =
+        Item(
+            id = id,
+            name = LocaleDTO(en_US = "API item", en_GB = "API item"),
+            quality = ItemQuality("UNCOMMON", LocaleDTO(en_US = "Uncommon", en_GB = "Uncommon")),
+            level = 10,
+            requiredLevel = 1,
+            mediaUrl = "https://example.test/api.png",
+            itemClass = ItemClass(7, LocaleDTO(en_US = "Trade Goods", en_GB = "Trade Goods")),
+            itemSubclass = ItemSubclass(7, 1, LocaleDTO(en_US = "Parts", en_GB = "Parts")),
+            inventoryType = InventoryType("NON_EQUIP", LocaleDTO(en_US = "Non-equippable", en_GB = "Non-equippable")),
+            purchasePrice = 0,
+            sellPrice = 1,
+            maxCount = 200,
+            isEquippable = false,
+            isStackable = true,
+            purchaseQuantity = 1,
+        )
+}
+
+private class FakeItemApiLookup : ItemApiLookup {
+    val items = mutableMapOf<Int, Item>()
+
+    override fun getById(id: Int): Item = items.getValue(id)
+}
+
+private class FakeAdminItemRepository : AdminItemRepositoryPort {
+    val baseItemIds = mutableSetOf<Int>()
+    val itemRows = mutableMapOf<Int, AdminItemRows>()
+    var lastUpsert: Pair<Int, AdminItemOverrideRequest>? = null
+
+    override fun searchItems(
+        query: String?,
+        hasBase: Boolean?,
+        hasOverride: Boolean?,
+        page: Int,
+        pageSize: Int,
+        localeColumnSuffix: String,
+    ): AdminItemSearchResult = AdminItemSearchResult(items = emptyList(), totalItems = 0)
+
+    override fun pageMetadata(
+        page: Int,
+        pageSize: Int,
+        totalItems: Long,
+    ): PageMetadata = PageMetadata(page = page, pageSize = pageSize, totalItems = totalItems, totalPages = 0)
+
+    override fun findItemRows(
+        id: Int,
+        localeColumnSuffix: String,
+    ): AdminItemRows? = itemRows[id]
+
+    override fun hasAnyItemRow(id: Int): Boolean = itemRows.containsKey(id)
+
+    override fun hasBaseItem(id: Int): Boolean = id in baseItemIds
+
+    override fun hasOverrideItem(id: Int): Boolean = itemRows[id]?.override != null
+
+    override fun qualityId(type: String): Long? = 1
+
+    override fun inventoryTypeId(type: String): Long? = 1
+
+    override fun bindingId(type: String): Long? = 1
+
+    override fun itemClassExists(id: Int): Boolean = true
+
+    override fun itemSubclassInternalId(
+        classId: Int,
+        subclassId: Int,
+    ): Long? = 1
+
+    override fun expansionExists(expansionId: Int): Boolean = true
+
+    override fun upsertOverride(
+        id: Int,
+        request: AdminItemOverrideRequest,
+        itemSubclassInternalId: Long?,
+    ) {
+        lastUpsert = id to request
+    }
+
+    override fun createOverrideOnly(
+        request: AdminItemCreateRequest,
+        itemSubclassInternalId: Long,
+    ) = Unit
+
+    override fun deleteOverride(id: Int): Boolean = itemRows.remove(id) != null
+}

--- a/backend/src/test/kotlin/net/jonasmf/auctionengine/service/admin/AdminItemServiceTest.kt
+++ b/backend/src/test/kotlin/net/jonasmf/auctionengine/service/admin/AdminItemServiceTest.kt
@@ -158,7 +158,7 @@ class AdminItemServiceTest {
     fun `search items accepts class and subclass filters without reference lookup`() {
         repository.itemSubclassExists = false
 
-        val result = service.searchItems(null, null, null, null, 1, 1, 1, 25)
+        val result = service.searchItems(null, null, null, null, 1, 1, null, null, 1, 25)
 
         assertEquals(0, result.items.size)
         assertEquals(1, repository.lastSearch?.itemClassId)
@@ -169,7 +169,7 @@ class AdminItemServiceTest {
     fun `search items requires class when subclass filter is set`() {
         val error =
             assertThrows(ResponseStatusException::class.java) {
-                service.searchItems(null, null, null, null, null, 1, 1, 25)
+                service.searchItems(null, null, null, null, null, 1, null, null, 1, 25)
             }
 
         assertEquals(400, error.statusCode.value())
@@ -225,6 +225,8 @@ private data class AdminItemSearchCall(
     val hasOverride: Boolean?,
     val itemClassId: Int?,
     val itemSubclassId: Int?,
+    val expansionId: Int?,
+    val hasRecipe: Boolean?,
     val page: Int,
     val pageSize: Int,
     val localeColumnSuffix: String,
@@ -253,6 +255,8 @@ private class FakeAdminItemRepository : AdminItemRepositoryPort {
         hasOverride: Boolean?,
         itemClassId: Int?,
         itemSubclassId: Int?,
+        expansionId: Int?,
+        hasRecipe: Boolean?,
         page: Int,
         pageSize: Int,
         localeColumnSuffix: String,
@@ -264,6 +268,8 @@ private class FakeAdminItemRepository : AdminItemRepositoryPort {
                 hasOverride = hasOverride,
                 itemClassId = itemClassId,
                 itemSubclassId = itemSubclassId,
+                expansionId = expansionId,
+                hasRecipe = hasRecipe,
                 page = page,
                 pageSize = pageSize,
                 localeColumnSuffix = localeColumnSuffix,

--- a/bun.lock
+++ b/bun.lock
@@ -61,7 +61,7 @@
         "jsdom": "^28.0.0",
         "ng-packagr": "^21.2.0",
         "postcss": "^8.5.3",
-        "prettier": "^3.8.1",
+        "prettier": "^3.9.4",
         "storybook": "^10.3.6",
         "tailwindcss": "^4.1.12",
         "typescript": "~5.9.2",
@@ -2131,7 +2131,7 @@
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
-    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
+    "prettier": ["prettier@3.9.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg=="],
 
     "pretty-error": ["pretty-error@4.0.0", "", { "dependencies": { "lodash": "^4.17.20", "renderkid": "^3.0.0" } }, "sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw=="],
 

--- a/frontend/ethereal-ui/src/lib/components/primitives/icon-button.component.ts
+++ b/frontend/ethereal-ui/src/lib/components/primitives/icon-button.component.ts
@@ -1,5 +1,5 @@
 import { A11yModule } from '@angular/cdk/a11y';
-import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, output, signal } from '@angular/core';
 
 import { SymbolIconComponent, SymbolIconName } from './symbol-icon.component';
 
@@ -7,17 +7,38 @@ import { SymbolIconComponent, SymbolIconName } from './symbol-icon.component';
   selector: 'ee-icon-button',
   imports: [A11yModule, SymbolIconComponent],
   template: `
-    <button
-      cdkMonitorElementFocus
-      type="button"
-      class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/0 text-primary transition hover:bg-white/5 hover:text-on-surface disabled:cursor-not-allowed disabled:opacity-45"
-      [attr.aria-label]="label()"
+    <span
+      class="inline-flex"
       [attr.title]="tooltip() || label()"
-      [disabled]="disabled()"
-      (click)="pressed.emit()"
+      (mouseenter)="showTooltip($event)"
+      (mouseleave)="hideTooltip()"
     >
-      <ee-symbol-icon class="text-[22px]" [name]="icon()" />
-    </button>
+      <button
+        cdkMonitorElementFocus
+        type="button"
+        class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/0 text-primary transition hover:bg-white/5 hover:text-on-surface disabled:cursor-not-allowed disabled:opacity-45"
+        [attr.aria-label]="label()"
+        [attr.aria-describedby]="tooltipText() ? tooltipId : null"
+        [attr.title]="tooltip() || label()"
+        [disabled]="disabled()"
+        (blur)="hideTooltip()"
+        (click)="pressed.emit()"
+        (focus)="showTooltip($event)"
+      >
+        <ee-symbol-icon class="text-[22px]" [name]="icon()" />
+      </button>
+    </span>
+    @if (visibleTooltip(); as tip) {
+      <span
+        [id]="tooltipId"
+        role="tooltip"
+        class="pointer-events-none fixed z-50 max-w-64 rounded-md border border-white/10 bg-surface-container-highest px-3 py-2 text-xs font-medium leading-snug text-on-surface shadow-xl"
+        [style.left.px]="tip.left"
+        [style.top.px]="tip.top"
+      >
+        {{ tip.text }}
+      </span>
+    }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -27,4 +48,27 @@ export class IconButtonComponent {
   readonly tooltip = input('');
   readonly disabled = input(false);
   readonly pressed = output<void>();
+
+  protected readonly tooltipId = `ee-icon-button-tooltip-${nextTooltipId++}`;
+  protected readonly tooltipPosition = signal<{ left: number; top: number } | null>(null);
+  protected readonly tooltipText = computed(() => this.tooltip() || this.label());
+  protected readonly visibleTooltip = computed(() => {
+    const position = this.tooltipPosition();
+    const text = this.tooltipText();
+    return position && text ? { ...position, text } : null;
+  });
+
+  protected showTooltip(event: Event): void {
+    const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+    this.tooltipPosition.set({
+      left: Math.min(window.innerWidth - 272, Math.max(8, rect.left + rect.width / 2 - 128)),
+      top: Math.max(8, rect.top - 44),
+    });
+  }
+
+  protected hideTooltip(): void {
+    this.tooltipPosition.set(null);
+  }
 }
+
+let nextTooltipId = 0;

--- a/frontend/ethereal-ui/src/lib/components/primitives/icon-button.component.ts
+++ b/frontend/ethereal-ui/src/lib/components/primitives/icon-button.component.ts
@@ -12,7 +12,7 @@ import { SymbolIconComponent, SymbolIconName } from './symbol-icon.component';
       type="button"
       class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/0 text-primary transition hover:bg-white/5 hover:text-on-surface disabled:cursor-not-allowed disabled:opacity-45"
       [attr.aria-label]="label()"
-      [attr.title]="label()"
+      [attr.title]="tooltip() || label()"
       [disabled]="disabled()"
       (click)="pressed.emit()"
     >
@@ -24,6 +24,7 @@ import { SymbolIconComponent, SymbolIconName } from './symbol-icon.component';
 export class IconButtonComponent {
   readonly icon = input.required<SymbolIconName | string>();
   readonly label = input.required<string>();
+  readonly tooltip = input('');
   readonly disabled = input(false);
   readonly pressed = output<void>();
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,7 +73,7 @@
     "jsdom": "^28.0.0",
     "ng-packagr": "^21.2.0",
     "postcss": "^8.5.3",
-    "prettier": "^3.8.1",
+    "prettier": "3.8.3",
     "storybook": "^10.3.6",
     "tailwindcss": "^4.1.12",
     "typescript": "~5.9.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,7 +73,7 @@
     "jsdom": "^28.0.0",
     "ng-packagr": "^21.2.0",
     "postcss": "^8.5.3",
-    "prettier": "3.8.3",
+    "prettier": "^3.9.4",
     "storybook": "^10.3.6",
     "tailwindcss": "^4.1.12",
     "typescript": "~5.9.2",

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -81,6 +81,13 @@ export const routes: TitledRoutes = [
             (module) => module.ExpansionsPage,
           ),
       },
+      {
+        path: 'items',
+        title: $localize`:@@route.admin.items:Items`,
+        icon: 'inventory_2',
+        loadComponent: () =>
+          import('@features/admin/items/items.page').then((module) => module.ItemsPage),
+      },
     ],
   },
   {

--- a/frontend/src/app/core/services/query.service.ts
+++ b/frontend/src/app/core/services/query.service.ts
@@ -16,11 +16,10 @@ export const TO_QUERY_PARAMS_MAPPER = new InjectionToken<
 });
 
 export type Region = 'eu' | 'us' | 'kr' | 'tw';
-@Injectable(
-  /*{
+@Injectable()
+/*{
   providedIn: 'root',
 }*/
-)
 export class QueryService<QueryParam> {
   readonly region = signal<Region>('eu');
   readonly realmSlug = signal<string | undefined>(undefined);

--- a/frontend/src/app/core/services/query.service.ts
+++ b/frontend/src/app/core/services/query.service.ts
@@ -16,9 +16,11 @@ export const TO_QUERY_PARAMS_MAPPER = new InjectionToken<
 });
 
 export type Region = 'eu' | 'us' | 'kr' | 'tw';
-@Injectable(/*{
+@Injectable(
+  /*{
   providedIn: 'root',
-}*/)
+}*/
+)
 export class QueryService<QueryParam> {
   readonly region = signal<Region>('eu');
   readonly realmSlug = signal<string | undefined>(undefined);

--- a/frontend/src/app/features/admin/items/admin-item-actions-cell.component.ts
+++ b/frontend/src/app/features/admin/items/admin-item-actions-cell.component.ts
@@ -1,0 +1,63 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { AdminItem1 } from '@api/generated';
+import { injectFlexRenderContext } from '@tanstack/angular-table';
+import type { CellContext } from '@tanstack/table-core';
+import { IconButtonComponent } from '@ui';
+
+type AdminItemActionsMeta = {
+  readonly onEdit?: (item: AdminItem1) => void;
+  readonly onCompare?: (item: AdminItem1) => void;
+  readonly onDeleteOverride?: (item: AdminItem1) => void;
+};
+
+@Component({
+  selector: 'app-admin-item-actions-cell',
+  imports: [IconButtonComponent],
+  template: `
+    <div class="flex items-center justify-end gap-1">
+      <ee-icon-button
+        icon="edit"
+        label="Edit item override"
+        tooltip="Open the item override editor for this item."
+        (pressed)="edit()"
+      />
+      <ee-icon-button
+        icon="import_export"
+        label="Compare Blizzard API"
+        tooltip="Compare the local item data with the current Blizzard API response."
+        (pressed)="compare()"
+      />
+      <ee-icon-button
+        icon="delete"
+        label="Delete override"
+        tooltip="Remove this item override and inherit base item data again."
+        [disabled]="!item().hasOverride"
+        (pressed)="deleteOverride()"
+      />
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AdminItemActionsCellComponent {
+  private readonly ctx = injectFlexRenderContext<CellContext<AdminItem1, unknown>>();
+
+  protected item(): AdminItem1 {
+    return this.ctx.row.original;
+  }
+
+  protected edit(): void {
+    this.actions()?.onEdit?.(this.item());
+  }
+
+  protected compare(): void {
+    this.actions()?.onCompare?.(this.item());
+  }
+
+  protected deleteOverride(): void {
+    this.actions()?.onDeleteOverride?.(this.item());
+  }
+
+  private actions(): AdminItemActionsMeta | undefined {
+    return this.ctx.column.columnDef.meta as AdminItemActionsMeta | undefined;
+  }
+}

--- a/frontend/src/app/features/admin/items/admin-item-actions-cell.component.ts
+++ b/frontend/src/app/features/admin/items/admin-item-actions-cell.component.ts
@@ -6,6 +6,7 @@ import { IconButtonComponent } from '@ui';
 
 type AdminItemActionsMeta = {
   readonly onEdit?: (item: AdminItem1) => void;
+  readonly onAssociateRecipe?: (item: AdminItem1) => void;
   readonly onCompare?: (item: AdminItem1) => void;
   readonly onDeleteOverride?: (item: AdminItem1) => void;
 };
@@ -20,6 +21,12 @@ type AdminItemActionsMeta = {
         label="Edit item override"
         tooltip="Open the item override editor for this item."
         (pressed)="edit()"
+      />
+      <ee-icon-button
+        icon="restaurant"
+        label="Associate recipe"
+        tooltip="Associate a profession recipe with this item as its crafted output."
+        (pressed)="associateRecipe()"
       />
       <ee-icon-button
         icon="import_export"
@@ -47,6 +54,10 @@ export class AdminItemActionsCellComponent {
 
   protected edit(): void {
     this.actions()?.onEdit?.(this.item());
+  }
+
+  protected associateRecipe(): void {
+    this.actions()?.onAssociateRecipe?.(this.item());
   }
 
   protected compare(): void {

--- a/frontend/src/app/features/admin/items/admin-item-compare-panel.component.ts
+++ b/frontend/src/app/features/admin/items/admin-item-compare-panel.component.ts
@@ -1,0 +1,85 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { AdminItemCompareField, AdminItemCompareResponse } from '@api/generated';
+
+type CompareRow = {
+  readonly key: string;
+  readonly value: AdminItemCompareField;
+};
+
+@Component({
+  selector: 'app-admin-item-compare-panel',
+  template: `
+    <div class="grid gap-4">
+      @if (loading()) {
+        <p class="ee-data text-outline" role="status">Comparing with Blizzard API...</p>
+      } @else if (error()) {
+        <p
+          class="rounded-md border border-error/30 bg-error/10 px-3 py-2 text-sm text-error"
+          role="alert"
+        >
+          {{ error() }}
+        </p>
+      } @else if (compare(); as result) {
+        <p class="ee-data text-outline"><span>Item</span> #{{ result.itemId }}</p>
+        <div class="overflow-x-auto rounded-md border border-white/10">
+          <table class="min-w-full divide-y divide-white/10 text-sm">
+            <thead class="bg-surface-container-high text-left ee-label text-outline">
+              <tr>
+                <th class="px-3 py-2">Field</th>
+                <th class="px-3 py-2">Base</th>
+                <th class="px-3 py-2">Override</th>
+                <th class="px-3 py-2">API</th>
+                <th class="px-3 py-2">Effective</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-white/5">
+              @for (row of rows(); track row.key) {
+                <tr>
+                  <th class="px-3 py-2 text-left font-semibold text-on-surface">
+                    {{ row.key }}
+                  </th>
+                  <td class="max-w-48 px-3 py-2 text-outline">{{ format(row.value.base) }}</td>
+                  <td class="max-w-48 px-3 py-2 text-outline">
+                    {{ format(row.value.override) }}
+                  </td>
+                  <td class="max-w-48 px-3 py-2 text-outline">{{ format(row.value.api) }}</td>
+                  <td class="max-w-48 px-3 py-2 text-on-surface">
+                    {{ format(row.value.effective) }}
+                  </td>
+                </tr>
+              } @empty {
+                <tr>
+                  <td class="px-3 py-6 text-center text-outline" colspan="5">
+                    <span>No comparable fields returned.</span>
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      } @else {
+        <p class="ee-data text-outline">Run compare to inspect Blizzard API differences.</p>
+      }
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AdminItemComparePanelComponent {
+  readonly compare = input<AdminItemCompareResponse | null>(null);
+  readonly loading = input(false);
+  readonly error = input<string | null>(null);
+
+  protected readonly rows = computed<CompareRow[]>(() => {
+    const fields = this.compare()?.fields ?? {};
+    return Object.entries(fields)
+      .map(([key, value]) => ({ key, value }))
+      .sort((left, right) => left.key.localeCompare(right.key));
+  });
+
+  protected format(value: object | null | undefined): string {
+    if (value === undefined || value === null) return '—';
+    if (typeof value === 'string') return value;
+    if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+    return JSON.stringify(value);
+  }
+}

--- a/frontend/src/app/features/admin/items/admin-item-create-form.component.ts
+++ b/frontend/src/app/features/admin/items/admin-item-create-form.component.ts
@@ -1,0 +1,304 @@
+import { ChangeDetectionStrategy, Component, input, output, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { AdminItemCreateRequest, GameLocale } from '@api/generated';
+import { emptyGameLocale, hasEnglishGameLocale } from '@features/admin/shared/game-locale-fields';
+import { LocaleFieldsComponent } from '@features/admin/shared/locale-fields.component';
+import { SelectInputComponent, TextInputComponent } from '@ui';
+
+const standaloneModel = { standalone: true };
+
+@Component({
+  selector: 'app-admin-item-create-form',
+  imports: [FormsModule, LocaleFieldsComponent, SelectInputComponent, TextInputComponent],
+  template: `
+    <form class="grid gap-5" (submit)="onSubmit($event)">
+      <fieldset class="grid gap-4">
+        <legend class="font-semibold text-on-surface">Identity</legend>
+        <ee-text-input
+          label="Item ID"
+          type="number"
+          [required]="true"
+          [ngModel]="id()"
+          [ngModelOptions]="standaloneModel"
+          (ngModelChange)="id.set($event)"
+        />
+        <app-locale-fields [value]="nameLocales()" (valueChange)="nameLocales.set($event)" />
+      </fieldset>
+
+      <fieldset class="grid gap-4">
+        <legend class="font-semibold text-on-surface">Core item data</legend>
+        <div class="grid gap-4 md:grid-cols-2">
+          <ee-text-input
+            label="Quality type"
+            placeholder="COMMON"
+            [required]="true"
+            [ngModel]="qualityType()"
+            [ngModelOptions]="standaloneModel"
+            (ngModelChange)="qualityType.set($event)"
+          />
+          <ee-text-input
+            label="Level"
+            type="number"
+            [required]="true"
+            [ngModel]="level()"
+            [ngModelOptions]="standaloneModel"
+            (ngModelChange)="level.set($event)"
+          />
+          <ee-text-input
+            label="Required level"
+            type="number"
+            [required]="true"
+            [ngModel]="requiredLevel()"
+            [ngModelOptions]="standaloneModel"
+            (ngModelChange)="requiredLevel.set($event)"
+          />
+          <ee-text-input
+            label="Expansion ID"
+            type="number"
+            [ngModel]="expansionId()"
+            [ngModelOptions]="standaloneModel"
+            (ngModelChange)="expansionId.set($event)"
+          />
+        </div>
+      </fieldset>
+
+      <fieldset class="grid gap-4">
+        <legend class="font-semibold text-on-surface">Classification</legend>
+        <div class="grid gap-4 md:grid-cols-2">
+          <ee-text-input
+            label="Class ID"
+            type="number"
+            [required]="true"
+            [ngModel]="itemClassId()"
+            [ngModelOptions]="standaloneModel"
+            (ngModelChange)="itemClassId.set($event)"
+          />
+          <ee-text-input
+            label="Subclass ID"
+            type="number"
+            [required]="true"
+            [ngModel]="itemSubclassId()"
+            [ngModelOptions]="standaloneModel"
+            (ngModelChange)="itemSubclassId.set($event)"
+          />
+          <ee-text-input
+            label="Inventory type"
+            [required]="true"
+            [ngModel]="inventoryType()"
+            [ngModelOptions]="standaloneModel"
+            (ngModelChange)="inventoryType.set($event)"
+          />
+          <ee-text-input
+            label="Binding type"
+            [ngModel]="bindingType()"
+            [ngModelOptions]="standaloneModel"
+            (ngModelChange)="bindingType.set($event)"
+          />
+        </div>
+      </fieldset>
+
+      <fieldset class="grid gap-4">
+        <legend class="font-semibold text-on-surface">Media and economy</legend>
+        <ee-text-input
+          label="Media URL"
+          type="url"
+          [required]="true"
+          [ngModel]="mediaUrl()"
+          [ngModelOptions]="standaloneModel"
+          (ngModelChange)="mediaUrl.set($event)"
+        />
+        <ee-text-input
+          label="Media source URL"
+          type="url"
+          [ngModel]="mediaSourceUrl()"
+          [ngModelOptions]="standaloneModel"
+          (ngModelChange)="mediaSourceUrl.set($event)"
+        />
+        <div class="grid gap-4 md:grid-cols-2">
+          <ee-text-input
+            label="Purchase price"
+            type="number"
+            [required]="true"
+            [ngModel]="purchasePrice()"
+            [ngModelOptions]="standaloneModel"
+            (ngModelChange)="purchasePrice.set($event)"
+          />
+          <ee-text-input
+            label="Sell price"
+            type="number"
+            [required]="true"
+            [ngModel]="sellPrice()"
+            [ngModelOptions]="standaloneModel"
+            (ngModelChange)="sellPrice.set($event)"
+          />
+          <ee-text-input
+            label="Max count"
+            type="number"
+            [required]="true"
+            [ngModel]="maxCount()"
+            [ngModelOptions]="standaloneModel"
+            (ngModelChange)="maxCount.set($event)"
+          />
+          <ee-text-input
+            label="Purchase quantity"
+            type="number"
+            [required]="true"
+            [ngModel]="purchaseQuantity()"
+            [ngModelOptions]="standaloneModel"
+            (ngModelChange)="purchaseQuantity.set($event)"
+          />
+          <ee-select-input
+            label="Equippable"
+            [options]="booleanOptions"
+            [ngModel]="isEquippable()"
+            [ngModelOptions]="standaloneModel"
+            (ngModelChange)="isEquippable.set($event)"
+          />
+          <ee-select-input
+            label="Stackable"
+            [options]="booleanOptions"
+            [ngModel]="isStackable()"
+            [ngModelOptions]="standaloneModel"
+            (ngModelChange)="isStackable.set($event)"
+          />
+        </div>
+      </fieldset>
+
+      <ee-text-input
+        label="Override note"
+        [ngModel]="overrideNote()"
+        [ngModelOptions]="standaloneModel"
+        (ngModelChange)="overrideNote.set($event)"
+      />
+
+      @if (validationError()) {
+        <p
+          class="rounded-md border border-error/30 bg-error/10 px-3 py-2 text-sm text-error"
+          role="alert"
+        >
+          {{ validationError() }}
+        </p>
+      }
+
+      <div class="flex flex-wrap gap-3">
+        <button
+          type="submit"
+          class="h-10 rounded-md bg-primary px-4 font-semibold text-on-primary transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-primary-container"
+          [disabled]="submitting()"
+        >
+          Create item
+        </button>
+        <button
+          type="button"
+          class="h-10 rounded-md border border-white/10 px-4 font-semibold text-on-surface transition hover:bg-white/5 focus:outline-none focus:ring-2 focus:ring-primary-container"
+          (click)="cancelled.emit()"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AdminItemCreateFormComponent {
+  protected readonly standaloneModel = standaloneModel;
+  protected readonly booleanOptions = [
+    { id: 'true', label: $localize`:@@common.yes:Yes` },
+    { id: 'false', label: $localize`:@@common.no:No` },
+  ];
+
+  readonly submitting = input(false);
+  readonly submitted = output<AdminItemCreateRequest>();
+  readonly cancelled = output<void>();
+
+  protected readonly id = signal('');
+  protected readonly nameLocales = signal<GameLocale>(emptyGameLocale());
+  protected readonly qualityType = signal('COMMON');
+  protected readonly level = signal('1');
+  protected readonly requiredLevel = signal('1');
+  protected readonly mediaUrl = signal('');
+  protected readonly mediaSourceUrl = signal('');
+  protected readonly itemClassId = signal('');
+  protected readonly itemSubclassId = signal('');
+  protected readonly inventoryType = signal('NON_EQUIP');
+  protected readonly bindingType = signal('');
+  protected readonly purchasePrice = signal('0');
+  protected readonly sellPrice = signal('0');
+  protected readonly maxCount = signal('1');
+  protected readonly isEquippable = signal('false');
+  protected readonly isStackable = signal('true');
+  protected readonly purchaseQuantity = signal('1');
+  protected readonly expansionId = signal('');
+  protected readonly overrideNote = signal('');
+  protected readonly validationError = signal<string | null>(null);
+
+  protected onSubmit(event: Event): void {
+    event.preventDefault();
+    this.validationError.set(null);
+
+    if (!hasEnglishGameLocale(this.nameLocales())) {
+      this.validationError.set(
+        $localize`:@@admin.items.create.englishRequired:English (US) or English (GB) name is required.`,
+      );
+      return;
+    }
+
+    const request: AdminItemCreateRequest = {
+      id: this.requiredInt(this.id(), 'Item ID'),
+      nameLocales: this.nameLocales(),
+      qualityType: this.requiredString(this.qualityType(), 'Quality type'),
+      level: this.requiredInt(this.level(), 'Level'),
+      requiredLevel: this.requiredInt(this.requiredLevel(), 'Required level'),
+      mediaUrl: this.requiredString(this.mediaUrl(), 'Media URL'),
+      mediaSourceUrl: this.optionalString(this.mediaSourceUrl()),
+      itemClassId: this.requiredInt(this.itemClassId(), 'Class ID'),
+      itemSubclassId: this.requiredInt(this.itemSubclassId(), 'Subclass ID'),
+      inventoryType: this.requiredString(this.inventoryType(), 'Inventory type'),
+      bindingType: this.optionalString(this.bindingType()),
+      purchasePrice: this.requiredInt(this.purchasePrice(), 'Purchase price'),
+      sellPrice: this.requiredInt(this.sellPrice(), 'Sell price'),
+      maxCount: this.requiredInt(this.maxCount(), 'Max count'),
+      isEquippable: this.isEquippable() === 'true',
+      isStackable: this.isStackable() === 'true',
+      purchaseQuantity: this.requiredInt(this.purchaseQuantity(), 'Purchase quantity'),
+      expansionId: this.optionalInt(this.expansionId(), 'Expansion ID'),
+      overrideNote: this.optionalString(this.overrideNote()),
+    };
+    if (this.validationError()) return;
+
+    this.submitted.emit(request);
+  }
+
+  private requiredString(value: string, label: string): string {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      this.validationError.set(`${label} is required.`);
+    }
+    return trimmed;
+  }
+
+  private optionalString(value: string): string | null {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  private requiredInt(value: string, label: string): number {
+    const parsed = this.optionalInt(value, label);
+    if (parsed === null) {
+      this.validationError.set(`${label} is required.`);
+      return 0;
+    }
+    return parsed;
+  }
+
+  private optionalInt(value: string, label: string): number | null {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return null;
+    const parsed = Number.parseInt(trimmed, 10);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      this.validationError.set(`${label} must be a non-negative number.`);
+      return null;
+    }
+    return parsed;
+  }
+}

--- a/frontend/src/app/features/admin/items/admin-item-name-cell.component.ts
+++ b/frontend/src/app/features/admin/items/admin-item-name-cell.component.ts
@@ -1,0 +1,29 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { AdminItem1 } from '@api/generated';
+import { injectFlexRenderContext } from '@tanstack/angular-table';
+import type { CellContext } from '@tanstack/table-core';
+
+@Component({
+  selector: 'app-admin-item-name-cell',
+  template: `
+    <div class="grid min-w-0 gap-1">
+      <span class="truncate font-semibold text-on-surface">
+        {{ item().effective.name || 'Unnamed item' }}
+      </span>
+      @for (recipe of item().effective.recipes ?? []; track recipe.recipeId) {
+        <span class="min-w-0 text-xs leading-snug text-outline">
+          <span class="text-on-surface/80">{{ recipe.name }}</span>
+          <span> · {{ recipe.professionName }}</span>
+        </span>
+      }
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AdminItemNameCellComponent {
+  private readonly ctx = injectFlexRenderContext<CellContext<AdminItem1, unknown>>();
+
+  protected item(): AdminItem1 {
+    return this.ctx.row.original;
+  }
+}

--- a/frontend/src/app/features/admin/items/admin-item-override-form.component.ts
+++ b/frontend/src/app/features/admin/items/admin-item-override-form.component.ts
@@ -1,0 +1,907 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  input,
+  output,
+  signal,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import {
+  AdminExpansion,
+  AdminItem1,
+  AdminItemFields,
+  AdminItemOverrideRequest,
+  GameLocale,
+} from '@api/generated';
+import { LocaleFieldsComponent } from '@features/admin/shared/locale-fields.component';
+import {
+  CheckboxInputComponent,
+  SelectInputComponent,
+  SelectInputOption,
+  TextInputComponent,
+} from '@ui';
+
+const standaloneModel = { standalone: true };
+
+@Component({
+  selector: 'app-admin-item-override-form',
+  imports: [
+    FormsModule,
+    CheckboxInputComponent,
+    LocaleFieldsComponent,
+    SelectInputComponent,
+    TextInputComponent,
+  ],
+  template: `
+    <form class="grid gap-5" (submit)="onSubmit($event)">
+      @if (item(); as currentItem) {
+        <section class="grid gap-2 rounded-md border border-white/10 bg-surface-container p-3">
+          <div class="flex flex-wrap items-start justify-between gap-3">
+            <div class="min-w-0">
+              <p class="ee-label text-outline">Effective</p>
+              <h3 class="truncate font-semibold text-on-surface">
+                {{ currentItem.effective.name || 'Unnamed item' }}
+              </h3>
+            </div>
+            <div class="grid justify-items-end gap-1 ee-data">
+              <p class="text-outline">#{{ currentItem.id }}</p>
+              <a
+                class="font-semibold text-primary-container underline-offset-4 transition hover:underline focus:outline-none focus:ring-2 focus:ring-primary-container"
+                [href]="wowheadUrl(currentItem.id)"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Wowhead
+              </a>
+            </div>
+          </div>
+          <dl class="grid gap-2 ee-data text-outline sm:grid-cols-2">
+            <div>
+              <dt>Base</dt>
+              <dd class="text-on-surface">{{ currentItem.hasBase ? 'Present' : 'Missing' }}</dd>
+            </div>
+            <div>
+              <dt>Override</dt>
+              <dd class="text-on-surface">
+                {{ currentItem.hasOverride ? 'Present' : 'Not set' }}
+              </dd>
+            </div>
+          </dl>
+          <dl class="grid gap-2 ee-data text-outline sm:grid-cols-2">
+            <div>
+              <dt>Quality</dt>
+              <dd class="text-on-surface">{{ referenceLabel(currentItem.effective.quality) }}</dd>
+            </div>
+            <div>
+              <dt>Level</dt>
+              <dd class="text-on-surface">{{ displayValue(currentItem.effective.level) }}</dd>
+            </div>
+            <div>
+              <dt>Class</dt>
+              <dd class="text-on-surface">
+                {{ referenceLabel(currentItem.effective.itemClass) }} /
+                {{ referenceLabel(currentItem.effective.itemSubclass) }}
+              </dd>
+            </div>
+            <div>
+              <dt>Expansion</dt>
+              <dd class="text-on-surface">
+                {{ currentItem.effective.expansion?.name ?? '—' }}
+              </dd>
+            </div>
+            <div>
+              <dt>Inventory</dt>
+              <dd class="text-on-surface">
+                {{ referenceLabel(currentItem.effective.inventoryType) }}
+              </dd>
+            </div>
+            <div>
+              <dt>Binding</dt>
+              <dd class="text-on-surface">{{ referenceLabel(currentItem.effective.binding) }}</dd>
+            </div>
+          </dl>
+        </section>
+
+        <fieldset class="grid gap-4">
+          <legend class="font-semibold text-on-surface">Localized name</legend>
+          <ee-checkbox-input
+            label="Override localized names"
+            [ngModel]="nameOverride()"
+            [ngModelOptions]="standaloneModel"
+            (ngModelChange)="nameOverride.set($event)"
+          />
+          @if (nameOverride()) {
+            <app-locale-fields [value]="nameLocales()" (valueChange)="nameLocales.set($event)" />
+          } @else {
+            <p class="ee-data text-outline">
+              {{ inheritedName(currentItem) }}
+            </p>
+          }
+        </fieldset>
+
+        <fieldset class="grid gap-4">
+          <legend class="font-semibold text-on-surface">Core fields</legend>
+          <div class="grid gap-4 md:grid-cols-2">
+            <ee-checkbox-input
+              label="Override quality"
+              [ngModel]="qualityOverride()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="qualityOverride.set($event)"
+            />
+            <ee-text-input
+              label="Quality type"
+              placeholder="COMMON"
+              [disabled]="!qualityOverride()"
+              [ngModel]="qualityType()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="qualityType.set($event)"
+            />
+            <ee-checkbox-input
+              label="Override level"
+              [ngModel]="levelOverride()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="levelOverride.set($event)"
+            />
+            <ee-text-input
+              label="Level"
+              type="number"
+              [disabled]="!levelOverride()"
+              [ngModel]="level()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="level.set($event)"
+            />
+            <ee-checkbox-input
+              label="Override required level"
+              [ngModel]="requiredLevelOverride()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="requiredLevelOverride.set($event)"
+            />
+            <ee-text-input
+              label="Required level"
+              type="number"
+              [disabled]="!requiredLevelOverride()"
+              [ngModel]="requiredLevel()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="requiredLevel.set($event)"
+            />
+          </div>
+        </fieldset>
+
+        <fieldset class="grid gap-4">
+          <legend class="font-semibold text-on-surface">Classification</legend>
+          <div class="grid gap-4 md:grid-cols-2">
+            <ee-select-input
+              label="Class"
+              [options]="classOptions()"
+              [ngModel]="itemClassId()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="setItemClass($event)"
+            />
+            <ee-select-input
+              label="Subclass"
+              [options]="subclassOptions()"
+              [ngModel]="itemSubclassId()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="itemSubclassId.set($event)"
+            />
+            <ee-select-input
+              label="Inventory type"
+              [options]="inventoryTypeOptions()"
+              [ngModel]="inventoryType()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="inventoryType.set($event)"
+            />
+            <ee-select-input
+              label="Binding type"
+              [options]="bindingTypeOptions()"
+              [ngModel]="bindingType()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="bindingType.set($event)"
+            />
+          </div>
+        </fieldset>
+
+        <fieldset class="grid gap-4">
+          <legend class="font-semibold text-on-surface">Media and economy</legend>
+          <div class="grid gap-4 md:grid-cols-2">
+            <ee-checkbox-input
+              label="Override media URL"
+              [ngModel]="mediaUrlOverride()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="mediaUrlOverride.set($event)"
+            />
+            <ee-text-input
+              label="Media URL"
+              type="url"
+              [disabled]="!mediaUrlOverride()"
+              [ngModel]="mediaUrl()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="mediaUrl.set($event)"
+            />
+            <ee-checkbox-input
+              label="Override media source URL"
+              [ngModel]="mediaSourceUrlOverride()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="mediaSourceUrlOverride.set($event)"
+            />
+            <ee-text-input
+              label="Media source URL"
+              type="url"
+              [disabled]="!mediaSourceUrlOverride()"
+              [ngModel]="mediaSourceUrl()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="mediaSourceUrl.set($event)"
+            />
+            <ee-select-input
+              label="Expansion"
+              [options]="expansionOptions()"
+              [ngModel]="expansionId()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="expansionId.set($event)"
+            />
+            <ee-checkbox-input
+              label="Override purchase price"
+              [ngModel]="purchasePriceOverride()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="purchasePriceOverride.set($event)"
+            />
+            <ee-text-input
+              label="Purchase price"
+              type="number"
+              [disabled]="!purchasePriceOverride()"
+              [ngModel]="purchasePrice()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="purchasePrice.set($event)"
+            />
+            <ee-checkbox-input
+              label="Override sell price"
+              [ngModel]="sellPriceOverride()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="sellPriceOverride.set($event)"
+            />
+            <ee-text-input
+              label="Sell price"
+              type="number"
+              [disabled]="!sellPriceOverride()"
+              [ngModel]="sellPrice()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="sellPrice.set($event)"
+            />
+          </div>
+        </fieldset>
+
+        <fieldset class="grid gap-4">
+          <legend class="font-semibold text-on-surface">Stack and flags</legend>
+          <div class="grid gap-4 md:grid-cols-2">
+            <ee-checkbox-input
+              label="Override max count"
+              [ngModel]="maxCountOverride()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="maxCountOverride.set($event)"
+            />
+            <ee-text-input
+              label="Max count"
+              type="number"
+              [disabled]="!maxCountOverride()"
+              [ngModel]="maxCount()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="maxCount.set($event)"
+            />
+            <ee-checkbox-input
+              label="Override purchase quantity"
+              [ngModel]="purchaseQuantityOverride()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="purchaseQuantityOverride.set($event)"
+            />
+            <ee-text-input
+              label="Purchase quantity"
+              type="number"
+              [disabled]="!purchaseQuantityOverride()"
+              [ngModel]="purchaseQuantity()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="purchaseQuantity.set($event)"
+            />
+            <ee-checkbox-input
+              label="Override equippable"
+              [ngModel]="equippableOverride()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="equippableOverride.set($event)"
+            />
+            <ee-select-input
+              label="Equippable"
+              [disabled]="!equippableOverride()"
+              [options]="booleanOptions"
+              [ngModel]="isEquippable()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="isEquippable.set($event)"
+            />
+            <ee-checkbox-input
+              label="Override stackable"
+              [ngModel]="stackableOverride()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="stackableOverride.set($event)"
+            />
+            <ee-select-input
+              label="Stackable"
+              [disabled]="!stackableOverride()"
+              [options]="booleanOptions"
+              [ngModel]="isStackable()"
+              [ngModelOptions]="standaloneModel"
+              (ngModelChange)="isStackable.set($event)"
+            />
+          </div>
+        </fieldset>
+
+        <ee-text-input
+          label="Override note"
+          [ngModel]="overrideNote()"
+          [ngModelOptions]="standaloneModel"
+          (ngModelChange)="overrideNote.set($event)"
+        />
+
+        @if (validationError()) {
+          <p
+            class="rounded-md border border-error/30 bg-error/10 px-3 py-2 text-sm text-error"
+            role="alert"
+          >
+            {{ validationError() }}
+          </p>
+        }
+        @if (submitError()) {
+          <p
+            class="rounded-md border border-error/30 bg-error/10 px-3 py-2 text-sm text-error"
+            role="alert"
+          >
+            {{ submitError() }}
+          </p>
+        }
+
+        <div class="flex flex-wrap gap-3">
+          <button
+            type="submit"
+            class="h-10 rounded-md bg-primary px-4 font-semibold text-on-primary transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-primary-container disabled:cursor-wait disabled:opacity-70"
+            [disabled]="submitting()"
+          >
+            Save override
+          </button>
+          <button
+            type="button"
+            class="h-10 rounded-md border border-white/10 px-4 font-semibold text-on-surface transition hover:bg-white/5 focus:outline-none focus:ring-2 focus:ring-primary-container"
+            (click)="cancelled.emit()"
+          >
+            Cancel
+          </button>
+        </div>
+      }
+    </form>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AdminItemOverrideFormComponent {
+  protected readonly standaloneModel = standaloneModel;
+  protected readonly booleanOptions = [
+    { id: 'true', label: $localize`:@@common.yes:Yes` },
+    { id: 'false', label: $localize`:@@common.no:No` },
+  ];
+
+  readonly item = input.required<AdminItem1>();
+  readonly expansions = input<readonly AdminExpansion[]>([]);
+  readonly submitting = input(false);
+  readonly submitError = input<string | null>(null);
+  readonly submitted = output<AdminItemOverrideRequest>();
+  readonly cancelled = output<void>();
+
+  protected readonly nameOverride = signal(false);
+  protected readonly nameLocales = signal<GameLocale>({});
+  protected readonly qualityOverride = signal(false);
+  protected readonly qualityType = signal('');
+  protected readonly levelOverride = signal(false);
+  protected readonly level = signal('');
+  protected readonly requiredLevelOverride = signal(false);
+  protected readonly requiredLevel = signal('');
+  protected readonly itemClassId = signal('');
+  protected readonly itemSubclassId = signal('');
+  protected readonly inventoryType = signal('');
+  protected readonly bindingType = signal('');
+  protected readonly mediaUrlOverride = signal(false);
+  protected readonly mediaUrl = signal('');
+  protected readonly mediaSourceUrlOverride = signal(false);
+  protected readonly mediaSourceUrl = signal('');
+  protected readonly purchasePriceOverride = signal(false);
+  protected readonly purchasePrice = signal('');
+  protected readonly sellPriceOverride = signal(false);
+  protected readonly sellPrice = signal('');
+  protected readonly maxCountOverride = signal(false);
+  protected readonly maxCount = signal('');
+  protected readonly equippableOverride = signal(false);
+  protected readonly isEquippable = signal('false');
+  protected readonly stackableOverride = signal(false);
+  protected readonly isStackable = signal('false');
+  protected readonly purchaseQuantityOverride = signal(false);
+  protected readonly purchaseQuantity = signal('');
+  protected readonly expansionId = signal('');
+  protected readonly overrideNote = signal('');
+  protected readonly validationError = signal<string | null>(null);
+  protected readonly classOptions = computed(() =>
+    mergeOptions(
+      ITEM_CLASS_OPTIONS,
+      referencesToOptions(
+        this.item().base?.itemClass,
+        this.item().override?.itemClass,
+        this.item().effective.itemClass,
+      ),
+    ),
+  );
+  protected readonly subclassOptions = computed(() =>
+    mergeOptions(
+      ITEM_SUBCLASS_OPTIONS[this.itemClassId()] ?? [],
+      referencesToOptions(
+        this.item().base?.itemSubclass,
+        this.item().override?.itemSubclass,
+        this.item().effective.itemSubclass,
+      ),
+    ),
+  );
+  protected readonly inventoryTypeOptions = computed(() =>
+    mergeOptions(
+      INVENTORY_TYPE_OPTIONS,
+      referencesToTypeOptions(
+        this.item().base?.inventoryType,
+        this.item().override?.inventoryType,
+        this.item().effective.inventoryType,
+      ),
+    ),
+  );
+  protected readonly bindingTypeOptions = computed(() =>
+    mergeOptions(
+      BINDING_TYPE_OPTIONS,
+      referencesToTypeOptions(
+        this.item().base?.binding,
+        this.item().override?.binding,
+        this.item().effective.binding,
+      ),
+    ),
+  );
+  protected readonly expansionOptions = computed(() =>
+    mergeOptions(
+      this.expansions().map((expansion) => ({
+        id: String(expansion.id),
+        label: expansion.name,
+      })),
+      expansionReferencesToOptions(
+        this.item().base?.expansion,
+        this.item().override?.expansion,
+        this.item().effective.expansion,
+      ),
+    ),
+  );
+
+  constructor() {
+    effect(() => {
+      this.initialize(this.item().override ?? {});
+    });
+  }
+
+  protected inheritedName(item: AdminItem1): string {
+    return item.effective.name ?? $localize`:@@admin.items.unnamed:Unnamed item`;
+  }
+
+  protected referenceLabel(
+    reference: { id: number; type?: string | null; name: string | null } | undefined,
+  ): string {
+    if (!reference) return '—';
+    return reference.name ?? reference.type ?? String(reference.id);
+  }
+
+  protected displayValue(value: number | string | boolean | null | undefined): string {
+    if (value === undefined || value === null || value === '') return '—';
+    return String(value);
+  }
+
+  protected wowheadUrl(itemId: number): string {
+    return `https://www.wowhead.com/item=${itemId}`;
+  }
+
+  protected onSubmit(event: Event): void {
+    event.preventDefault();
+    this.validationError.set(null);
+    const currentItem = this.item();
+
+    const itemClassId = this.parseOptionalInt(this.itemClassId(), 'Class ID');
+    const itemSubclassId = this.parseOptionalInt(this.itemSubclassId(), 'Subclass ID');
+    if (this.validationError()) return;
+    if (itemClassId !== null && itemSubclassId === null) {
+      this.validationError.set(
+        $localize`:@@admin.items.form.classSubclassRequired:Class ID and subclass ID are required together.`,
+      );
+      return;
+    }
+
+    const request: AdminItemOverrideRequest = {
+      nameLocales: this.nameOverride() ? this.nameLocales() : undefined,
+      qualityType: this.stringField(this.qualityOverride(), this.qualityType()),
+      level: this.numberField(this.levelOverride(), this.level(), 'Level'),
+      requiredLevel: this.numberField(
+        this.requiredLevelOverride(),
+        this.requiredLevel(),
+        'Required level',
+      ),
+      mediaUrl: this.stringField(this.mediaUrlOverride(), this.mediaUrl()),
+      mediaSourceUrl: this.stringField(this.mediaSourceUrlOverride(), this.mediaSourceUrl()),
+      itemClassId: this.overrideNumberField(itemClassId, currentItem.base?.itemClass?.id),
+      itemSubclassId: this.overrideNumberField(itemSubclassId, currentItem.base?.itemSubclass?.id),
+      inventoryType: this.overrideStringField(
+        this.inventoryType(),
+        currentItem.base?.inventoryType?.type,
+      ),
+      bindingType: this.overrideStringField(this.bindingType(), currentItem.base?.binding?.type),
+      purchasePrice: this.numberField(
+        this.purchasePriceOverride(),
+        this.purchasePrice(),
+        'Purchase price',
+      ),
+      sellPrice: this.numberField(this.sellPriceOverride(), this.sellPrice(), 'Sell price'),
+      maxCount: this.numberField(this.maxCountOverride(), this.maxCount(), 'Max count'),
+      isEquippable: this.equippableOverride() ? this.isEquippable() === 'true' : null,
+      isStackable: this.stackableOverride() ? this.isStackable() === 'true' : null,
+      purchaseQuantity: this.numberField(
+        this.purchaseQuantityOverride(),
+        this.purchaseQuantity(),
+        'Purchase quantity',
+      ),
+      expansionId: this.overrideNumberField(
+        this.parseOptionalInt(this.expansionId(), 'Expansion ID'),
+        currentItem.base?.expansion?.id,
+      ),
+      overrideNote: this.trimmedOrNull(this.overrideNote()),
+    };
+    if (this.validationError()) return;
+
+    this.submitted.emit(request);
+  }
+
+  private initialize(override: AdminItemFields): void {
+    this.nameOverride.set(Boolean(override.nameLocales));
+    this.nameLocales.set({ ...(override.nameLocales ?? {}) });
+    this.qualityOverride.set(Boolean(override.quality));
+    this.qualityType.set(override.quality?.type ?? '');
+    this.levelOverride.set(override.level !== undefined && override.level !== null);
+    this.level.set(valueString(override.level));
+    this.requiredLevelOverride.set(
+      override.requiredLevel !== undefined && override.requiredLevel !== null,
+    );
+    this.requiredLevel.set(valueString(override.requiredLevel));
+    const item = this.item();
+    this.itemClassId.set(valueString(item.effective.itemClass?.id));
+    this.itemSubclassId.set(valueString(item.effective.itemSubclass?.id));
+    this.inventoryType.set(item.effective.inventoryType?.type ?? '');
+    this.bindingType.set(item.effective.binding?.type ?? '');
+    this.mediaUrlOverride.set(override.mediaUrl !== undefined && override.mediaUrl !== null);
+    this.mediaUrl.set(override.mediaUrl ?? '');
+    this.mediaSourceUrlOverride.set(
+      override.mediaSourceUrl !== undefined && override.mediaSourceUrl !== null,
+    );
+    this.mediaSourceUrl.set(override.mediaSourceUrl ?? '');
+    this.purchasePriceOverride.set(
+      override.purchasePrice !== undefined && override.purchasePrice !== null,
+    );
+    this.purchasePrice.set(valueString(override.purchasePrice));
+    this.sellPriceOverride.set(override.sellPrice !== undefined && override.sellPrice !== null);
+    this.sellPrice.set(valueString(override.sellPrice));
+    this.maxCountOverride.set(override.maxCount !== undefined && override.maxCount !== null);
+    this.maxCount.set(valueString(override.maxCount));
+    this.equippableOverride.set(
+      override.isEquippable !== undefined && override.isEquippable !== null,
+    );
+    this.isEquippable.set(String(override.isEquippable === true));
+    this.stackableOverride.set(override.isStackable !== undefined && override.isStackable !== null);
+    this.isStackable.set(String(override.isStackable === true));
+    this.purchaseQuantityOverride.set(
+      override.purchaseQuantity !== undefined && override.purchaseQuantity !== null,
+    );
+    this.purchaseQuantity.set(valueString(override.purchaseQuantity));
+    this.expansionId.set(valueString(item.effective.expansion?.id));
+    this.overrideNote.set(override.overrideNote ?? '');
+    this.validationError.set(null);
+  }
+
+  protected setItemClass(value: string): void {
+    this.itemClassId.set(value);
+    const selectedSubclass = this.itemSubclassId();
+    const options = ITEM_SUBCLASS_OPTIONS[value] ?? [];
+    if (selectedSubclass && options.some((option) => option.id === selectedSubclass)) return;
+
+    const defaultSubclassId = valueString(this.item().base?.itemSubclass?.id);
+    this.itemSubclassId.set(
+      options.some((option) => option.id === defaultSubclassId) ? defaultSubclassId : '',
+    );
+  }
+
+  private stringField(enabled: boolean, value: string): string | null {
+    if (!enabled) return null;
+    return this.trimmedOrNull(value);
+  }
+
+  private numberField(enabled: boolean, value: string, label: string): number | null {
+    if (!enabled) return null;
+    return this.parseOptionalInt(value, label);
+  }
+
+  private overrideStringField(value: string, baseValue: string | null | undefined): string | null {
+    const selected = this.trimmedOrNull(value);
+    return selected === (baseValue ?? null) ? null : selected;
+  }
+
+  private overrideNumberField(
+    value: number | null,
+    baseValue: number | null | undefined,
+  ): number | null {
+    return value === (baseValue ?? null) ? null : value;
+  }
+
+  private parseOptionalInt(value: string, label: string): number | null {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return null;
+    const parsed = Number.parseInt(trimmed, 10);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      this.validationError.set(`${label} must be a non-negative number.`);
+      return null;
+    }
+    return parsed;
+  }
+
+  private trimmedOrNull(value: string): string | null {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+}
+
+function valueString(value: number | null | undefined): string {
+  return value === undefined || value === null ? '' : String(value);
+}
+
+function option(id: string | number, label: string): SelectInputOption {
+  return { id: String(id), label };
+}
+
+function mergeOptions(
+  primary: readonly SelectInputOption[],
+  secondary: readonly SelectInputOption[],
+): SelectInputOption[] {
+  const seen = new Set<string>();
+  return [...primary, ...secondary].filter((item) => {
+    if (seen.has(item.id)) return false;
+    seen.add(item.id);
+    return true;
+  });
+}
+
+function referencesToOptions(
+  ...references: Array<{ id: number; name: string | null } | undefined>
+): SelectInputOption[] {
+  return references
+    .filter((reference): reference is { id: number; name: string | null } => Boolean(reference))
+    .map((reference) => option(reference.id, reference.name ?? String(reference.id)));
+}
+
+function referencesToTypeOptions(
+  ...references: Array<{ type?: string | null; name: string | null } | undefined>
+): SelectInputOption[] {
+  return references
+    .filter((reference): reference is { type: string; name: string | null } =>
+      Boolean(reference?.type),
+    )
+    .map((reference) => option(reference.type, reference.name ?? reference.type));
+}
+
+function expansionReferencesToOptions(
+  ...expansions: Array<{ id: number; name: string } | undefined>
+): SelectInputOption[] {
+  return expansions
+    .filter((expansion): expansion is { id: number; name: string } => Boolean(expansion))
+    .map((expansion) => option(expansion.id, expansion.name));
+}
+
+const ITEM_CLASS_OPTIONS: readonly SelectInputOption[] = [
+  option(0, 'Consumable'),
+  option(1, 'Container'),
+  option(2, 'Weapon'),
+  option(3, 'Gem'),
+  option(4, 'Armor'),
+  option(5, 'Reagent'),
+  option(6, 'Projectile'),
+  option(7, 'Tradeskill'),
+  option(9, 'Recipe'),
+  option(11, 'Quiver'),
+  option(12, 'Quest'),
+  option(13, 'Key'),
+  option(15, 'Miscellaneous'),
+  option(16, 'Glyph'),
+  option(17, 'Battle Pets'),
+  option(19, 'WoW Token'),
+];
+
+const ITEM_SUBCLASS_OPTIONS: Record<string, readonly SelectInputOption[]> = {
+  '0': [
+    option(0, 'Consumable'),
+    option(1, 'Potion'),
+    option(2, 'Elixir'),
+    option(3, 'Flask'),
+    option(4, 'Scroll'),
+    option(5, 'Food & Drink'),
+    option(6, 'Item Enhancement'),
+    option(7, 'Bandage'),
+    option(8, 'Other'),
+    option(9, 'Vantus Rune'),
+  ],
+  '1': [
+    option(0, 'Bag'),
+    option(1, 'Soul Bag'),
+    option(2, 'Herb Bag'),
+    option(3, 'Enchanting Bag'),
+    option(4, 'Engineering Bag'),
+    option(5, 'Gem Bag'),
+    option(6, 'Mining Bag'),
+    option(7, 'Leatherworking Bag'),
+    option(8, 'Inscription Bag'),
+    option(9, 'Tackle Box'),
+    option(10, 'Cooking Bag'),
+  ],
+  '2': [
+    option(0, 'One-Handed Axe'),
+    option(1, 'Two-Handed Axe'),
+    option(2, 'Bow'),
+    option(3, 'Gun'),
+    option(4, 'One-Handed Mace'),
+    option(5, 'Two-Handed Mace'),
+    option(6, 'Polearm'),
+    option(7, 'One-Handed Sword'),
+    option(8, 'Two-Handed Sword'),
+    option(10, 'Staff'),
+    option(13, 'Fist Weapon'),
+    option(14, 'Miscellaneous'),
+    option(15, 'Dagger'),
+    option(16, 'Thrown'),
+    option(18, 'Crossbow'),
+    option(19, 'Wand'),
+    option(20, 'Fishing Pole'),
+  ],
+  '3': [
+    option(0, 'Intellect'),
+    option(1, 'Agility'),
+    option(2, 'Strength'),
+    option(3, 'Stamina'),
+    option(4, 'Spirit'),
+    option(5, 'Critical Strike'),
+    option(6, 'Mastery'),
+    option(7, 'Haste'),
+    option(8, 'Versatility'),
+    option(9, 'Other'),
+    option(10, 'Multiple Stats'),
+    option(11, 'Artifact Relic'),
+  ],
+  '4': [
+    option(0, 'Miscellaneous'),
+    option(1, 'Cloth'),
+    option(2, 'Leather'),
+    option(3, 'Mail'),
+    option(4, 'Plate'),
+    option(6, 'Shield'),
+    option(7, 'Libram'),
+    option(8, 'Idol'),
+    option(9, 'Totem'),
+    option(10, 'Sigil'),
+    option(11, 'Relic'),
+  ],
+  '5': [option(0, 'Reagent')],
+  '7': [
+    option(1, 'Parts'),
+    option(2, 'Explosives'),
+    option(3, 'Devices'),
+    option(4, 'Jewelcrafting'),
+    option(5, 'Cloth'),
+    option(6, 'Leather'),
+    option(7, 'Metal & Stone'),
+    option(8, 'Cooking'),
+    option(9, 'Herb'),
+    option(10, 'Elemental'),
+    option(11, 'Other'),
+    option(12, 'Enchanting'),
+    option(16, 'Inscription'),
+    option(18, 'Optional Reagents'),
+    option(19, 'Finishing Reagents'),
+  ],
+  '9': [
+    option(0, 'Book'),
+    option(1, 'Leatherworking'),
+    option(2, 'Tailoring'),
+    option(3, 'Engineering'),
+    option(4, 'Blacksmithing'),
+    option(5, 'Cooking'),
+    option(6, 'Alchemy'),
+    option(7, 'First Aid'),
+    option(8, 'Enchanting'),
+    option(9, 'Fishing'),
+    option(10, 'Jewelcrafting'),
+    option(11, 'Inscription'),
+  ],
+  '12': [option(0, 'Quest')],
+  '15': [
+    option(0, 'Junk'),
+    option(1, 'Reagent'),
+    option(2, 'Companion Pets'),
+    option(3, 'Holiday'),
+    option(4, 'Other'),
+    option(5, 'Mount'),
+  ],
+  '16': [
+    option(1, 'Warrior'),
+    option(2, 'Paladin'),
+    option(3, 'Hunter'),
+    option(4, 'Rogue'),
+    option(5, 'Priest'),
+    option(6, 'Death Knight'),
+    option(7, 'Shaman'),
+    option(8, 'Mage'),
+    option(9, 'Warlock'),
+    option(10, 'Monk'),
+    option(11, 'Druid'),
+    option(12, 'Demon Hunter'),
+  ],
+  '17': [
+    option(0, 'Humanoid'),
+    option(1, 'Dragonkin'),
+    option(2, 'Flying'),
+    option(3, 'Undead'),
+    option(4, 'Critter'),
+    option(5, 'Magic'),
+    option(6, 'Elemental'),
+    option(7, 'Beast'),
+    option(8, 'Aquatic'),
+    option(9, 'Mechanical'),
+  ],
+};
+
+const INVENTORY_TYPE_OPTIONS: readonly SelectInputOption[] = [
+  option('NON_EQUIP', 'Non-equippable'),
+  option('HEAD', 'Head'),
+  option('NECK', 'Neck'),
+  option('SHOULDER', 'Shoulder'),
+  option('BODY', 'Shirt'),
+  option('CHEST', 'Chest'),
+  option('WAIST', 'Waist'),
+  option('LEGS', 'Legs'),
+  option('FEET', 'Feet'),
+  option('WRIST', 'Wrist'),
+  option('HAND', 'Hands'),
+  option('FINGER', 'Finger'),
+  option('TRINKET', 'Trinket'),
+  option('WEAPON', 'One-hand'),
+  option('SHIELD', 'Off-hand shield'),
+  option('RANGED', 'Ranged'),
+  option('CLOAK', 'Back'),
+  option('TWOHWEAPON', 'Two-hand'),
+  option('BAG', 'Bag'),
+  option('TABARD', 'Tabard'),
+  option('ROBE', 'Robe'),
+  option('WEAPONMAINHAND', 'Main hand'),
+  option('WEAPONOFFHAND', 'Off hand'),
+  option('HOLDABLE', 'Held in off-hand'),
+  option('AMMO', 'Ammo'),
+  option('THROWN', 'Thrown'),
+  option('RANGEDRIGHT', 'Ranged right'),
+  option('QUIVER', 'Quiver'),
+  option('RELIC', 'Relic'),
+];
+
+const BINDING_TYPE_OPTIONS: readonly SelectInputOption[] = [
+  option('NONE', 'Not bound'),
+  option('ON_ACQUIRE', 'Binds when picked up'),
+  option('ON_EQUIP', 'Binds when equipped'),
+  option('ON_USE', 'Binds when used'),
+  option('QUEST', 'Quest item'),
+  option('ACCOUNT', 'Account bound'),
+  option('BNET_ACCOUNT', 'Battle.net account bound'),
+];

--- a/frontend/src/app/features/admin/items/admin-item-override-form.component.ts
+++ b/frontend/src/app/features/admin/items/admin-item-override-form.component.ts
@@ -704,7 +704,7 @@ function expansionReferencesToOptions(
     .map((expansion) => option(expansion.id, expansion.name));
 }
 
-const ITEM_CLASS_OPTIONS: readonly SelectInputOption[] = [
+export const ITEM_CLASS_OPTIONS: readonly SelectInputOption[] = [
   option(0, 'Consumable'),
   option(1, 'Container'),
   option(2, 'Weapon'),
@@ -723,7 +723,7 @@ const ITEM_CLASS_OPTIONS: readonly SelectInputOption[] = [
   option(19, 'WoW Token'),
 ];
 
-const ITEM_SUBCLASS_OPTIONS: Record<string, readonly SelectInputOption[]> = {
+export const ITEM_SUBCLASS_OPTIONS: Record<string, readonly SelectInputOption[]> = {
   '0': [
     option(0, 'Consumable'),
     option(1, 'Potion'),

--- a/frontend/src/app/features/admin/items/admin-item-quality-cell.component.ts
+++ b/frontend/src/app/features/admin/items/admin-item-quality-cell.component.ts
@@ -1,0 +1,38 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { AdminItem1 } from '@api/generated';
+import { injectFlexRenderContext } from '@tanstack/angular-table';
+import type { CellContext } from '@tanstack/table-core';
+import { ItemQuality, QualityBadgeComponent } from '@ui';
+
+const supportedQualities = new Set<ItemQuality>([
+  'common',
+  'uncommon',
+  'rare',
+  'epic',
+  'legendary',
+]);
+
+@Component({
+  selector: 'app-admin-item-quality-cell',
+  imports: [QualityBadgeComponent],
+  template: `
+    @if (quality(); as qualityValue) {
+      <ee-quality-badge [quality]="qualityValue" />
+    } @else {
+      <span class="text-outline">—</span>
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AdminItemQualityCellComponent {
+  private readonly ctx = injectFlexRenderContext<CellContext<AdminItem1, unknown>>();
+
+  protected quality(): ItemQuality | null {
+    const raw =
+      this.ctx.row.original.effective.quality?.type ??
+      this.ctx.row.original.effective.quality?.name ??
+      '';
+    const normalized = raw.toLowerCase();
+    return supportedQualities.has(normalized as ItemQuality) ? (normalized as ItemQuality) : null;
+  }
+}

--- a/frontend/src/app/features/admin/items/admin-item-recipe-association-panel.component.ts
+++ b/frontend/src/app/features/admin/items/admin-item-recipe-association-panel.component.ts
@@ -1,0 +1,190 @@
+import { ChangeDetectionStrategy, Component, input, output, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { AdminItem1, AdminRecipeAssociationRequest, AdminRecipeSearchResult } from '@api/generated';
+import { SearchInputComponent, TextInputComponent } from '@ui';
+
+const standaloneModel = { standalone: true };
+
+@Component({
+  selector: 'app-admin-item-recipe-association-panel',
+  imports: [FormsModule, SearchInputComponent, TextInputComponent],
+  template: `
+    <div class="grid gap-5">
+      @if (item(); as currentItem) {
+        <section class="grid gap-2 rounded-md border border-white/10 bg-surface-container p-3">
+          <div class="flex flex-wrap items-start justify-between gap-3">
+            <div class="min-w-0">
+              <p class="ee-label text-outline">Crafted item</p>
+              <h3 class="truncate font-semibold text-on-surface">
+                {{ currentItem.effective.name || 'Unnamed item' }}
+              </h3>
+            </div>
+            <p class="ee-data text-outline">#{{ currentItem.id }}</p>
+          </div>
+          @if ((currentItem.effective.recipes ?? []).length > 0) {
+            <div class="grid gap-2">
+              @for (recipe of currentItem.effective.recipes ?? []; track recipe.recipeId) {
+                <div
+                  class="flex flex-wrap items-center justify-between gap-2 rounded-md border border-white/10 bg-surface-container-highest px-3 py-2"
+                >
+                  <div class="min-w-0">
+                    <p class="truncate text-sm font-semibold text-on-surface">{{ recipe.name }}</p>
+                    <p class="ee-data text-outline">{{ recipe.professionName }}</p>
+                  </div>
+                  <button
+                    type="button"
+                    class="rounded-md border border-white/10 px-3 py-2 text-sm font-semibold text-on-surface transition hover:bg-white/5 focus:outline-none focus:ring-2 focus:ring-primary-container disabled:cursor-wait disabled:opacity-60"
+                    [disabled]="submitting()"
+                    (click)="clearRecipe(recipe.recipeId)"
+                  >
+                    Clear
+                  </button>
+                </div>
+              }
+            </div>
+          } @else {
+            <p class="ee-data text-outline">No recipes are associated with this item.</p>
+          }
+        </section>
+
+        <form class="grid gap-4" (submit)="submit($event)">
+          @if (submitError()) {
+            <p
+              class="rounded-md border border-error/30 bg-error/10 px-3 py-2 text-sm text-error"
+              role="alert"
+            >
+              {{ submitError() }}
+            </p>
+          }
+
+          <ee-search-input
+            label="Recipe"
+            [showLabel]="true"
+            placeholder="Search by recipe name or ID"
+            [ngModel]="query()"
+            [ngModelOptions]="standaloneModel"
+            (ngModelChange)="setQuery($event)"
+          />
+
+          @if (searching()) {
+            <p class="ee-data text-outline" role="status">Searching recipes...</p>
+          } @else if (results().length > 0) {
+            <div class="grid max-h-80 gap-2 overflow-auto pr-1" role="listbox" aria-label="Recipes">
+              @for (recipe of results(); track recipe.recipeId) {
+                <button
+                  type="button"
+                  class="grid gap-1 rounded-md border px-3 py-2 text-left transition focus:outline-none focus:ring-2 focus:ring-primary-container"
+                  [class.border-primary]="selectedRecipe()?.recipeId === recipe.recipeId"
+                  [class.bg-primary-container]="selectedRecipe()?.recipeId === recipe.recipeId"
+                  [class.text-on-primary-container]="selectedRecipe()?.recipeId === recipe.recipeId"
+                  [class.border-white\\/10]="selectedRecipe()?.recipeId !== recipe.recipeId"
+                  [class.bg-surface-container]="selectedRecipe()?.recipeId !== recipe.recipeId"
+                  (click)="selectRecipe(recipe)"
+                >
+                  <span class="text-sm font-semibold">{{ recipe.name }}</span>
+                  <span class="ee-data">
+                    {{ recipe.professionName }} · {{ recipe.skillTierName }} ·
+                    {{ recipe.professionCategoryName }}
+                  </span>
+                  <span
+                    class="ee-data"
+                    [class.text-outline]="selectedRecipe()?.recipeId !== recipe.recipeId"
+                  >
+                    @if (recipe.craftedItemId) {
+                      Associated with #{{ recipe.craftedItemId }}
+                      {{ recipe.craftedItemName || '' }}
+                      @if (recipe.craftedQuantity) {
+                        · qty {{ recipe.craftedQuantity }}
+                      }
+                    } @else {
+                      Not associated with a crafted item
+                    }
+                  </span>
+                </button>
+              }
+            </div>
+          } @else if (query().trim().length >= 2) {
+            <p class="ee-data text-outline">No recipes match this search.</p>
+          }
+
+          <ee-text-input
+            label="Crafted quantity"
+            type="number"
+            [disabled]="!selectedRecipe() || submitting()"
+            [ngModel]="craftedQuantity()"
+            [ngModelOptions]="standaloneModel"
+            (ngModelChange)="craftedQuantity.set($event)"
+          />
+
+          <div class="flex flex-wrap justify-end gap-2">
+            <button
+              type="button"
+              class="rounded-md border border-white/10 px-4 py-2 font-semibold text-on-surface transition hover:bg-white/5 focus:outline-none focus:ring-2 focus:ring-primary-container"
+              (click)="cancelled.emit()"
+            >
+              Close
+            </button>
+            <button
+              type="submit"
+              class="rounded-md bg-primary px-4 py-2 font-semibold text-on-primary transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-primary-container disabled:cursor-wait disabled:opacity-70"
+              [disabled]="!selectedRecipe() || submitting()"
+            >
+              Associate recipe
+            </button>
+          </div>
+        </form>
+      }
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AdminItemRecipeAssociationPanelComponent {
+  readonly item = input.required<AdminItem1>();
+  readonly results = input<readonly AdminRecipeSearchResult[]>([]);
+  readonly searching = input(false);
+  readonly submitting = input(false);
+  readonly submitError = input<string | null>(null);
+  readonly search = output<string>();
+  readonly submitted = output<{ recipeId: number; request: AdminRecipeAssociationRequest }>();
+  readonly cancelled = output<void>();
+
+  protected readonly query = signal('');
+  protected readonly selectedRecipe = signal<AdminRecipeSearchResult | null>(null);
+  protected readonly craftedQuantity = signal('1');
+  protected readonly standaloneModel = standaloneModel;
+
+  protected setQuery(value: string): void {
+    this.query.set(value);
+    this.selectedRecipe.set(null);
+    this.search.emit(value);
+  }
+
+  protected selectRecipe(recipe: AdminRecipeSearchResult): void {
+    this.selectedRecipe.set(recipe);
+    this.craftedQuantity.set(String(recipe.craftedQuantity ?? 1));
+  }
+
+  protected clearRecipe(recipeId: number): void {
+    this.submitted.emit({
+      recipeId,
+      request: {
+        craftedItemId: null,
+        craftedQuantity: null,
+      },
+    });
+  }
+
+  protected submit(event: Event): void {
+    event.preventDefault();
+    const recipe = this.selectedRecipe();
+    if (!recipe) return;
+    const quantity = Number.parseInt(this.craftedQuantity(), 10);
+    this.submitted.emit({
+      recipeId: recipe.recipeId,
+      request: {
+        craftedItemId: this.item().id,
+        craftedQuantity: Number.isFinite(quantity) ? quantity : 1,
+      },
+    });
+  }
+}

--- a/frontend/src/app/features/admin/items/admin-item-state-cell.component.ts
+++ b/frontend/src/app/features/admin/items/admin-item-state-cell.component.ts
@@ -1,0 +1,31 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { AdminItem1 } from '@api/generated';
+import { injectFlexRenderContext } from '@tanstack/angular-table';
+import type { CellContext } from '@tanstack/table-core';
+import { BadgeComponent } from '@ui';
+
+@Component({
+  selector: 'app-admin-item-state-cell',
+  imports: [BadgeComponent],
+  template: `
+    <div class="flex flex-wrap gap-2">
+      @if (item().hasBase) {
+        <ee-badge quality="common">Base</ee-badge>
+      }
+      @if (item().hasOverride) {
+        <ee-badge quality="rare">Override</ee-badge>
+      }
+      @if (!item().hasBase && item().hasOverride) {
+        <ee-badge quality="epic">Manual</ee-badge>
+      }
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AdminItemStateCellComponent {
+  private readonly ctx = injectFlexRenderContext<CellContext<AdminItem1, unknown>>();
+
+  protected item(): AdminItem1 {
+    return this.ctx.row.original;
+  }
+}

--- a/frontend/src/app/features/admin/items/admin-item.service.spec.ts
+++ b/frontend/src/app/features/admin/items/admin-item.service.spec.ts
@@ -107,6 +107,8 @@ describe('AdminItemService', () => {
       true,
       undefined,
       undefined,
+      undefined,
+      undefined,
       1,
       25,
     );

--- a/frontend/src/app/features/admin/items/admin-item.service.spec.ts
+++ b/frontend/src/app/features/admin/items/admin-item.service.spec.ts
@@ -1,0 +1,122 @@
+import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import {
+  AdminApiService,
+  AdminItem1,
+  AdminItemOverrideRequest,
+  AdminItemPage,
+} from '@api/generated';
+import { LocaleService } from '@core/services/locale.service';
+import { ToastService } from '@core/services/toast.service';
+import { defaultAdminItemFilters } from './item-filters';
+import { AdminItemService } from './admin-item.service';
+
+const itemFixture: AdminItem1 = {
+  id: 19019,
+  hasBase: true,
+  hasOverride: true,
+  effective: {
+    name: 'Thunderfury',
+    quality: { id: 5, type: 'LEGENDARY', name: 'Legendary' },
+  },
+  base: {
+    name: 'Thunderfury',
+  },
+  override: {
+    level: 80,
+    itemClass: { id: 2, name: 'Weapon' },
+    itemSubclass: { id: 7, name: 'Sword' },
+    overrideNote: 'test',
+  },
+};
+
+const pageFixture: AdminItemPage = {
+  items: [itemFixture],
+  page: {
+    page: 1,
+    pageSize: 25,
+    totalItems: 1,
+    totalPages: 1,
+  },
+};
+
+describe('AdminItemService', () => {
+  let service: AdminItemService;
+  let api: {
+    searchAdminItems: ReturnType<typeof vitest.fn>;
+    getAdminItem: ReturnType<typeof vitest.fn>;
+    upsertAdminItemOverride: ReturnType<typeof vitest.fn>;
+    deleteAdminItemOverride: ReturnType<typeof vitest.fn>;
+    createAdminItem: ReturnType<typeof vitest.fn>;
+    compareAdminItemWithApi: ReturnType<typeof vitest.fn>;
+  };
+  let toast: { error: ReturnType<typeof vitest.fn> };
+
+  beforeEach(() => {
+    api = {
+      searchAdminItems: vitest.fn().mockReturnValue(of(pageFixture)),
+      getAdminItem: vitest.fn().mockReturnValue(of(itemFixture)),
+      upsertAdminItemOverride: vitest.fn().mockReturnValue(of(itemFixture)),
+      deleteAdminItemOverride: vitest.fn().mockReturnValue(of(undefined)),
+      createAdminItem: vitest.fn().mockReturnValue(of(itemFixture)),
+      compareAdminItemWithApi: vitest.fn().mockReturnValue(of({ itemId: 19019, fields: {} })),
+    };
+    toast = { error: vitest.fn() };
+
+    TestBed.configureTestingModule({
+      providers: [
+        AdminItemService,
+        { provide: AdminApiService, useValue: api },
+        { provide: ToastService, useValue: toast },
+        { provide: LocaleService, useValue: { apiLocaleOverride: () => 'en_US' } },
+      ],
+    });
+    service = TestBed.inject(AdminItemService);
+  });
+
+  it('searches items with generated API parameters', () => {
+    service
+      .search({
+        ...defaultAdminItemFilters(),
+        name: 'thunder',
+        hasOverride: 'true',
+      })
+      .subscribe();
+
+    expect(api.searchAdminItems).toHaveBeenCalledWith('thunder', 'en_US', undefined, true, 1, 25);
+    expect(service.items()).toEqual([itemFixture]);
+    expect(service.page()).toEqual(pageFixture.page);
+  });
+
+  it('loads item details with base and override rows', () => {
+    service.loadItem(19019).subscribe();
+
+    expect(api.getAdminItem).toHaveBeenCalledWith(19019, 'en_US', true, true);
+    expect(service.selectedItem()).toEqual(itemFixture);
+  });
+
+  it('submits the provided full sparse override state on save', () => {
+    const request: AdminItemOverrideRequest = {
+      level: 80,
+      requiredLevel: null,
+      itemClassId: 2,
+      itemSubclassId: 7,
+      overrideNote: 'test',
+    };
+
+    service.upsertOverride(19019, request, defaultAdminItemFilters()).subscribe();
+
+    expect(api.upsertAdminItemOverride).toHaveBeenCalledWith(19019, request);
+    expect(api.searchAdminItems).toHaveBeenCalledOnce();
+    expect(api.getAdminItem).toHaveBeenCalledWith(19019, 'en_US', true, true);
+  });
+
+  it('stores and reports search errors', () => {
+    api.searchAdminItems.mockReturnValue(throwError(() => new Error('network')));
+
+    service.search(defaultAdminItemFilters()).subscribe({ error: () => undefined });
+
+    expect(service.error()).toBe('Unable to load items.');
+    expect(toast.error).toHaveBeenCalledWith('Unable to load items.');
+  });
+});

--- a/frontend/src/app/features/admin/items/admin-item.service.spec.ts
+++ b/frontend/src/app/features/admin/items/admin-item.service.spec.ts
@@ -100,7 +100,16 @@ describe('AdminItemService', () => {
       })
       .subscribe();
 
-    expect(api.searchAdminItems).toHaveBeenCalledWith('thunder', 'en_US', undefined, true, 1, 25);
+    expect(api.searchAdminItems).toHaveBeenCalledWith(
+      'thunder',
+      'en_US',
+      undefined,
+      true,
+      undefined,
+      undefined,
+      1,
+      25,
+    );
     expect(service.items()).toEqual([itemFixture]);
     expect(service.page()).toEqual(pageFixture.page);
   });

--- a/frontend/src/app/features/admin/items/admin-item.service.spec.ts
+++ b/frontend/src/app/features/admin/items/admin-item.service.spec.ts
@@ -47,6 +47,8 @@ describe('AdminItemService', () => {
     getAdminItem: ReturnType<typeof vitest.fn>;
     upsertAdminItemOverride: ReturnType<typeof vitest.fn>;
     deleteAdminItemOverride: ReturnType<typeof vitest.fn>;
+    searchAdminRecipes: ReturnType<typeof vitest.fn>;
+    upsertAdminItemRecipeAssociation: ReturnType<typeof vitest.fn>;
     createAdminItem: ReturnType<typeof vitest.fn>;
     compareAdminItemWithApi: ReturnType<typeof vitest.fn>;
   };
@@ -58,6 +60,21 @@ describe('AdminItemService', () => {
       getAdminItem: vitest.fn().mockReturnValue(of(itemFixture)),
       upsertAdminItemOverride: vitest.fn().mockReturnValue(of(itemFixture)),
       deleteAdminItemOverride: vitest.fn().mockReturnValue(of(undefined)),
+      searchAdminRecipes: vitest.fn().mockReturnValue(
+        of([
+          {
+            recipeId: 338995,
+            name: 'Craft Thunderfury',
+            professionName: 'Blacksmithing',
+            skillTierName: 'Classic',
+            professionCategoryName: 'Weapons',
+            craftedItemId: null,
+            craftedItemName: null,
+            craftedQuantity: null,
+          },
+        ]),
+      ),
+      upsertAdminItemRecipeAssociation: vitest.fn().mockReturnValue(of(itemFixture)),
       createAdminItem: vitest.fn().mockReturnValue(of(itemFixture)),
       compareAdminItemWithApi: vitest.fn().mockReturnValue(of({ itemId: 19019, fields: {} })),
     };
@@ -107,6 +124,22 @@ describe('AdminItemService', () => {
     service.upsertOverride(19019, request, defaultAdminItemFilters()).subscribe();
 
     expect(api.upsertAdminItemOverride).toHaveBeenCalledWith(19019, request);
+    expect(api.searchAdminItems).toHaveBeenCalledOnce();
+    expect(api.getAdminItem).toHaveBeenCalledWith(19019, 'en_US', true, true);
+  });
+
+  it('searches recipes with locale and limit', () => {
+    service.searchRecipes('craft thunder', 10).subscribe();
+
+    expect(api.searchAdminRecipes).toHaveBeenCalledWith('craft thunder', 'en_US', 10);
+  });
+
+  it('associates a recipe and reloads the item', () => {
+    const request = { craftedItemId: 19019, craftedQuantity: 2 };
+
+    service.upsertRecipeAssociation(19019, 338995, request, defaultAdminItemFilters()).subscribe();
+
+    expect(api.upsertAdminItemRecipeAssociation).toHaveBeenCalledWith(19019, 338995, request);
     expect(api.searchAdminItems).toHaveBeenCalledOnce();
     expect(api.getAdminItem).toHaveBeenCalledWith(19019, 'en_US', true, true);
   });

--- a/frontend/src/app/features/admin/items/admin-item.service.ts
+++ b/frontend/src/app/features/admin/items/admin-item.service.ts
@@ -6,6 +6,8 @@ import {
   AdminItemCompareResponse,
   AdminItemCreateRequest,
   AdminItemOverrideRequest,
+  AdminRecipeAssociationRequest,
+  AdminRecipeSearchResult,
   PageMetadata,
 } from '@api/generated';
 import { LocaleService } from '@core/services/locale.service';
@@ -120,6 +122,33 @@ export class AdminItemService {
       switchMap(() => this.loadItem(id)),
       map(() => undefined),
     );
+  }
+
+  searchRecipes(query: string, limit = 20): Observable<readonly AdminRecipeSearchResult[]> {
+    const locale = this.localeService.apiLocaleOverride();
+    return this.api.searchAdminRecipes(query, locale, limit).pipe(
+      catchError((error: unknown) => {
+        this.toast.error(
+          readHttpErrorMessage(
+            error,
+            $localize`:@@admin.items.recipeSearchError:Unable to search recipes.`,
+          ),
+        );
+        return throwError(() => error);
+      }),
+    );
+  }
+
+  upsertRecipeAssociation(
+    id: number,
+    recipeId: number,
+    request: AdminRecipeAssociationRequest,
+    filters: AdminItemFilterState,
+  ): Observable<AdminItem1> {
+    return this.mutate(
+      () => this.api.upsertAdminItemRecipeAssociation(id, recipeId, request),
+      filters,
+    ).pipe(switchMap(() => this.loadItem(id)));
   }
 
   compareWithApi(id: number): Observable<AdminItemCompareResponse> {

--- a/frontend/src/app/features/admin/items/admin-item.service.ts
+++ b/frontend/src/app/features/admin/items/admin-item.service.ts
@@ -56,6 +56,8 @@ export class AdminItemService {
         params.hasOverride,
         params.itemClassId,
         params.itemSubclassId,
+        params.expansionId,
+        params.hasRecipe,
         params.page,
         params.pageSize,
       )

--- a/frontend/src/app/features/admin/items/admin-item.service.ts
+++ b/frontend/src/app/features/admin/items/admin-item.service.ts
@@ -1,0 +1,188 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { inject, Injectable, signal } from '@angular/core';
+import {
+  AdminApiService,
+  AdminItem1,
+  AdminItemCompareResponse,
+  AdminItemCreateRequest,
+  AdminItemOverrideRequest,
+  PageMetadata,
+} from '@api/generated';
+import { LocaleService } from '@core/services/locale.service';
+import { ToastService } from '@core/services/toast.service';
+import { AdminItemFilterState, toAdminItemSearchParams } from './item-filters';
+import { catchError, finalize, map, Observable, switchMap, tap, throwError } from 'rxjs';
+
+const EMPTY_PAGE: PageMetadata = {
+  page: 1,
+  pageSize: 25,
+  totalItems: 0,
+  totalPages: 1,
+};
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AdminItemService {
+  readonly loading = signal(false);
+  readonly mutationLoading = signal(false);
+  readonly detailLoading = signal(false);
+  readonly compareLoading = signal(false);
+  readonly items = signal<readonly AdminItem1[]>([]);
+  readonly page = signal<PageMetadata>(EMPTY_PAGE);
+  readonly selectedItem = signal<AdminItem1 | null>(null);
+  readonly compare = signal<AdminItemCompareResponse | null>(null);
+  readonly error = signal<string | null>(null);
+  readonly detailError = signal<string | null>(null);
+  readonly compareError = signal<string | null>(null);
+
+  private readonly api = inject(AdminApiService);
+  private readonly localeService = inject(LocaleService);
+  private readonly toast = inject(ToastService);
+
+  search(filters: AdminItemFilterState): Observable<readonly AdminItem1[]> {
+    this.loading.set(true);
+    this.error.set(null);
+    const params = toAdminItemSearchParams(filters);
+    const locale = this.localeService.apiLocaleOverride();
+
+    return this.api
+      .searchAdminItems(
+        params.query,
+        locale,
+        undefined,
+        params.hasOverride,
+        params.page,
+        params.pageSize,
+      )
+      .pipe(
+        tap({
+          next: (result) => {
+            this.items.set(result.items);
+            this.page.set(result.page);
+          },
+          error: (error: unknown) => {
+            const message = readHttpErrorMessage(
+              error,
+              $localize`:@@admin.items.loadError:Unable to load items.`,
+            );
+            this.error.set(message);
+            this.toast.error(message);
+          },
+        }),
+        map((result) => result.items),
+        finalize(() => this.loading.set(false)),
+      );
+  }
+
+  loadItem(id: number): Observable<AdminItem1> {
+    this.detailLoading.set(true);
+    this.detailError.set(null);
+    const locale = this.localeService.apiLocaleOverride();
+
+    return this.api.getAdminItem(id, locale, true, true).pipe(
+      tap({
+        next: (item) => this.selectedItem.set(item),
+        error: (error: unknown) => {
+          const message = readHttpErrorMessage(
+            error,
+            $localize`:@@admin.items.detailError:Unable to load item details.`,
+          );
+          this.detailError.set(message);
+          this.toast.error(message);
+        },
+      }),
+      finalize(() => this.detailLoading.set(false)),
+    );
+  }
+
+  upsertOverride(
+    id: number,
+    request: AdminItemOverrideRequest,
+    filters: AdminItemFilterState,
+  ): Observable<AdminItem1> {
+    return this.mutate(() => this.api.upsertAdminItemOverride(id, request), filters).pipe(
+      switchMap(() => this.loadItem(id)),
+    );
+  }
+
+  createItem(
+    request: AdminItemCreateRequest,
+    filters: AdminItemFilterState,
+  ): Observable<AdminItem1> {
+    return this.mutate(() => this.api.createAdminItem(request), filters).pipe(
+      tap((item) => this.selectedItem.set(item)),
+    );
+  }
+
+  deleteOverride(id: number, filters: AdminItemFilterState): Observable<void> {
+    return this.mutate(() => this.api.deleteAdminItemOverride(id), filters).pipe(
+      switchMap(() => this.loadItem(id)),
+      map(() => undefined),
+    );
+  }
+
+  compareWithApi(id: number): Observable<AdminItemCompareResponse> {
+    this.compareLoading.set(true);
+    this.compareError.set(null);
+    this.compare.set(null);
+
+    return this.api.compareAdminItemWithApi(id).pipe(
+      tap({
+        next: (result) => this.compare.set(result),
+        error: (error: unknown) => {
+          const message = readHttpErrorMessage(
+            error,
+            $localize`:@@admin.items.compareError:Unable to compare item with Blizzard API.`,
+          );
+          this.compareError.set(message);
+          this.toast.error(message);
+        },
+      }),
+      finalize(() => this.compareLoading.set(false)),
+    );
+  }
+
+  clearSelection(): void {
+    this.selectedItem.set(null);
+    this.detailError.set(null);
+    this.compare.set(null);
+    this.compareError.set(null);
+  }
+
+  private mutate<T>(request: () => Observable<T>, filters: AdminItemFilterState): Observable<T> {
+    this.mutationLoading.set(true);
+    return request().pipe(
+      switchMap((result) => this.search(filters).pipe(map(() => result))),
+      catchError((error: unknown) => {
+        this.toast.error(
+          readHttpErrorMessage(error, $localize`:@@admin.items.mutationError:Item request failed.`),
+        );
+        return throwError(() => error);
+      }),
+      finalize(() => this.mutationLoading.set(false)),
+    );
+  }
+}
+
+function readHttpErrorMessage(error: unknown, fallback: string): string {
+  if (!(error instanceof HttpErrorResponse)) {
+    return fallback;
+  }
+
+  const body = error.error;
+  if (typeof body === 'string' && body.trim().length > 0) {
+    return body;
+  }
+  if (
+    body &&
+    typeof body === 'object' &&
+    'message' in body &&
+    typeof body.message === 'string' &&
+    body.message.trim().length > 0
+  ) {
+    return body.message;
+  }
+
+  return fallback;
+}

--- a/frontend/src/app/features/admin/items/admin-item.service.ts
+++ b/frontend/src/app/features/admin/items/admin-item.service.ts
@@ -54,6 +54,8 @@ export class AdminItemService {
         locale,
         undefined,
         params.hasOverride,
+        params.itemClassId,
+        params.itemSubclassId,
         params.page,
         params.pageSize,
       )

--- a/frontend/src/app/features/admin/items/admin-items-table.columns.ts
+++ b/frontend/src/app/features/admin/items/admin-items-table.columns.ts
@@ -15,6 +15,7 @@ type AdminItemColumnMeta = {
 
 export type AdminItemTableActions = {
   readonly onEdit: (item: AdminItem1) => void;
+  readonly onAssociateRecipe: (item: AdminItem1) => void;
   readonly onCompare: (item: AdminItem1) => void;
   readonly onDeleteOverride: (item: AdminItem1) => void;
 };
@@ -92,7 +93,7 @@ export const createAdminItemColumns = (actions: AdminItemTableActions) => {
       header: $localize`:@@admin.items.table.actions:Actions`,
       meta: {
         align: 'right',
-        gridTrack: 'minmax(9rem, 0.8fr)',
+        gridTrack: 'minmax(11rem, 0.9fr)',
         ...actions,
       } satisfies AdminItemColumnMeta,
       cell: () => flexRenderComponent(AdminItemActionsCellComponent),

--- a/frontend/src/app/features/admin/items/admin-items-table.columns.ts
+++ b/frontend/src/app/features/admin/items/admin-items-table.columns.ts
@@ -1,0 +1,99 @@
+import { ColumnDef, createColumnHelper, flexRenderComponent } from '@tanstack/angular-table';
+import { AdminItem1 } from '@api/generated';
+import { AdminItemActionsCellComponent } from './admin-item-actions-cell.component';
+import { AdminItemQualityCellComponent } from './admin-item-quality-cell.component';
+import { AdminItemStateCellComponent } from './admin-item-state-cell.component';
+
+type AdminItemColumnMeta = {
+  readonly align: 'left' | 'right';
+  readonly gridTrack: string;
+  readonly cardRole?: 'primary' | 'metric' | 'detail';
+  readonly cardLabel?: string;
+  readonly cardPriority?: number;
+} & AdminItemTableActions;
+
+export type AdminItemTableActions = {
+  readonly onEdit: (item: AdminItem1) => void;
+  readonly onCompare: (item: AdminItem1) => void;
+  readonly onDeleteOverride: (item: AdminItem1) => void;
+};
+
+export const createAdminItemColumns = (actions: AdminItemTableActions) => {
+  const helper = createColumnHelper<AdminItem1>();
+  return [
+    helper.accessor('id', {
+      header: $localize`:@@admin.items.table.id:Item ID`,
+      meta: {
+        align: 'left',
+        gridTrack: 'minmax(6rem, 0.65fr)',
+        cardRole: 'metric',
+        cardLabel: $localize`:@@admin.items.table.id:Item ID`,
+        ...actions,
+      } satisfies AdminItemColumnMeta,
+    }),
+    helper.accessor((row) => row.effective.name ?? $localize`:@@admin.items.unnamed:Unnamed item`, {
+      id: 'name',
+      header: $localize`:@@admin.items.table.name:Name`,
+      meta: {
+        align: 'left',
+        gridTrack: 'minmax(14rem, 2fr)',
+        cardRole: 'primary',
+        cardPriority: 0,
+        ...actions,
+      } satisfies AdminItemColumnMeta,
+    }),
+    helper.display({
+      id: 'quality',
+      header: $localize`:@@admin.items.table.quality:Quality`,
+      meta: {
+        align: 'left',
+        gridTrack: 'minmax(7rem, 0.8fr)',
+        cardRole: 'metric',
+        cardLabel: $localize`:@@admin.items.table.quality:Quality`,
+        ...actions,
+      } satisfies AdminItemColumnMeta,
+      cell: () => flexRenderComponent(AdminItemQualityCellComponent),
+    }),
+    helper.accessor((row) => row.effective.itemClass?.name ?? '—', {
+      id: 'class',
+      header: $localize`:@@admin.items.table.class:Class`,
+      meta: {
+        align: 'left',
+        gridTrack: 'minmax(9rem, 1fr)',
+        cardRole: 'detail',
+        ...actions,
+      } satisfies AdminItemColumnMeta,
+    }),
+    helper.accessor((row) => row.effective.expansion?.name ?? '—', {
+      id: 'expansion',
+      header: $localize`:@@admin.items.table.expansion:Expansion`,
+      meta: {
+        align: 'left',
+        gridTrack: 'minmax(9rem, 1fr)',
+        cardRole: 'detail',
+        ...actions,
+      } satisfies AdminItemColumnMeta,
+    }),
+    helper.display({
+      id: 'state',
+      header: $localize`:@@admin.items.table.state:State`,
+      meta: {
+        align: 'left',
+        gridTrack: 'minmax(10rem, 1fr)',
+        cardRole: 'detail',
+        ...actions,
+      } satisfies AdminItemColumnMeta,
+      cell: () => flexRenderComponent(AdminItemStateCellComponent),
+    }),
+    helper.display({
+      id: 'actions',
+      header: $localize`:@@admin.items.table.actions:Actions`,
+      meta: {
+        align: 'right',
+        gridTrack: 'minmax(9rem, 0.8fr)',
+        ...actions,
+      } satisfies AdminItemColumnMeta,
+      cell: () => flexRenderComponent(AdminItemActionsCellComponent),
+    }),
+  ] as ColumnDef<AdminItem1, unknown>[];
+};

--- a/frontend/src/app/features/admin/items/admin-items-table.columns.ts
+++ b/frontend/src/app/features/admin/items/admin-items-table.columns.ts
@@ -1,6 +1,7 @@
 import { ColumnDef, createColumnHelper, flexRenderComponent } from '@tanstack/angular-table';
 import { AdminItem1 } from '@api/generated';
 import { AdminItemActionsCellComponent } from './admin-item-actions-cell.component';
+import { AdminItemNameCellComponent } from './admin-item-name-cell.component';
 import { AdminItemQualityCellComponent } from './admin-item-quality-cell.component';
 import { AdminItemStateCellComponent } from './admin-item-state-cell.component';
 
@@ -41,6 +42,7 @@ export const createAdminItemColumns = (actions: AdminItemTableActions) => {
         cardPriority: 0,
         ...actions,
       } satisfies AdminItemColumnMeta,
+      cell: () => flexRenderComponent(AdminItemNameCellComponent),
     }),
     helper.display({
       id: 'quality',

--- a/frontend/src/app/features/admin/items/item-filters.spec.ts
+++ b/frontend/src/app/features/admin/items/item-filters.spec.ts
@@ -8,11 +8,15 @@ describe('admin item filters', () => {
       pageSize: 50,
       name: 'potion',
       hasOverride: 'true',
+      classId: '7',
+      subclassId: '1',
     };
 
     expect(toAdminItemSearchParams(filters)).toEqual({
       query: 'potion',
       hasOverride: true,
+      itemClassId: 7,
+      itemSubclassId: 1,
       page: 3,
       pageSize: 50,
     });
@@ -29,6 +33,25 @@ describe('admin item filters', () => {
     expect(toAdminItemSearchParams(filters)).toEqual({
       query: '19019',
       hasOverride: undefined,
+      itemClassId: undefined,
+      itemSubclassId: undefined,
+      page: 1,
+      pageSize: 25,
+    });
+  });
+
+  it('preserves consumable class id zero', () => {
+    const filters = {
+      ...defaultAdminItemFilters(),
+      classId: '0',
+      subclassId: '1',
+    };
+
+    expect(toAdminItemSearchParams(filters)).toEqual({
+      query: undefined,
+      hasOverride: undefined,
+      itemClassId: 0,
+      itemSubclassId: 1,
       page: 1,
       pageSize: 25,
     });

--- a/frontend/src/app/features/admin/items/item-filters.spec.ts
+++ b/frontend/src/app/features/admin/items/item-filters.spec.ts
@@ -1,4 +1,10 @@
-import { defaultAdminItemFilters, toAdminItemSearchParams } from './item-filters';
+import { convertToParamMap } from '@angular/router';
+import {
+  defaultAdminItemFilters,
+  readAdminItemFilters,
+  toAdminItemQueryParams,
+  toAdminItemSearchParams,
+} from './item-filters';
 
 describe('admin item filters', () => {
   it('maps zero-based UI pages to one-based API pages', () => {
@@ -64,5 +70,89 @@ describe('admin item filters', () => {
     };
 
     expect(toAdminItemSearchParams(filters).hasOverride).toBe(false);
+  });
+
+  it('reads filter state from query params', () => {
+    expect(
+      readAdminItemFilters(
+        convertToParamMap({
+          name: 'potion',
+          classId: '0',
+          subclassId: '1',
+          hasOverride: 'true',
+          page: '2',
+          pageSize: '50',
+        }),
+      ),
+    ).toEqual({
+      ...defaultAdminItemFilters(),
+      name: 'potion',
+      classId: '0',
+      subclassId: '1',
+      hasOverride: 'true',
+      page: 2,
+      pageSize: 50,
+    });
+  });
+
+  it('writes non-default filters to query params', () => {
+    expect(
+      toAdminItemQueryParams({
+        ...defaultAdminItemFilters(),
+        name: 'potion',
+        classId: '0',
+        subclassId: '1',
+        hasOverride: 'true',
+        page: 2,
+        pageSize: 50,
+      }),
+    ).toEqual({
+      name: 'potion',
+      itemId: null,
+      qualityId: null,
+      classId: '0',
+      subclassId: '1',
+      expansionId: null,
+      hasOverride: 'true',
+      hasRecipe: null,
+      sort: null,
+      page: 2,
+      pageSize: 50,
+    });
+  });
+
+  it('omits default query params', () => {
+    expect(toAdminItemQueryParams(defaultAdminItemFilters())).toEqual({
+      name: null,
+      itemId: null,
+      qualityId: null,
+      classId: null,
+      subclassId: null,
+      expansionId: null,
+      hasOverride: null,
+      hasRecipe: null,
+      sort: null,
+      page: null,
+      pageSize: null,
+    });
+  });
+
+  it('maps recipe and expansion filters to search params', () => {
+    const filters = {
+      ...defaultAdminItemFilters(),
+      expansionId: '3',
+      hasRecipe: 'false',
+    };
+
+    expect(toAdminItemSearchParams(filters)).toEqual({
+      query: undefined,
+      hasOverride: undefined,
+      itemClassId: undefined,
+      itemSubclassId: undefined,
+      expansionId: 3,
+      hasRecipe: false,
+      page: 1,
+      pageSize: 25,
+    });
   });
 });

--- a/frontend/src/app/features/admin/items/item-filters.spec.ts
+++ b/frontend/src/app/features/admin/items/item-filters.spec.ts
@@ -1,0 +1,45 @@
+import { defaultAdminItemFilters, toAdminItemSearchParams } from './item-filters';
+
+describe('admin item filters', () => {
+  it('maps zero-based UI pages to one-based API pages', () => {
+    const filters = {
+      ...defaultAdminItemFilters(),
+      page: 2,
+      pageSize: 50,
+      name: 'potion',
+      hasOverride: 'true',
+    };
+
+    expect(toAdminItemSearchParams(filters)).toEqual({
+      query: 'potion',
+      hasOverride: true,
+      page: 3,
+      pageSize: 50,
+    });
+  });
+
+  it('uses item ID query before name when both are present', () => {
+    const filters = {
+      ...defaultAdminItemFilters(),
+      itemId: '19019',
+      name: 'Thunderfury',
+      hasOverride: '',
+    };
+
+    expect(toAdminItemSearchParams(filters)).toEqual({
+      query: '19019',
+      hasOverride: undefined,
+      page: 1,
+      pageSize: 25,
+    });
+  });
+
+  it('maps false override filter', () => {
+    const filters = {
+      ...defaultAdminItemFilters(),
+      hasOverride: 'false',
+    };
+
+    expect(toAdminItemSearchParams(filters).hasOverride).toBe(false);
+  });
+});

--- a/frontend/src/app/features/admin/items/item-filters.ts
+++ b/frontend/src/app/features/admin/items/item-filters.ts
@@ -14,6 +14,8 @@ export type AdminItemFilterState = {
 export type AdminItemSearchParams = {
   readonly query?: string;
   readonly hasOverride?: boolean;
+  readonly itemClassId?: number;
+  readonly itemSubclassId?: number;
   readonly page: number;
   readonly pageSize: number;
 };
@@ -39,9 +41,18 @@ export function toAdminItemSearchParams(filters: AdminItemFilterState): AdminIte
   return {
     query: query.length > 0 ? query : undefined,
     hasOverride: parseBooleanFilter(filters.hasOverride),
+    itemClassId: parseOptionalInt(filters.classId),
+    itemSubclassId: parseOptionalInt(filters.subclassId),
     page: filters.page + 1,
     pageSize: filters.pageSize,
   };
+}
+
+function parseOptionalInt(value: string): number | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
 }
 
 function parseBooleanFilter(value: string): boolean | undefined {

--- a/frontend/src/app/features/admin/items/item-filters.ts
+++ b/frontend/src/app/features/admin/items/item-filters.ts
@@ -1,0 +1,55 @@
+export type AdminItemFilterState = {
+  readonly page: number;
+  readonly pageSize: number;
+  readonly itemId: string;
+  readonly name: string;
+  readonly qualityId: string;
+  readonly classId: string;
+  readonly subclassId: string;
+  readonly expansionId: string;
+  readonly hasOverride: string;
+  readonly sort: string;
+};
+
+export type AdminItemSearchParams = {
+  readonly query?: string;
+  readonly hasOverride?: boolean;
+  readonly page: number;
+  readonly pageSize: number;
+};
+
+export const defaultAdminItemFilters = (): AdminItemFilterState => ({
+  page: 0,
+  pageSize: 25,
+  itemId: '',
+  name: '',
+  qualityId: '',
+  classId: '',
+  subclassId: '',
+  expansionId: '',
+  hasOverride: '',
+  sort: '',
+});
+
+export function toAdminItemSearchParams(filters: AdminItemFilterState): AdminItemSearchParams {
+  const itemId = filters.itemId.trim();
+  const name = filters.name.trim();
+  const query = itemId.length > 0 ? itemId : name;
+
+  return {
+    query: query.length > 0 ? query : undefined,
+    hasOverride: parseBooleanFilter(filters.hasOverride),
+    page: filters.page + 1,
+    pageSize: filters.pageSize,
+  };
+}
+
+function parseBooleanFilter(value: string): boolean | undefined {
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
+  return undefined;
+}

--- a/frontend/src/app/features/admin/items/item-filters.ts
+++ b/frontend/src/app/features/admin/items/item-filters.ts
@@ -1,3 +1,9 @@
+import { ParamMap, Params } from '@angular/router';
+
+const DEFAULT_PAGE = 0;
+const DEFAULT_PAGE_SIZE = 25;
+const MAX_PAGE_SIZE = 100;
+
 export type AdminItemFilterState = {
   readonly page: number;
   readonly pageSize: number;
@@ -8,6 +14,7 @@ export type AdminItemFilterState = {
   readonly subclassId: string;
   readonly expansionId: string;
   readonly hasOverride: string;
+  readonly hasRecipe: string;
   readonly sort: string;
 };
 
@@ -16,6 +23,8 @@ export type AdminItemSearchParams = {
   readonly hasOverride?: boolean;
   readonly itemClassId?: number;
   readonly itemSubclassId?: number;
+  readonly expansionId?: number;
+  readonly hasRecipe?: boolean;
   readonly page: number;
   readonly pageSize: number;
 };
@@ -30,6 +39,7 @@ export const defaultAdminItemFilters = (): AdminItemFilterState => ({
   subclassId: '',
   expansionId: '',
   hasOverride: '',
+  hasRecipe: '',
   sort: '',
 });
 
@@ -43,6 +53,8 @@ export function toAdminItemSearchParams(filters: AdminItemFilterState): AdminIte
     hasOverride: parseBooleanFilter(filters.hasOverride),
     itemClassId: parseOptionalInt(filters.classId),
     itemSubclassId: parseOptionalInt(filters.subclassId),
+    expansionId: parseOptionalInt(filters.expansionId),
+    hasRecipe: parseBooleanFilter(filters.hasRecipe),
     page: filters.page + 1,
     pageSize: filters.pageSize,
   };
@@ -63,4 +75,69 @@ function parseBooleanFilter(value: string): boolean | undefined {
     return false;
   }
   return undefined;
+}
+
+export function readAdminItemFilters(queryParamMap: ParamMap): AdminItemFilterState {
+  const hasOverride = queryParamMap.get('hasOverride');
+  const hasRecipe = queryParamMap.get('hasRecipe');
+  return {
+    ...defaultAdminItemFilters(),
+    page: clampPage(nullableNumber(queryParamMap.get('page'))),
+    pageSize: clampPageSize(nullableNumber(queryParamMap.get('pageSize'))),
+    itemId: queryParamMap.get('itemId') ?? '',
+    name: queryParamMap.get('name') ?? '',
+    qualityId: queryParamMap.get('qualityId') ?? '',
+    classId: readOptionalQueryString(queryParamMap.get('classId')),
+    subclassId: readOptionalQueryString(queryParamMap.get('subclassId')),
+    expansionId: readOptionalQueryString(queryParamMap.get('expansionId')),
+    hasOverride: hasOverride === 'true' || hasOverride === 'false' ? hasOverride : '',
+    hasRecipe: hasRecipe === 'true' || hasRecipe === 'false' ? hasRecipe : '',
+    sort: queryParamMap.get('sort') ?? '',
+  };
+}
+
+export function toAdminItemQueryParams(filters: AdminItemFilterState): Params {
+  return {
+    name: trimmedOrNull(filters.name),
+    itemId: trimmedOrNull(filters.itemId),
+    qualityId: trimmedOrNull(filters.qualityId),
+    classId: filters.classId !== '' ? filters.classId : null,
+    subclassId: filters.subclassId !== '' ? filters.subclassId : null,
+    expansionId: filters.expansionId !== '' ? filters.expansionId : null,
+    hasOverride:
+      filters.hasOverride === 'true' || filters.hasOverride === 'false'
+        ? filters.hasOverride
+        : null,
+    hasRecipe:
+      filters.hasRecipe === 'true' || filters.hasRecipe === 'false' ? filters.hasRecipe : null,
+    sort: trimmedOrNull(filters.sort),
+    page: filters.page === DEFAULT_PAGE ? null : filters.page,
+    pageSize: filters.pageSize === DEFAULT_PAGE_SIZE ? null : filters.pageSize,
+  };
+}
+
+function readOptionalQueryString(value: string | null): string {
+  if (value === null || value.trim() === '') return '';
+  return value;
+}
+
+function trimmedOrNull(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function nullableNumber(value: string | null): number | null {
+  if (value === null || value.trim() === '') return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function clampPage(value: number | null): number {
+  if (value === null || !Number.isFinite(value)) return DEFAULT_PAGE;
+  return Math.max(DEFAULT_PAGE, Math.floor(value));
+}
+
+function clampPageSize(value: number | null): number {
+  if (value === null || !Number.isFinite(value)) return DEFAULT_PAGE_SIZE;
+  return Math.min(MAX_PAGE_SIZE, Math.max(1, Math.floor(value)));
 }

--- a/frontend/src/app/features/admin/items/items.page.html
+++ b/frontend/src/app/features/admin/items/items.page.html
@@ -31,63 +31,85 @@
       </button>
     </div>
 
-    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-[1fr_1fr_12rem_12rem_14rem_8rem_auto_auto]">
-      <ee-search-input
-        label="Name"
-        [showLabel]="true"
-        placeholder="Search localized names"
-        [ngModel]="filters().name"
-        (ngModelChange)="updateFilter('name', $event)"
-      />
-      <ee-search-input
-        label="Item ID"
-        [showLabel]="true"
-        placeholder="Exact or partial item ID"
-        [ngModel]="filters().itemId"
-        (ngModelChange)="updateFilter('itemId', $event)"
-      />
-      <ee-select-input
-        label="Class"
-        [options]="itemClassOptions"
-        [ngModel]="filters().classId"
-        (ngModelChange)="updateClassFilter($event)"
-      />
-      <ee-select-input
-        label="Subclass"
-        [options]="itemSubclassOptions()"
-        [disabled]="filters().classId === ''"
-        [ngModel]="filters().subclassId"
-        (ngModelChange)="updateFilter('subclassId', $event)"
-      />
-      <ee-select-input
-        label="Override state"
-        [options]="hasOverrideOptions"
-        [ngModel]="filters().hasOverride"
-        (ngModelChange)="updateFilter('hasOverride', $event)"
-      />
-      <ee-select-input
-        label="Page size"
-        [options]="pageSizeOptions"
-        [ngModel]="pageSizeValue()"
-        (ngModelChange)="updatePageSize($event)"
-      />
-      <button
-        type="button"
-        class="h-12 rounded-md bg-primary px-4 font-semibold text-on-primary transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-primary-container disabled:cursor-wait disabled:opacity-70 md:self-end"
-        [disabled]="loading()"
-        (click)="applyFilters()"
-        type="submit"
-      >
-        Apply
-      </button>
-      <button
-        type="button"
-        class="h-12 rounded-md border border-white/10 px-4 font-semibold text-on-surface transition hover:bg-white/5 focus:outline-none focus:ring-2 focus:ring-primary-container md:self-end"
-        (click)="resetFilters()"
-      >
-        Reset
-      </button>
-    </div>
+    <form class="grid gap-4" (ngSubmit)="applyFilters()">
+      <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <ee-search-input
+          label="Name"
+          [showLabel]="true"
+          placeholder="Search localized names"
+          [ngModel]="filters().name"
+          [ngModelOptions]="standaloneModel"
+          (ngModelChange)="updateFilter('name', $event)"
+        />
+        <ee-search-input
+          label="Item ID"
+          [showLabel]="true"
+          placeholder="Exact or partial item ID"
+          [ngModel]="filters().itemId"
+          [ngModelOptions]="standaloneModel"
+          (ngModelChange)="updateFilter('itemId', $event)"
+        />
+        <ee-select-input
+          label="Class"
+          [options]="itemClassOptions"
+          [ngModel]="filters().classId"
+          [ngModelOptions]="standaloneModel"
+          (ngModelChange)="updateClassFilter($event)"
+        />
+        <ee-select-input
+          label="Subclass"
+          [options]="itemSubclassOptions()"
+          [disabled]="filters().classId === ''"
+          [ngModel]="filters().subclassId"
+          [ngModelOptions]="standaloneModel"
+          (ngModelChange)="updateFilter('subclassId', $event)"
+        />
+        <ee-select-input
+          label="Expansion"
+          [options]="expansionOptions()"
+          [ngModel]="filters().expansionId"
+          [ngModelOptions]="standaloneModel"
+          (ngModelChange)="updateFilter('expansionId', $event)"
+        />
+        <ee-select-input
+          label="Recipe association"
+          [options]="hasRecipeOptions"
+          [ngModel]="filters().hasRecipe"
+          [ngModelOptions]="standaloneModel"
+          (ngModelChange)="updateFilter('hasRecipe', $event)"
+        />
+        <ee-select-input
+          label="Override state"
+          [options]="hasOverrideOptions"
+          [ngModel]="filters().hasOverride"
+          [ngModelOptions]="standaloneModel"
+          (ngModelChange)="updateFilter('hasOverride', $event)"
+        />
+        <ee-select-input
+          label="Page size"
+          [options]="pageSizeOptions"
+          [ngModel]="pageSizeValue()"
+          [ngModelOptions]="standaloneModel"
+          (ngModelChange)="updatePageSize($event)"
+        />
+      </div>
+      <div class="flex flex-wrap gap-3">
+        <button
+          type="submit"
+          class="h-12 rounded-md bg-primary px-4 font-semibold text-on-primary transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-primary-container disabled:cursor-wait disabled:opacity-70"
+          [disabled]="loading()"
+        >
+          Apply
+        </button>
+        <button
+          type="button"
+          class="h-12 rounded-md border border-white/10 px-4 font-semibold text-on-surface transition hover:bg-white/5 focus:outline-none focus:ring-2 focus:ring-primary-container"
+          (click)="resetFilters()"
+        >
+          Reset
+        </button>
+      </div>
+    </form>
   </section>
 
   <section class="grid min-h-0 flex-1 gap-4" aria-label="Admin item results">

--- a/frontend/src/app/features/admin/items/items.page.html
+++ b/frontend/src/app/features/admin/items/items.page.html
@@ -1,0 +1,145 @@
+<ee-page-frame
+  title="Items"
+  eyebrow="Admin"
+  [loading]="loading() && items().length === 0"
+  titleId="admin-items-title"
+>
+  @if (error()) {
+    <p
+      class="rounded-md border border-error/30 bg-error/10 px-3 py-2 text-sm text-error"
+      role="alert"
+    >
+      {{ error() }}
+    </p>
+  }
+
+  <section class="grid gap-4" aria-label="Item search filters">
+    <div class="flex flex-wrap items-end justify-between gap-3">
+      <div class="grid gap-1">
+        <h2 class="font-cinzel text-xl font-bold text-primary-container">Item overrides</h2>
+        <p class="ee-data text-outline">
+          Search effective item rows and manage sparse admin overrides.
+        </p>
+      </div>
+      <button
+        type="button"
+        class="h-10 rounded-md bg-primary px-4 font-semibold text-on-primary transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-primary-container disabled:cursor-wait disabled:opacity-70"
+        [disabled]="mutationLoading()"
+        (click)="openCreatePanel()"
+      >
+        Create manual item
+      </button>
+    </div>
+
+    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-[1fr_1fr_14rem_8rem_auto_auto]">
+      <ee-search-input
+        label="Name"
+        [showLabel]="true"
+        placeholder="Search localized names"
+        [ngModel]="filters().name"
+        (ngModelChange)="updateFilter('name', $event)"
+      />
+      <ee-search-input
+        label="Item ID"
+        [showLabel]="true"
+        placeholder="Exact or partial item ID"
+        [ngModel]="filters().itemId"
+        (ngModelChange)="updateFilter('itemId', $event)"
+      />
+      <ee-select-input
+        label="Override state"
+        [options]="hasOverrideOptions"
+        [ngModel]="filters().hasOverride"
+        (ngModelChange)="updateFilter('hasOverride', $event)"
+      />
+      <ee-select-input
+        label="Page size"
+        [options]="pageSizeOptions"
+        [ngModel]="pageSizeValue()"
+        (ngModelChange)="updatePageSize($event)"
+      />
+      <button
+        type="button"
+        class="h-12 rounded-md bg-primary px-4 font-semibold text-on-primary transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-primary-container disabled:cursor-wait disabled:opacity-70 md:self-end"
+        [disabled]="loading()"
+        (click)="applyFilters()"
+      >
+        Apply
+      </button>
+      <button
+        type="button"
+        class="h-12 rounded-md border border-white/10 px-4 font-semibold text-on-surface transition hover:bg-white/5 focus:outline-none focus:ring-2 focus:ring-primary-container md:self-end"
+        (click)="resetFilters()"
+      >
+        Reset
+      </button>
+    </div>
+  </section>
+
+  <section class="grid min-h-0 flex-1 gap-4" aria-label="Admin item results">
+    <ee-table
+      [columns]="columns()"
+      [data]="items()"
+      [loading]="loading()"
+      [skeletonRowCount]="10"
+      [showFooter]="true"
+      [showPagination]="true"
+      [paginationState]="paginationState()"
+      [cardView]="cardView()"
+      [getRowId]="rowId"
+      emptyMessage="No items match the current filters."
+      sectionAriaLabel="Admin items"
+      paginationRowLabel="items"
+      (pageChange)="onPageChange($event)"
+    />
+  </section>
+</ee-page-frame>
+
+<ee-slide-over
+  [open]="panelMode() !== null"
+  [title]="panelTitle()"
+  titleId="admin-item-panel-title"
+  (closed)="closePanel()"
+>
+  @if (panelMode() === 'create') {
+    @if (formError()) {
+      <p
+        class="mb-4 rounded-md border border-error/30 bg-error/10 px-3 py-2 text-sm text-error"
+        role="alert"
+      >
+        {{ formError() }}
+      </p>
+    }
+    <app-admin-item-create-form
+      [submitting]="mutationLoading()"
+      (submitted)="submitCreate($event)"
+      (cancelled)="closePanel()"
+    />
+  } @else if (panelMode() === 'edit') {
+    @if (detailLoading()) {
+      <p class="ee-data text-outline" role="status">Loading item details...</p>
+    } @else if (selectedItem(); as item) {
+      <app-admin-item-override-form
+        [item]="item"
+        [expansions]="expansions()"
+        [submitting]="mutationLoading()"
+        [submitError]="formError() || detailError()"
+        (submitted)="submitOverride($event)"
+        (cancelled)="closePanel()"
+      />
+    } @else if (detailError()) {
+      <p
+        class="rounded-md border border-error/30 bg-error/10 px-3 py-2 text-sm text-error"
+        role="alert"
+      >
+        {{ detailError() }}
+      </p>
+    }
+  } @else if (panelMode() === 'compare') {
+    <app-admin-item-compare-panel
+      [compare]="compare()"
+      [loading]="compareLoading()"
+      [error]="compareError()"
+    />
+  }
+</ee-slide-over>

--- a/frontend/src/app/features/admin/items/items.page.html
+++ b/frontend/src/app/features/admin/items/items.page.html
@@ -31,7 +31,7 @@
       </button>
     </div>
 
-    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-[1fr_1fr_14rem_8rem_auto_auto]">
+    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-[1fr_1fr_12rem_12rem_14rem_8rem_auto_auto]">
       <ee-search-input
         label="Name"
         [showLabel]="true"
@@ -45,6 +45,19 @@
         placeholder="Exact or partial item ID"
         [ngModel]="filters().itemId"
         (ngModelChange)="updateFilter('itemId', $event)"
+      />
+      <ee-select-input
+        label="Class"
+        [options]="itemClassOptions"
+        [ngModel]="filters().classId"
+        (ngModelChange)="updateClassFilter($event)"
+      />
+      <ee-select-input
+        label="Subclass"
+        [options]="itemSubclassOptions()"
+        [disabled]="filters().classId === ''"
+        [ngModel]="filters().subclassId"
+        (ngModelChange)="updateFilter('subclassId', $event)"
       />
       <ee-select-input
         label="Override state"
@@ -63,6 +76,7 @@
         class="h-12 rounded-md bg-primary px-4 font-semibold text-on-primary transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-primary-container disabled:cursor-wait disabled:opacity-70 md:self-end"
         [disabled]="loading()"
         (click)="applyFilters()"
+        type="submit"
       >
         Apply
       </button>

--- a/frontend/src/app/features/admin/items/items.page.html
+++ b/frontend/src/app/features/admin/items/items.page.html
@@ -141,5 +141,27 @@
       [loading]="compareLoading()"
       [error]="compareError()"
     />
+  } @else if (panelMode() === 'recipe') {
+    @if (detailLoading()) {
+      <p class="ee-data text-outline" role="status">Loading item details...</p>
+    } @else if (selectedItem(); as item) {
+      <app-admin-item-recipe-association-panel
+        [item]="item"
+        [results]="recipeResults()"
+        [searching]="recipeSearching()"
+        [submitting]="mutationLoading()"
+        [submitError]="formError() || detailError()"
+        (search)="searchRecipes($event)"
+        (submitted)="submitRecipeAssociation($event)"
+        (cancelled)="closePanel()"
+      />
+    } @else if (detailError()) {
+      <p
+        class="rounded-md border border-error/30 bg-error/10 px-3 py-2 text-sm text-error"
+        role="alert"
+      >
+        {{ detailError() }}
+      </p>
+    }
   }
 </ee-slide-over>

--- a/frontend/src/app/features/admin/items/items.page.scss
+++ b/frontend/src/app/features/admin/items/items.page.scss
@@ -1,0 +1,3 @@
+:host {
+  display: contents;
+}

--- a/frontend/src/app/features/admin/items/items.page.ts
+++ b/frontend/src/app/features/admin/items/items.page.ts
@@ -10,6 +10,7 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
 import {
   AdminItem1,
   AdminItemCreateRequest,
@@ -24,7 +25,12 @@ import { ITEM_CLASS_OPTIONS, ITEM_SUBCLASS_OPTIONS } from './admin-item-override
 import { AdminItemRecipeAssociationPanelComponent } from './admin-item-recipe-association-panel.component';
 import { AdminItemService } from './admin-item.service';
 import { createAdminItemColumns } from './admin-items-table.columns';
-import { AdminItemFilterState, defaultAdminItemFilters } from './item-filters';
+import {
+  AdminItemFilterState,
+  defaultAdminItemFilters,
+  readAdminItemFilters,
+  toAdminItemQueryParams,
+} from './item-filters';
 import { AdminExpansionService } from '@features/admin/expansions/admin-expansion.service';
 import {
   PageFrameComponent,
@@ -41,6 +47,7 @@ type PanelMode = 'edit' | 'create' | 'compare' | 'recipe';
 
 const DEFAULT_VIEWPORT_WIDTH = 1280;
 const MOBILE_CARD_VIEW_MAX_WIDTH = 767;
+const standaloneModel = { standalone: true };
 
 @Component({
   selector: 'app-admin-items-page',
@@ -63,6 +70,8 @@ const MOBILE_CARD_VIEW_MAX_WIDTH = 767;
 export class ItemsPage {
   private readonly service = inject(AdminItemService);
   private readonly expansionService = inject(AdminExpansionService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
   private readonly platformId = inject(PLATFORM_ID);
   private recipeSearchSequence = 0;
@@ -87,11 +96,17 @@ export class ItemsPage {
   protected readonly recipeSearching = signal(false);
   protected readonly viewportWidth = signal(DEFAULT_VIEWPORT_WIDTH);
   protected readonly cardView = computed(() => this.viewportWidth() <= MOBILE_CARD_VIEW_MAX_WIDTH);
+  protected readonly standaloneModel = standaloneModel;
 
   protected readonly hasOverrideOptions = [
     { id: '', label: $localize`:@@admin.items.filter.anyOverride:All override states` },
     { id: 'true', label: $localize`:@@admin.items.filter.hasOverride:Has override` },
     { id: 'false', label: $localize`:@@admin.items.filter.noOverride:No override` },
+  ];
+  protected readonly hasRecipeOptions = [
+    { id: '', label: $localize`:@@admin.items.filter.anyRecipe:All recipe states` },
+    { id: 'true', label: $localize`:@@admin.items.filter.hasRecipe:Has recipe` },
+    { id: 'false', label: $localize`:@@admin.items.filter.noRecipe:No recipe` },
   ];
 
   protected readonly pageSizeOptions = [
@@ -106,6 +121,13 @@ export class ItemsPage {
   protected readonly itemSubclassOptions = computed<readonly SelectInputOption[]>(() => [
     { id: '', label: $localize`:@@admin.items.filter.anySubclass:All subclasses` },
     ...(ITEM_SUBCLASS_OPTIONS[this.filters().classId] ?? []),
+  ]);
+  protected readonly expansionOptions = computed<readonly SelectInputOption[]>(() => [
+    { id: '', label: $localize`:@@admin.items.filter.anyExpansion:All expansions` },
+    ...this.expansions().map((expansion) => ({
+      id: String(expansion.id),
+      label: expansion.name,
+    })),
   ]);
   protected readonly rowId = (item: AdminItem1): string => String(item.id);
 
@@ -156,7 +178,11 @@ export class ItemsPage {
         });
     }
 
-    void this.reload();
+    this.route.queryParamMap.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((paramMap) => {
+      this.filters.set(readAdminItemFilters(paramMap));
+      void this.reload();
+    });
+
     void firstValueFrom(this.expansionService.load()).catch(() => undefined);
   }
 
@@ -169,12 +195,11 @@ export class ItemsPage {
 
   protected updatePageSize(value: string): void {
     const pageSize = Number.parseInt(value, 10);
-    this.filters.update((current) => ({
-      ...current,
+    this.syncFilters({
+      ...this.filters(),
       page: 0,
       pageSize: Number.isFinite(pageSize) ? pageSize : 25,
-    }));
-    void this.reload();
+    });
   }
 
   protected updateClassFilter(value: string): void {
@@ -187,18 +212,15 @@ export class ItemsPage {
   }
 
   protected applyFilters(): void {
-    this.filters.update((current) => ({ ...current, page: 0 }));
-    void this.reload();
+    this.syncFilters({ ...this.filters(), page: 0 });
   }
 
   protected resetFilters(): void {
-    this.filters.set(defaultAdminItemFilters());
-    void this.reload();
+    this.syncFilters(defaultAdminItemFilters());
   }
 
   protected onPageChange(page: number): void {
-    this.filters.update((current) => ({ ...current, page }));
-    void this.reload();
+    this.syncFilters({ ...this.filters(), page });
   }
 
   protected async openEditPanel(item: AdminItem1): Promise<void> {
@@ -312,6 +334,14 @@ export class ItemsPage {
 
   protected pageSizeValue(): string {
     return String(this.filters().pageSize);
+  }
+
+  private syncFilters(filters: AdminItemFilterState): void {
+    void this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: toAdminItemQueryParams(filters),
+      replaceUrl: true,
+    });
   }
 
   private async reload(): Promise<void> {

--- a/frontend/src/app/features/admin/items/items.page.ts
+++ b/frontend/src/app/features/admin/items/items.page.ts
@@ -10,10 +10,17 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
-import { AdminItem1, AdminItemCreateRequest, AdminItemOverrideRequest } from '@api/generated';
+import {
+  AdminItem1,
+  AdminItemCreateRequest,
+  AdminItemOverrideRequest,
+  AdminRecipeAssociationRequest,
+  AdminRecipeSearchResult,
+} from '@api/generated';
 import { AdminItemComparePanelComponent } from './admin-item-compare-panel.component';
 import { AdminItemCreateFormComponent } from './admin-item-create-form.component';
 import { AdminItemOverrideFormComponent } from './admin-item-override-form.component';
+import { AdminItemRecipeAssociationPanelComponent } from './admin-item-recipe-association-panel.component';
 import { AdminItemService } from './admin-item.service';
 import { createAdminItemColumns } from './admin-items-table.columns';
 import { AdminItemFilterState, defaultAdminItemFilters } from './item-filters';
@@ -28,7 +35,7 @@ import {
 } from '@ui';
 import { firstValueFrom, fromEvent, map, startWith } from 'rxjs';
 
-type PanelMode = 'edit' | 'create' | 'compare';
+type PanelMode = 'edit' | 'create' | 'compare' | 'recipe';
 
 const DEFAULT_VIEWPORT_WIDTH = 1280;
 const MOBILE_CARD_VIEW_MAX_WIDTH = 767;
@@ -40,6 +47,7 @@ const MOBILE_CARD_VIEW_MAX_WIDTH = 767;
     AdminItemComparePanelComponent,
     AdminItemCreateFormComponent,
     AdminItemOverrideFormComponent,
+    AdminItemRecipeAssociationPanelComponent,
     PageFrameComponent,
     SearchInputComponent,
     SelectInputComponent,
@@ -55,6 +63,7 @@ export class ItemsPage {
   private readonly expansionService = inject(AdminExpansionService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly platformId = inject(PLATFORM_ID);
+  private recipeSearchSequence = 0;
 
   protected readonly loading = this.service.loading.asReadonly();
   protected readonly mutationLoading = this.service.mutationLoading.asReadonly();
@@ -72,6 +81,8 @@ export class ItemsPage {
   protected readonly filters = signal<AdminItemFilterState>(defaultAdminItemFilters());
   protected readonly panelMode = signal<PanelMode | null>(null);
   protected readonly formError = signal<string | null>(null);
+  protected readonly recipeResults = signal<readonly AdminRecipeSearchResult[]>([]);
+  protected readonly recipeSearching = signal(false);
   protected readonly viewportWidth = signal(DEFAULT_VIEWPORT_WIDTH);
   protected readonly cardView = computed(() => this.viewportWidth() <= MOBILE_CARD_VIEW_MAX_WIDTH);
 
@@ -91,6 +102,7 @@ export class ItemsPage {
   protected readonly columns = signal(
     createAdminItemColumns({
       onEdit: (item) => void this.openEditPanel(item),
+      onAssociateRecipe: (item) => void this.openRecipePanel(item),
       onCompare: (item) => void this.openComparePanel(item),
       onDeleteOverride: (item) => void this.deleteOverride(item),
     }),
@@ -114,6 +126,8 @@ export class ItemsPage {
         return $localize`:@@admin.items.panel.compare:Compare Blizzard API`;
       case 'edit':
         return $localize`:@@admin.items.panel.edit:Edit item override`;
+      case 'recipe':
+        return $localize`:@@admin.items.panel.recipe:Associate recipe`;
       default:
         return '';
     }
@@ -187,9 +201,17 @@ export class ItemsPage {
     await firstValueFrom(this.service.compareWithApi(item.id)).catch(() => undefined);
   }
 
+  protected async openRecipePanel(item: AdminItem1): Promise<void> {
+    this.formError.set(null);
+    this.recipeResults.set([]);
+    this.panelMode.set('recipe');
+    await this.loadItem(item.id);
+  }
+
   protected closePanel(): void {
     this.panelMode.set(null);
     this.formError.set(null);
+    this.recipeResults.set([]);
     this.service.clearSelection();
   }
 
@@ -214,6 +236,47 @@ export class ItemsPage {
       .catch((error: unknown) => {
         this.formError.set(error instanceof Error ? error.message : 'Unable to create item.');
       });
+  }
+
+  protected async searchRecipes(query: string): Promise<void> {
+    const normalized = query.trim();
+    const sequence = ++this.recipeSearchSequence;
+    if (normalized.length < 2) {
+      this.recipeResults.set([]);
+      this.recipeSearching.set(false);
+      return;
+    }
+    this.recipeSearching.set(true);
+    await firstValueFrom(this.service.searchRecipes(normalized))
+      .then((recipes) => {
+        if (sequence === this.recipeSearchSequence) {
+          this.recipeResults.set(recipes);
+        }
+      })
+      .catch(() => {
+        if (sequence === this.recipeSearchSequence) {
+          this.recipeResults.set([]);
+        }
+      })
+      .finally(() => {
+        if (sequence === this.recipeSearchSequence) {
+          this.recipeSearching.set(false);
+        }
+      });
+  }
+
+  protected async submitRecipeAssociation(event: {
+    recipeId: number;
+    request: AdminRecipeAssociationRequest;
+  }): Promise<void> {
+    const item = this.selectedItem();
+    if (!item) return;
+    this.formError.set(null);
+    await firstValueFrom(
+      this.service.upsertRecipeAssociation(item.id, event.recipeId, event.request, this.filters()),
+    ).catch((error: unknown) => {
+      this.formError.set(error instanceof Error ? error.message : 'Unable to update recipe.');
+    });
   }
 
   protected async deleteOverride(item: AdminItem1): Promise<void> {

--- a/frontend/src/app/features/admin/items/items.page.ts
+++ b/frontend/src/app/features/admin/items/items.page.ts
@@ -20,6 +20,7 @@ import {
 import { AdminItemComparePanelComponent } from './admin-item-compare-panel.component';
 import { AdminItemCreateFormComponent } from './admin-item-create-form.component';
 import { AdminItemOverrideFormComponent } from './admin-item-override-form.component';
+import { ITEM_CLASS_OPTIONS, ITEM_SUBCLASS_OPTIONS } from './admin-item-override-form.component';
 import { AdminItemRecipeAssociationPanelComponent } from './admin-item-recipe-association-panel.component';
 import { AdminItemService } from './admin-item.service';
 import { createAdminItemColumns } from './admin-items-table.columns';
@@ -30,6 +31,7 @@ import {
   PaginationState,
   SearchInputComponent,
   SelectInputComponent,
+  SelectInputOption,
   SlideOverPanelComponent,
   TableComponent,
 } from '@ui';
@@ -97,6 +99,14 @@ export class ItemsPage {
     { id: '50', label: '50' },
     { id: '100', label: '100' },
   ];
+  protected readonly itemClassOptions: readonly SelectInputOption[] = [
+    { id: '', label: $localize`:@@admin.items.filter.anyClass:All classes` },
+    ...ITEM_CLASS_OPTIONS,
+  ];
+  protected readonly itemSubclassOptions = computed<readonly SelectInputOption[]>(() => [
+    { id: '', label: $localize`:@@admin.items.filter.anySubclass:All subclasses` },
+    ...(ITEM_SUBCLASS_OPTIONS[this.filters().classId] ?? []),
+  ]);
   protected readonly rowId = (item: AdminItem1): string => String(item.id);
 
   protected readonly columns = signal(
@@ -165,6 +175,15 @@ export class ItemsPage {
       pageSize: Number.isFinite(pageSize) ? pageSize : 25,
     }));
     void this.reload();
+  }
+
+  protected updateClassFilter(value: string): void {
+    this.filters.update((current) => ({
+      ...current,
+      classId: value,
+      subclassId: '',
+      page: 0,
+    }));
   }
 
   protected applyFilters(): void {

--- a/frontend/src/app/features/admin/items/items.page.ts
+++ b/frontend/src/app/features/admin/items/items.page.ts
@@ -1,0 +1,242 @@
+import { isPlatformBrowser } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  DestroyRef,
+  inject,
+  PLATFORM_ID,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { AdminItem1, AdminItemCreateRequest, AdminItemOverrideRequest } from '@api/generated';
+import { AdminItemComparePanelComponent } from './admin-item-compare-panel.component';
+import { AdminItemCreateFormComponent } from './admin-item-create-form.component';
+import { AdminItemOverrideFormComponent } from './admin-item-override-form.component';
+import { AdminItemService } from './admin-item.service';
+import { createAdminItemColumns } from './admin-items-table.columns';
+import { AdminItemFilterState, defaultAdminItemFilters } from './item-filters';
+import { AdminExpansionService } from '@features/admin/expansions/admin-expansion.service';
+import {
+  PageFrameComponent,
+  PaginationState,
+  SearchInputComponent,
+  SelectInputComponent,
+  SlideOverPanelComponent,
+  TableComponent,
+} from '@ui';
+import { firstValueFrom, fromEvent, map, startWith } from 'rxjs';
+
+type PanelMode = 'edit' | 'create' | 'compare';
+
+const DEFAULT_VIEWPORT_WIDTH = 1280;
+const MOBILE_CARD_VIEW_MAX_WIDTH = 767;
+
+@Component({
+  selector: 'app-admin-items-page',
+  imports: [
+    FormsModule,
+    AdminItemComparePanelComponent,
+    AdminItemCreateFormComponent,
+    AdminItemOverrideFormComponent,
+    PageFrameComponent,
+    SearchInputComponent,
+    SelectInputComponent,
+    SlideOverPanelComponent,
+    TableComponent,
+  ],
+  templateUrl: './items.page.html',
+  styleUrl: './items.page.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ItemsPage {
+  private readonly service = inject(AdminItemService);
+  private readonly expansionService = inject(AdminExpansionService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly platformId = inject(PLATFORM_ID);
+
+  protected readonly loading = this.service.loading.asReadonly();
+  protected readonly mutationLoading = this.service.mutationLoading.asReadonly();
+  protected readonly detailLoading = this.service.detailLoading.asReadonly();
+  protected readonly compareLoading = this.service.compareLoading.asReadonly();
+  protected readonly items = this.service.items.asReadonly();
+  protected readonly page = this.service.page.asReadonly();
+  protected readonly selectedItem = this.service.selectedItem.asReadonly();
+  protected readonly compare = this.service.compare.asReadonly();
+  protected readonly error = this.service.error.asReadonly();
+  protected readonly detailError = this.service.detailError.asReadonly();
+  protected readonly compareError = this.service.compareError.asReadonly();
+  protected readonly expansions = this.expansionService.expansions.asReadonly();
+
+  protected readonly filters = signal<AdminItemFilterState>(defaultAdminItemFilters());
+  protected readonly panelMode = signal<PanelMode | null>(null);
+  protected readonly formError = signal<string | null>(null);
+  protected readonly viewportWidth = signal(DEFAULT_VIEWPORT_WIDTH);
+  protected readonly cardView = computed(() => this.viewportWidth() <= MOBILE_CARD_VIEW_MAX_WIDTH);
+
+  protected readonly hasOverrideOptions = [
+    { id: '', label: $localize`:@@admin.items.filter.anyOverride:All override states` },
+    { id: 'true', label: $localize`:@@admin.items.filter.hasOverride:Has override` },
+    { id: 'false', label: $localize`:@@admin.items.filter.noOverride:No override` },
+  ];
+
+  protected readonly pageSizeOptions = [
+    { id: '25', label: '25' },
+    { id: '50', label: '50' },
+    { id: '100', label: '100' },
+  ];
+  protected readonly rowId = (item: AdminItem1): string => String(item.id);
+
+  protected readonly columns = signal(
+    createAdminItemColumns({
+      onEdit: (item) => void this.openEditPanel(item),
+      onCompare: (item) => void this.openComparePanel(item),
+      onDeleteOverride: (item) => void this.deleteOverride(item),
+    }),
+  );
+
+  protected readonly paginationState = computed<PaginationState>(() => {
+    const page = this.page();
+    return {
+      page: Math.max(0, page.page - 1),
+      pageSize: page.pageSize,
+      totalItems: page.totalItems,
+      totalPages: Math.max(1, page.totalPages),
+    };
+  });
+
+  protected readonly panelTitle = computed(() => {
+    switch (this.panelMode()) {
+      case 'create':
+        return $localize`:@@admin.items.panel.create:Create manual item`;
+      case 'compare':
+        return $localize`:@@admin.items.panel.compare:Compare Blizzard API`;
+      case 'edit':
+        return $localize`:@@admin.items.panel.edit:Edit item override`;
+      default:
+        return '';
+    }
+  });
+
+  constructor() {
+    if (isPlatformBrowser(this.platformId)) {
+      fromEvent(window, 'resize')
+        .pipe(
+          startWith(null),
+          map(() => window.innerWidth),
+          takeUntilDestroyed(this.destroyRef),
+        )
+        .subscribe((width) => {
+          this.viewportWidth.set(width);
+        });
+    }
+
+    void this.reload();
+    void firstValueFrom(this.expansionService.load()).catch(() => undefined);
+  }
+
+  protected updateFilter<K extends keyof AdminItemFilterState>(
+    key: K,
+    value: AdminItemFilterState[K],
+  ): void {
+    this.filters.update((current) => ({ ...current, [key]: value, page: 0 }));
+  }
+
+  protected updatePageSize(value: string): void {
+    const pageSize = Number.parseInt(value, 10);
+    this.filters.update((current) => ({
+      ...current,
+      page: 0,
+      pageSize: Number.isFinite(pageSize) ? pageSize : 25,
+    }));
+    void this.reload();
+  }
+
+  protected applyFilters(): void {
+    this.filters.update((current) => ({ ...current, page: 0 }));
+    void this.reload();
+  }
+
+  protected resetFilters(): void {
+    this.filters.set(defaultAdminItemFilters());
+    void this.reload();
+  }
+
+  protected onPageChange(page: number): void {
+    this.filters.update((current) => ({ ...current, page }));
+    void this.reload();
+  }
+
+  protected async openEditPanel(item: AdminItem1): Promise<void> {
+    this.formError.set(null);
+    this.panelMode.set('edit');
+    await this.loadItem(item.id);
+  }
+
+  protected openCreatePanel(): void {
+    this.service.clearSelection();
+    this.formError.set(null);
+    this.panelMode.set('create');
+  }
+
+  protected async openComparePanel(item: AdminItem1): Promise<void> {
+    this.formError.set(null);
+    this.panelMode.set('compare');
+    await this.loadItem(item.id);
+    await firstValueFrom(this.service.compareWithApi(item.id)).catch(() => undefined);
+  }
+
+  protected closePanel(): void {
+    this.panelMode.set(null);
+    this.formError.set(null);
+    this.service.clearSelection();
+  }
+
+  protected async submitOverride(request: AdminItemOverrideRequest): Promise<void> {
+    const item = this.selectedItem();
+    if (!item) return;
+    this.formError.set(null);
+    await firstValueFrom(this.service.upsertOverride(item.id, request, this.filters())).catch(
+      (error: unknown) => {
+        this.formError.set(error instanceof Error ? error.message : 'Unable to save override.');
+      },
+    );
+  }
+
+  protected async submitCreate(request: AdminItemCreateRequest): Promise<void> {
+    this.formError.set(null);
+    await firstValueFrom(this.service.createItem(request, this.filters()))
+      .then((item) => {
+        this.panelMode.set('edit');
+        return this.loadItem(item.id);
+      })
+      .catch((error: unknown) => {
+        this.formError.set(error instanceof Error ? error.message : 'Unable to create item.');
+      });
+  }
+
+  protected async deleteOverride(item: AdminItem1): Promise<void> {
+    if (!item.hasOverride) return;
+    const confirmed = window.confirm(
+      $localize`:@@admin.items.deleteConfirm:Delete this item override? Base item data will be inherited again.`,
+    );
+    if (!confirmed) return;
+
+    await firstValueFrom(this.service.deleteOverride(item.id, this.filters())).catch(
+      () => undefined,
+    );
+  }
+
+  protected pageSizeValue(): string {
+    return String(this.filters().pageSize);
+  }
+
+  private async reload(): Promise<void> {
+    await firstValueFrom(this.service.search(this.filters())).catch(() => undefined);
+  }
+
+  private async loadItem(id: number): Promise<void> {
+    await firstValueFrom(this.service.loadItem(id)).catch(() => undefined);
+  }
+}

--- a/frontend/src/app/features/admin/status/admin-sql-result.component.ts
+++ b/frontend/src/app/features/admin/status/admin-sql-result.component.ts
@@ -32,8 +32,7 @@ const pageSizes = [25, 50, 100, 250] as const;
             </div>
             <pre
               class="max-h-40 overflow-auto whitespace-pre-wrap rounded-md border border-white/10 bg-surface-container p-3 font-mono text-xs text-on-surface"
-              >{{ result.effectiveSql }}</pre
-            >
+              >{{ result.effectiveSql }}</pre>
           </div>
         }
 
@@ -45,8 +44,7 @@ const pageSizes = [25, 50, 100, 250] as const;
             </div>
             <pre
               class="max-h-[28rem] overflow-auto whitespace-pre-wrap rounded-md border border-white/10 bg-surface-container p-3 font-mono text-xs text-on-surface"
-              >{{ json }}</pre
-            >
+              >{{ json }}</pre>
           </div>
         } @else if (result.columns.length > 0) {
           <div class="grid gap-3">

--- a/frontend/src/app/features/admin/status/admin-sql-result.component.ts
+++ b/frontend/src/app/features/admin/status/admin-sql-result.component.ts
@@ -32,7 +32,8 @@ const pageSizes = [25, 50, 100, 250] as const;
             </div>
             <pre
               class="max-h-40 overflow-auto whitespace-pre-wrap rounded-md border border-white/10 bg-surface-container p-3 font-mono text-xs text-on-surface"
-              >{{ result.effectiveSql }}</pre>
+              >{{ result.effectiveSql }}</pre
+            >
           </div>
         }
 
@@ -44,7 +45,8 @@ const pageSizes = [25, 50, 100, 250] as const;
             </div>
             <pre
               class="max-h-[28rem] overflow-auto whitespace-pre-wrap rounded-md border border-white/10 bg-surface-container p-3 font-mono text-xs text-on-surface"
-              >{{ json }}</pre>
+              >{{ json }}</pre
+            >
           </div>
         } @else if (result.columns.length > 0) {
           <div class="grid gap-3">

--- a/frontend/src/app/features/admin/status/admin-sql.service.ts
+++ b/frontend/src/app/features/admin/status/admin-sql.service.ts
@@ -28,7 +28,9 @@ export class AdminSqlService {
 export function readAdminSqlError(error: unknown): string {
   if (error instanceof HttpErrorResponse) {
     const payload = error.error as
-      { readonly detail?: string; readonly message?: string } | string | null;
+      | { readonly detail?: string; readonly message?: string }
+      | string
+      | null;
     if (typeof payload === 'string' && payload.trim()) {
       return payload;
     }

--- a/frontend/src/app/features/admin/status/admin-sql.service.ts
+++ b/frontend/src/app/features/admin/status/admin-sql.service.ts
@@ -28,9 +28,7 @@ export class AdminSqlService {
 export function readAdminSqlError(error: unknown): string {
   if (error instanceof HttpErrorResponse) {
     const payload = error.error as
-      | { readonly detail?: string; readonly message?: string }
-      | string
-      | null;
+      { readonly detail?: string; readonly message?: string } | string | null;
     if (typeof payload === 'string' && payload.trim()) {
       return payload;
     }

--- a/frontend/src/locale/messages.de.xlf
+++ b/frontend/src/locale/messages.de.xlf
@@ -1770,6 +1770,23 @@
         <source>No override</source>
         <target>No override</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.filter.anyRecipe" datatype="html">
+        <source>All recipe states</source>
+        <target>All recipe states</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.hasRecipe" datatype="html">
+        <source>Has recipe</source>
+        <target>Has recipe</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.noRecipe" datatype="html">
+        <source>No recipe</source>
+        <target>No recipe</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anyExpansion" datatype="html">
+        <source>All expansions</source>
+        <target>All expansions</target>
+      </trans-unit>
       <trans-unit id="admin.items.panel.create" datatype="html">
         <source>Create manual item</source>
         <target>Create manual item</target>

--- a/frontend/src/locale/messages.de.xlf
+++ b/frontend/src/locale/messages.de.xlf
@@ -1702,6 +1702,94 @@
           <context context-type="linenumber">78</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="route.admin.items" datatype="html">
+        <source>Items</source>
+        <target>Items</target>
+      </trans-unit>
+      <trans-unit id="admin.items.loadError" datatype="html">
+        <source>Unable to load items.</source>
+        <target>Unable to load items.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.detailError" datatype="html">
+        <source>Unable to load item details.</source>
+        <target>Unable to load item details.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.compareError" datatype="html">
+        <source>Unable to compare item with Blizzard API.</source>
+        <target>Unable to compare item with Blizzard API.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.mutationError" datatype="html">
+        <source>Item request failed.</source>
+        <target>Item request failed.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.create.englishRequired" datatype="html">
+        <source>English (US) or English (GB) name is required.</source>
+        <target>English (US) or English (GB) name is required.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.id" datatype="html">
+        <source>Item ID</source>
+        <target>Item ID</target>
+      </trans-unit>
+      <trans-unit id="admin.items.unnamed" datatype="html">
+        <source>Unnamed item</source>
+        <target>Unnamed item</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.name" datatype="html">
+        <source>Name</source>
+        <target>Name</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.quality" datatype="html">
+        <source>Quality</source>
+        <target>Quality</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.class" datatype="html">
+        <source>Class</source>
+        <target>Class</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.expansion" datatype="html">
+        <source>Expansion</source>
+        <target>Expansion</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.state" datatype="html">
+        <source>State</source>
+        <target>State</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.actions" datatype="html">
+        <source>Actions</source>
+        <target>Actions</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anyOverride" datatype="html">
+        <source>All override states</source>
+        <target>All override states</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.hasOverride" datatype="html">
+        <source>Has override</source>
+        <target>Has override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.noOverride" datatype="html">
+        <source>No override</source>
+        <target>No override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.create" datatype="html">
+        <source>Create manual item</source>
+        <target>Create manual item</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.compare" datatype="html">
+        <source>Compare Blizzard API</source>
+        <target>Compare Blizzard API</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.edit" datatype="html">
+        <source>Edit item override</source>
+        <target>Edit item override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.deleteConfirm" datatype="html">
+        <source>Delete this item override? Base item data will be inherited again.</source>
+        <target>Delete this item override? Base item data will be inherited again.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.form.classSubclassRequired" datatype="html">
+        <source>Class ID and subclass ID are required together.</source>
+        <target>Class ID and subclass ID are required together.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/frontend/src/locale/messages.de.xlf
+++ b/frontend/src/locale/messages.de.xlf
@@ -1722,6 +1722,11 @@
         <source>Item request failed.</source>
         <target>Item request failed.</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.recipeSearchError" datatype="html">
+        <source>Unable to search recipes.</source>
+        <target>Unable to search recipes.</target>
+      </trans-unit>
       <trans-unit id="admin.items.create.englishRequired" datatype="html">
         <source>English (US) or English (GB) name is required.</source>
         <target>English (US) or English (GB) name is required.</target>
@@ -1787,6 +1792,15 @@
         <source>All expansions</source>
         <target>All expansions</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.filter.anyClass" datatype="html">
+        <source>All classes</source>
+        <target>All classes</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anySubclass" datatype="html">
+        <source>All subclasses</source>
+        <target>All subclasses</target>
+      </trans-unit>
       <trans-unit id="admin.items.panel.create" datatype="html">
         <source>Create manual item</source>
         <target>Create manual item</target>
@@ -1798,6 +1812,11 @@
       <trans-unit id="admin.items.panel.edit" datatype="html">
         <source>Edit item override</source>
         <target>Edit item override</target>
+      </trans-unit>
+
+      <trans-unit id="admin.items.panel.recipe" datatype="html">
+        <source>Associate recipe</source>
+        <target>Associate recipe</target>
       </trans-unit>
       <trans-unit id="admin.items.deleteConfirm" datatype="html">
         <source>Delete this item override? Base item data will be inherited again.</source>

--- a/frontend/src/locale/messages.es.xlf
+++ b/frontend/src/locale/messages.es.xlf
@@ -1770,6 +1770,23 @@
         <source>No override</source>
         <target>No override</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.filter.anyRecipe" datatype="html">
+        <source>All recipe states</source>
+        <target>All recipe states</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.hasRecipe" datatype="html">
+        <source>Has recipe</source>
+        <target>Has recipe</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.noRecipe" datatype="html">
+        <source>No recipe</source>
+        <target>No recipe</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anyExpansion" datatype="html">
+        <source>All expansions</source>
+        <target>All expansions</target>
+      </trans-unit>
       <trans-unit id="admin.items.panel.create" datatype="html">
         <source>Create manual item</source>
         <target>Create manual item</target>

--- a/frontend/src/locale/messages.es.xlf
+++ b/frontend/src/locale/messages.es.xlf
@@ -1702,6 +1702,94 @@
           <context context-type="linenumber">78</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="route.admin.items" datatype="html">
+        <source>Items</source>
+        <target>Items</target>
+      </trans-unit>
+      <trans-unit id="admin.items.loadError" datatype="html">
+        <source>Unable to load items.</source>
+        <target>Unable to load items.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.detailError" datatype="html">
+        <source>Unable to load item details.</source>
+        <target>Unable to load item details.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.compareError" datatype="html">
+        <source>Unable to compare item with Blizzard API.</source>
+        <target>Unable to compare item with Blizzard API.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.mutationError" datatype="html">
+        <source>Item request failed.</source>
+        <target>Item request failed.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.create.englishRequired" datatype="html">
+        <source>English (US) or English (GB) name is required.</source>
+        <target>English (US) or English (GB) name is required.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.id" datatype="html">
+        <source>Item ID</source>
+        <target>Item ID</target>
+      </trans-unit>
+      <trans-unit id="admin.items.unnamed" datatype="html">
+        <source>Unnamed item</source>
+        <target>Unnamed item</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.name" datatype="html">
+        <source>Name</source>
+        <target>Name</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.quality" datatype="html">
+        <source>Quality</source>
+        <target>Quality</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.class" datatype="html">
+        <source>Class</source>
+        <target>Class</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.expansion" datatype="html">
+        <source>Expansion</source>
+        <target>Expansion</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.state" datatype="html">
+        <source>State</source>
+        <target>State</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.actions" datatype="html">
+        <source>Actions</source>
+        <target>Actions</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anyOverride" datatype="html">
+        <source>All override states</source>
+        <target>All override states</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.hasOverride" datatype="html">
+        <source>Has override</source>
+        <target>Has override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.noOverride" datatype="html">
+        <source>No override</source>
+        <target>No override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.create" datatype="html">
+        <source>Create manual item</source>
+        <target>Create manual item</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.compare" datatype="html">
+        <source>Compare Blizzard API</source>
+        <target>Compare Blizzard API</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.edit" datatype="html">
+        <source>Edit item override</source>
+        <target>Edit item override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.deleteConfirm" datatype="html">
+        <source>Delete this item override? Base item data will be inherited again.</source>
+        <target>Delete this item override? Base item data will be inherited again.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.form.classSubclassRequired" datatype="html">
+        <source>Class ID and subclass ID are required together.</source>
+        <target>Class ID and subclass ID are required together.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/frontend/src/locale/messages.es.xlf
+++ b/frontend/src/locale/messages.es.xlf
@@ -1722,6 +1722,11 @@
         <source>Item request failed.</source>
         <target>Item request failed.</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.recipeSearchError" datatype="html">
+        <source>Unable to search recipes.</source>
+        <target>Unable to search recipes.</target>
+      </trans-unit>
       <trans-unit id="admin.items.create.englishRequired" datatype="html">
         <source>English (US) or English (GB) name is required.</source>
         <target>English (US) or English (GB) name is required.</target>
@@ -1787,6 +1792,15 @@
         <source>All expansions</source>
         <target>All expansions</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.filter.anyClass" datatype="html">
+        <source>All classes</source>
+        <target>All classes</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anySubclass" datatype="html">
+        <source>All subclasses</source>
+        <target>All subclasses</target>
+      </trans-unit>
       <trans-unit id="admin.items.panel.create" datatype="html">
         <source>Create manual item</source>
         <target>Create manual item</target>
@@ -1798,6 +1812,11 @@
       <trans-unit id="admin.items.panel.edit" datatype="html">
         <source>Edit item override</source>
         <target>Edit item override</target>
+      </trans-unit>
+
+      <trans-unit id="admin.items.panel.recipe" datatype="html">
+        <source>Associate recipe</source>
+        <target>Associate recipe</target>
       </trans-unit>
       <trans-unit id="admin.items.deleteConfirm" datatype="html">
         <source>Delete this item override? Base item data will be inherited again.</source>

--- a/frontend/src/locale/messages.fr.xlf
+++ b/frontend/src/locale/messages.fr.xlf
@@ -1770,6 +1770,23 @@
         <source>No override</source>
         <target>No override</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.filter.anyRecipe" datatype="html">
+        <source>All recipe states</source>
+        <target>All recipe states</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.hasRecipe" datatype="html">
+        <source>Has recipe</source>
+        <target>Has recipe</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.noRecipe" datatype="html">
+        <source>No recipe</source>
+        <target>No recipe</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anyExpansion" datatype="html">
+        <source>All expansions</source>
+        <target>All expansions</target>
+      </trans-unit>
       <trans-unit id="admin.items.panel.create" datatype="html">
         <source>Create manual item</source>
         <target>Create manual item</target>

--- a/frontend/src/locale/messages.fr.xlf
+++ b/frontend/src/locale/messages.fr.xlf
@@ -1702,6 +1702,94 @@
           <context context-type="linenumber">78</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="route.admin.items" datatype="html">
+        <source>Items</source>
+        <target>Items</target>
+      </trans-unit>
+      <trans-unit id="admin.items.loadError" datatype="html">
+        <source>Unable to load items.</source>
+        <target>Unable to load items.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.detailError" datatype="html">
+        <source>Unable to load item details.</source>
+        <target>Unable to load item details.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.compareError" datatype="html">
+        <source>Unable to compare item with Blizzard API.</source>
+        <target>Unable to compare item with Blizzard API.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.mutationError" datatype="html">
+        <source>Item request failed.</source>
+        <target>Item request failed.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.create.englishRequired" datatype="html">
+        <source>English (US) or English (GB) name is required.</source>
+        <target>English (US) or English (GB) name is required.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.id" datatype="html">
+        <source>Item ID</source>
+        <target>Item ID</target>
+      </trans-unit>
+      <trans-unit id="admin.items.unnamed" datatype="html">
+        <source>Unnamed item</source>
+        <target>Unnamed item</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.name" datatype="html">
+        <source>Name</source>
+        <target>Name</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.quality" datatype="html">
+        <source>Quality</source>
+        <target>Quality</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.class" datatype="html">
+        <source>Class</source>
+        <target>Class</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.expansion" datatype="html">
+        <source>Expansion</source>
+        <target>Expansion</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.state" datatype="html">
+        <source>State</source>
+        <target>State</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.actions" datatype="html">
+        <source>Actions</source>
+        <target>Actions</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anyOverride" datatype="html">
+        <source>All override states</source>
+        <target>All override states</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.hasOverride" datatype="html">
+        <source>Has override</source>
+        <target>Has override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.noOverride" datatype="html">
+        <source>No override</source>
+        <target>No override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.create" datatype="html">
+        <source>Create manual item</source>
+        <target>Create manual item</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.compare" datatype="html">
+        <source>Compare Blizzard API</source>
+        <target>Compare Blizzard API</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.edit" datatype="html">
+        <source>Edit item override</source>
+        <target>Edit item override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.deleteConfirm" datatype="html">
+        <source>Delete this item override? Base item data will be inherited again.</source>
+        <target>Delete this item override? Base item data will be inherited again.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.form.classSubclassRequired" datatype="html">
+        <source>Class ID and subclass ID are required together.</source>
+        <target>Class ID and subclass ID are required together.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/frontend/src/locale/messages.fr.xlf
+++ b/frontend/src/locale/messages.fr.xlf
@@ -1722,6 +1722,11 @@
         <source>Item request failed.</source>
         <target>Item request failed.</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.recipeSearchError" datatype="html">
+        <source>Unable to search recipes.</source>
+        <target>Unable to search recipes.</target>
+      </trans-unit>
       <trans-unit id="admin.items.create.englishRequired" datatype="html">
         <source>English (US) or English (GB) name is required.</source>
         <target>English (US) or English (GB) name is required.</target>
@@ -1787,6 +1792,15 @@
         <source>All expansions</source>
         <target>All expansions</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.filter.anyClass" datatype="html">
+        <source>All classes</source>
+        <target>All classes</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anySubclass" datatype="html">
+        <source>All subclasses</source>
+        <target>All subclasses</target>
+      </trans-unit>
       <trans-unit id="admin.items.panel.create" datatype="html">
         <source>Create manual item</source>
         <target>Create manual item</target>
@@ -1798,6 +1812,11 @@
       <trans-unit id="admin.items.panel.edit" datatype="html">
         <source>Edit item override</source>
         <target>Edit item override</target>
+      </trans-unit>
+
+      <trans-unit id="admin.items.panel.recipe" datatype="html">
+        <source>Associate recipe</source>
+        <target>Associate recipe</target>
       </trans-unit>
       <trans-unit id="admin.items.deleteConfirm" datatype="html">
         <source>Delete this item override? Base item data will be inherited again.</source>

--- a/frontend/src/locale/messages.it.xlf
+++ b/frontend/src/locale/messages.it.xlf
@@ -1770,6 +1770,23 @@
         <source>No override</source>
         <target>No override</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.filter.anyRecipe" datatype="html">
+        <source>All recipe states</source>
+        <target>All recipe states</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.hasRecipe" datatype="html">
+        <source>Has recipe</source>
+        <target>Has recipe</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.noRecipe" datatype="html">
+        <source>No recipe</source>
+        <target>No recipe</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anyExpansion" datatype="html">
+        <source>All expansions</source>
+        <target>All expansions</target>
+      </trans-unit>
       <trans-unit id="admin.items.panel.create" datatype="html">
         <source>Create manual item</source>
         <target>Create manual item</target>

--- a/frontend/src/locale/messages.it.xlf
+++ b/frontend/src/locale/messages.it.xlf
@@ -1702,6 +1702,94 @@
           <context context-type="linenumber">78</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="route.admin.items" datatype="html">
+        <source>Items</source>
+        <target>Items</target>
+      </trans-unit>
+      <trans-unit id="admin.items.loadError" datatype="html">
+        <source>Unable to load items.</source>
+        <target>Unable to load items.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.detailError" datatype="html">
+        <source>Unable to load item details.</source>
+        <target>Unable to load item details.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.compareError" datatype="html">
+        <source>Unable to compare item with Blizzard API.</source>
+        <target>Unable to compare item with Blizzard API.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.mutationError" datatype="html">
+        <source>Item request failed.</source>
+        <target>Item request failed.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.create.englishRequired" datatype="html">
+        <source>English (US) or English (GB) name is required.</source>
+        <target>English (US) or English (GB) name is required.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.id" datatype="html">
+        <source>Item ID</source>
+        <target>Item ID</target>
+      </trans-unit>
+      <trans-unit id="admin.items.unnamed" datatype="html">
+        <source>Unnamed item</source>
+        <target>Unnamed item</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.name" datatype="html">
+        <source>Name</source>
+        <target>Name</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.quality" datatype="html">
+        <source>Quality</source>
+        <target>Quality</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.class" datatype="html">
+        <source>Class</source>
+        <target>Class</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.expansion" datatype="html">
+        <source>Expansion</source>
+        <target>Expansion</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.state" datatype="html">
+        <source>State</source>
+        <target>State</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.actions" datatype="html">
+        <source>Actions</source>
+        <target>Actions</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anyOverride" datatype="html">
+        <source>All override states</source>
+        <target>All override states</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.hasOverride" datatype="html">
+        <source>Has override</source>
+        <target>Has override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.noOverride" datatype="html">
+        <source>No override</source>
+        <target>No override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.create" datatype="html">
+        <source>Create manual item</source>
+        <target>Create manual item</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.compare" datatype="html">
+        <source>Compare Blizzard API</source>
+        <target>Compare Blizzard API</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.edit" datatype="html">
+        <source>Edit item override</source>
+        <target>Edit item override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.deleteConfirm" datatype="html">
+        <source>Delete this item override? Base item data will be inherited again.</source>
+        <target>Delete this item override? Base item data will be inherited again.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.form.classSubclassRequired" datatype="html">
+        <source>Class ID and subclass ID are required together.</source>
+        <target>Class ID and subclass ID are required together.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/frontend/src/locale/messages.it.xlf
+++ b/frontend/src/locale/messages.it.xlf
@@ -1722,6 +1722,11 @@
         <source>Item request failed.</source>
         <target>Item request failed.</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.recipeSearchError" datatype="html">
+        <source>Unable to search recipes.</source>
+        <target>Unable to search recipes.</target>
+      </trans-unit>
       <trans-unit id="admin.items.create.englishRequired" datatype="html">
         <source>English (US) or English (GB) name is required.</source>
         <target>English (US) or English (GB) name is required.</target>
@@ -1787,6 +1792,15 @@
         <source>All expansions</source>
         <target>All expansions</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.filter.anyClass" datatype="html">
+        <source>All classes</source>
+        <target>All classes</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anySubclass" datatype="html">
+        <source>All subclasses</source>
+        <target>All subclasses</target>
+      </trans-unit>
       <trans-unit id="admin.items.panel.create" datatype="html">
         <source>Create manual item</source>
         <target>Create manual item</target>
@@ -1798,6 +1812,11 @@
       <trans-unit id="admin.items.panel.edit" datatype="html">
         <source>Edit item override</source>
         <target>Edit item override</target>
+      </trans-unit>
+
+      <trans-unit id="admin.items.panel.recipe" datatype="html">
+        <source>Associate recipe</source>
+        <target>Associate recipe</target>
       </trans-unit>
       <trans-unit id="admin.items.deleteConfirm" datatype="html">
         <source>Delete this item override? Base item data will be inherited again.</source>

--- a/frontend/src/locale/messages.ko.xlf
+++ b/frontend/src/locale/messages.ko.xlf
@@ -1770,6 +1770,23 @@
         <source>No override</source>
         <target>No override</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.filter.anyRecipe" datatype="html">
+        <source>All recipe states</source>
+        <target>All recipe states</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.hasRecipe" datatype="html">
+        <source>Has recipe</source>
+        <target>Has recipe</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.noRecipe" datatype="html">
+        <source>No recipe</source>
+        <target>No recipe</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anyExpansion" datatype="html">
+        <source>All expansions</source>
+        <target>All expansions</target>
+      </trans-unit>
       <trans-unit id="admin.items.panel.create" datatype="html">
         <source>Create manual item</source>
         <target>Create manual item</target>

--- a/frontend/src/locale/messages.ko.xlf
+++ b/frontend/src/locale/messages.ko.xlf
@@ -1702,6 +1702,94 @@
           <context context-type="linenumber">78</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="route.admin.items" datatype="html">
+        <source>Items</source>
+        <target>Items</target>
+      </trans-unit>
+      <trans-unit id="admin.items.loadError" datatype="html">
+        <source>Unable to load items.</source>
+        <target>Unable to load items.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.detailError" datatype="html">
+        <source>Unable to load item details.</source>
+        <target>Unable to load item details.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.compareError" datatype="html">
+        <source>Unable to compare item with Blizzard API.</source>
+        <target>Unable to compare item with Blizzard API.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.mutationError" datatype="html">
+        <source>Item request failed.</source>
+        <target>Item request failed.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.create.englishRequired" datatype="html">
+        <source>English (US) or English (GB) name is required.</source>
+        <target>English (US) or English (GB) name is required.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.id" datatype="html">
+        <source>Item ID</source>
+        <target>Item ID</target>
+      </trans-unit>
+      <trans-unit id="admin.items.unnamed" datatype="html">
+        <source>Unnamed item</source>
+        <target>Unnamed item</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.name" datatype="html">
+        <source>Name</source>
+        <target>Name</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.quality" datatype="html">
+        <source>Quality</source>
+        <target>Quality</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.class" datatype="html">
+        <source>Class</source>
+        <target>Class</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.expansion" datatype="html">
+        <source>Expansion</source>
+        <target>Expansion</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.state" datatype="html">
+        <source>State</source>
+        <target>State</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.actions" datatype="html">
+        <source>Actions</source>
+        <target>Actions</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anyOverride" datatype="html">
+        <source>All override states</source>
+        <target>All override states</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.hasOverride" datatype="html">
+        <source>Has override</source>
+        <target>Has override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.noOverride" datatype="html">
+        <source>No override</source>
+        <target>No override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.create" datatype="html">
+        <source>Create manual item</source>
+        <target>Create manual item</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.compare" datatype="html">
+        <source>Compare Blizzard API</source>
+        <target>Compare Blizzard API</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.edit" datatype="html">
+        <source>Edit item override</source>
+        <target>Edit item override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.deleteConfirm" datatype="html">
+        <source>Delete this item override? Base item data will be inherited again.</source>
+        <target>Delete this item override? Base item data will be inherited again.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.form.classSubclassRequired" datatype="html">
+        <source>Class ID and subclass ID are required together.</source>
+        <target>Class ID and subclass ID are required together.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/frontend/src/locale/messages.ko.xlf
+++ b/frontend/src/locale/messages.ko.xlf
@@ -1722,6 +1722,11 @@
         <source>Item request failed.</source>
         <target>Item request failed.</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.recipeSearchError" datatype="html">
+        <source>Unable to search recipes.</source>
+        <target>Unable to search recipes.</target>
+      </trans-unit>
       <trans-unit id="admin.items.create.englishRequired" datatype="html">
         <source>English (US) or English (GB) name is required.</source>
         <target>English (US) or English (GB) name is required.</target>
@@ -1787,6 +1792,15 @@
         <source>All expansions</source>
         <target>All expansions</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.filter.anyClass" datatype="html">
+        <source>All classes</source>
+        <target>All classes</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anySubclass" datatype="html">
+        <source>All subclasses</source>
+        <target>All subclasses</target>
+      </trans-unit>
       <trans-unit id="admin.items.panel.create" datatype="html">
         <source>Create manual item</source>
         <target>Create manual item</target>
@@ -1798,6 +1812,11 @@
       <trans-unit id="admin.items.panel.edit" datatype="html">
         <source>Edit item override</source>
         <target>Edit item override</target>
+      </trans-unit>
+
+      <trans-unit id="admin.items.panel.recipe" datatype="html">
+        <source>Associate recipe</source>
+        <target>Associate recipe</target>
       </trans-unit>
       <trans-unit id="admin.items.deleteConfirm" datatype="html">
         <source>Delete this item override? Base item data will be inherited again.</source>

--- a/frontend/src/locale/messages.pt.xlf
+++ b/frontend/src/locale/messages.pt.xlf
@@ -1770,6 +1770,23 @@
         <source>No override</source>
         <target>No override</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.filter.anyRecipe" datatype="html">
+        <source>All recipe states</source>
+        <target>All recipe states</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.hasRecipe" datatype="html">
+        <source>Has recipe</source>
+        <target>Has recipe</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.noRecipe" datatype="html">
+        <source>No recipe</source>
+        <target>No recipe</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anyExpansion" datatype="html">
+        <source>All expansions</source>
+        <target>All expansions</target>
+      </trans-unit>
       <trans-unit id="admin.items.panel.create" datatype="html">
         <source>Create manual item</source>
         <target>Create manual item</target>

--- a/frontend/src/locale/messages.pt.xlf
+++ b/frontend/src/locale/messages.pt.xlf
@@ -1702,6 +1702,94 @@
           <context context-type="linenumber">78</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="route.admin.items" datatype="html">
+        <source>Items</source>
+        <target>Items</target>
+      </trans-unit>
+      <trans-unit id="admin.items.loadError" datatype="html">
+        <source>Unable to load items.</source>
+        <target>Unable to load items.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.detailError" datatype="html">
+        <source>Unable to load item details.</source>
+        <target>Unable to load item details.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.compareError" datatype="html">
+        <source>Unable to compare item with Blizzard API.</source>
+        <target>Unable to compare item with Blizzard API.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.mutationError" datatype="html">
+        <source>Item request failed.</source>
+        <target>Item request failed.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.create.englishRequired" datatype="html">
+        <source>English (US) or English (GB) name is required.</source>
+        <target>English (US) or English (GB) name is required.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.id" datatype="html">
+        <source>Item ID</source>
+        <target>Item ID</target>
+      </trans-unit>
+      <trans-unit id="admin.items.unnamed" datatype="html">
+        <source>Unnamed item</source>
+        <target>Unnamed item</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.name" datatype="html">
+        <source>Name</source>
+        <target>Name</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.quality" datatype="html">
+        <source>Quality</source>
+        <target>Quality</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.class" datatype="html">
+        <source>Class</source>
+        <target>Class</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.expansion" datatype="html">
+        <source>Expansion</source>
+        <target>Expansion</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.state" datatype="html">
+        <source>State</source>
+        <target>State</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.actions" datatype="html">
+        <source>Actions</source>
+        <target>Actions</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anyOverride" datatype="html">
+        <source>All override states</source>
+        <target>All override states</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.hasOverride" datatype="html">
+        <source>Has override</source>
+        <target>Has override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.noOverride" datatype="html">
+        <source>No override</source>
+        <target>No override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.create" datatype="html">
+        <source>Create manual item</source>
+        <target>Create manual item</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.compare" datatype="html">
+        <source>Compare Blizzard API</source>
+        <target>Compare Blizzard API</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.edit" datatype="html">
+        <source>Edit item override</source>
+        <target>Edit item override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.deleteConfirm" datatype="html">
+        <source>Delete this item override? Base item data will be inherited again.</source>
+        <target>Delete this item override? Base item data will be inherited again.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.form.classSubclassRequired" datatype="html">
+        <source>Class ID and subclass ID are required together.</source>
+        <target>Class ID and subclass ID are required together.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/frontend/src/locale/messages.pt.xlf
+++ b/frontend/src/locale/messages.pt.xlf
@@ -1722,6 +1722,11 @@
         <source>Item request failed.</source>
         <target>Item request failed.</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.recipeSearchError" datatype="html">
+        <source>Unable to search recipes.</source>
+        <target>Unable to search recipes.</target>
+      </trans-unit>
       <trans-unit id="admin.items.create.englishRequired" datatype="html">
         <source>English (US) or English (GB) name is required.</source>
         <target>English (US) or English (GB) name is required.</target>
@@ -1787,6 +1792,15 @@
         <source>All expansions</source>
         <target>All expansions</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.filter.anyClass" datatype="html">
+        <source>All classes</source>
+        <target>All classes</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anySubclass" datatype="html">
+        <source>All subclasses</source>
+        <target>All subclasses</target>
+      </trans-unit>
       <trans-unit id="admin.items.panel.create" datatype="html">
         <source>Create manual item</source>
         <target>Create manual item</target>
@@ -1798,6 +1812,11 @@
       <trans-unit id="admin.items.panel.edit" datatype="html">
         <source>Edit item override</source>
         <target>Edit item override</target>
+      </trans-unit>
+
+      <trans-unit id="admin.items.panel.recipe" datatype="html">
+        <source>Associate recipe</source>
+        <target>Associate recipe</target>
       </trans-unit>
       <trans-unit id="admin.items.deleteConfirm" datatype="html">
         <source>Delete this item override? Base item data will be inherited again.</source>

--- a/frontend/src/locale/messages.ru.xlf
+++ b/frontend/src/locale/messages.ru.xlf
@@ -1770,6 +1770,23 @@
         <source>No override</source>
         <target>No override</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.filter.anyRecipe" datatype="html">
+        <source>All recipe states</source>
+        <target>All recipe states</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.hasRecipe" datatype="html">
+        <source>Has recipe</source>
+        <target>Has recipe</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.noRecipe" datatype="html">
+        <source>No recipe</source>
+        <target>No recipe</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anyExpansion" datatype="html">
+        <source>All expansions</source>
+        <target>All expansions</target>
+      </trans-unit>
       <trans-unit id="admin.items.panel.create" datatype="html">
         <source>Create manual item</source>
         <target>Create manual item</target>

--- a/frontend/src/locale/messages.ru.xlf
+++ b/frontend/src/locale/messages.ru.xlf
@@ -1702,6 +1702,94 @@
           <context context-type="linenumber">78</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="route.admin.items" datatype="html">
+        <source>Items</source>
+        <target>Items</target>
+      </trans-unit>
+      <trans-unit id="admin.items.loadError" datatype="html">
+        <source>Unable to load items.</source>
+        <target>Unable to load items.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.detailError" datatype="html">
+        <source>Unable to load item details.</source>
+        <target>Unable to load item details.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.compareError" datatype="html">
+        <source>Unable to compare item with Blizzard API.</source>
+        <target>Unable to compare item with Blizzard API.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.mutationError" datatype="html">
+        <source>Item request failed.</source>
+        <target>Item request failed.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.create.englishRequired" datatype="html">
+        <source>English (US) or English (GB) name is required.</source>
+        <target>English (US) or English (GB) name is required.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.id" datatype="html">
+        <source>Item ID</source>
+        <target>Item ID</target>
+      </trans-unit>
+      <trans-unit id="admin.items.unnamed" datatype="html">
+        <source>Unnamed item</source>
+        <target>Unnamed item</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.name" datatype="html">
+        <source>Name</source>
+        <target>Name</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.quality" datatype="html">
+        <source>Quality</source>
+        <target>Quality</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.class" datatype="html">
+        <source>Class</source>
+        <target>Class</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.expansion" datatype="html">
+        <source>Expansion</source>
+        <target>Expansion</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.state" datatype="html">
+        <source>State</source>
+        <target>State</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.actions" datatype="html">
+        <source>Actions</source>
+        <target>Actions</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anyOverride" datatype="html">
+        <source>All override states</source>
+        <target>All override states</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.hasOverride" datatype="html">
+        <source>Has override</source>
+        <target>Has override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.noOverride" datatype="html">
+        <source>No override</source>
+        <target>No override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.create" datatype="html">
+        <source>Create manual item</source>
+        <target>Create manual item</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.compare" datatype="html">
+        <source>Compare Blizzard API</source>
+        <target>Compare Blizzard API</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.edit" datatype="html">
+        <source>Edit item override</source>
+        <target>Edit item override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.deleteConfirm" datatype="html">
+        <source>Delete this item override? Base item data will be inherited again.</source>
+        <target>Delete this item override? Base item data will be inherited again.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.form.classSubclassRequired" datatype="html">
+        <source>Class ID and subclass ID are required together.</source>
+        <target>Class ID and subclass ID are required together.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/frontend/src/locale/messages.ru.xlf
+++ b/frontend/src/locale/messages.ru.xlf
@@ -1722,6 +1722,11 @@
         <source>Item request failed.</source>
         <target>Item request failed.</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.recipeSearchError" datatype="html">
+        <source>Unable to search recipes.</source>
+        <target>Unable to search recipes.</target>
+      </trans-unit>
       <trans-unit id="admin.items.create.englishRequired" datatype="html">
         <source>English (US) or English (GB) name is required.</source>
         <target>English (US) or English (GB) name is required.</target>
@@ -1787,6 +1792,15 @@
         <source>All expansions</source>
         <target>All expansions</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.filter.anyClass" datatype="html">
+        <source>All classes</source>
+        <target>All classes</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anySubclass" datatype="html">
+        <source>All subclasses</source>
+        <target>All subclasses</target>
+      </trans-unit>
       <trans-unit id="admin.items.panel.create" datatype="html">
         <source>Create manual item</source>
         <target>Create manual item</target>
@@ -1798,6 +1812,11 @@
       <trans-unit id="admin.items.panel.edit" datatype="html">
         <source>Edit item override</source>
         <target>Edit item override</target>
+      </trans-unit>
+
+      <trans-unit id="admin.items.panel.recipe" datatype="html">
+        <source>Associate recipe</source>
+        <target>Associate recipe</target>
       </trans-unit>
       <trans-unit id="admin.items.deleteConfirm" datatype="html">
         <source>Delete this item override? Base item data will be inherited again.</source>

--- a/frontend/src/locale/messages.xlf
+++ b/frontend/src/locale/messages.xlf
@@ -6,14 +6,14 @@
         <source>Search</source>
         <context-group purpose="location">
           <context context-type="sourcefile">ethereal-ui/src/lib/components/forms/search-input.component.ts</context>
-          <context context-type="linenumber">71</context>
+          <context context-type="linenumber">82</context>
         </context-group>
       </trans-unit>
       <trans-unit id="search.placeholder" datatype="html">
         <source>Search items, reagents, or recipes...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">ethereal-ui/src/lib/components/forms/search-input.component.ts</context>
-          <context context-type="linenumber">73</context>
+          <context context-type="linenumber">85</context>
         </context-group>
       </trans-unit>
       <trans-unit id="filters.aria" datatype="html">
@@ -76,14 +76,14 @@
         <source> <x id="INTERPOLATION" equiv-text="{{ eyebrow() }}"/> </source>
         <context-group purpose="location">
           <context context-type="sourcefile">ethereal-ui/src/lib/components/shell/page-frame.component.ts</context>
-          <context context-type="linenumber">24,26</context>
+          <context context-type="linenumber">23,25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="pageFrame.title" datatype="html">
         <source> <x id="INTERPOLATION" equiv-text="{{ title() }}"/> </source>
         <context-group purpose="location">
           <context context-type="sourcefile">ethereal-ui/src/lib/components/shell/page-frame.component.ts</context>
-          <context context-type="linenumber">31,32</context>
+          <context context-type="linenumber">30,32</context>
         </context-group>
       </trans-unit>
       <trans-unit id="topNav.openNavigation" datatype="html">
@@ -164,11 +164,11 @@
         <source> <x id="INTERPOLATION" equiv-text="{{ emptyMessage() }}"/> </source>
         <context-group purpose="location">
           <context context-type="sourcefile">ethereal-ui/src/lib/components/table/table.component.ts</context>
-          <context context-type="linenumber">214,215</context>
+          <context context-type="linenumber">215,216</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">ethereal-ui/src/lib/components/table/table.component.ts</context>
-          <context context-type="linenumber">318,319</context>
+          <context context-type="linenumber">319,320</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quality.common" datatype="html">
@@ -179,7 +179,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/utils/filter.ts</context>
-          <context context-type="linenumber">47</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quality.uncommon" datatype="html">
@@ -190,7 +190,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/utils/filter.ts</context>
-          <context context-type="linenumber">49</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quality.rare" datatype="html">
@@ -201,7 +201,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/utils/filter.ts</context>
-          <context context-type="linenumber">51</context>
+          <context context-type="linenumber">53</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quality.epic" datatype="html">
@@ -212,7 +212,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/utils/filter.ts</context>
-          <context context-type="linenumber">53</context>
+          <context context-type="linenumber">55</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quality.legendary" datatype="html">
@@ -223,7 +223,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/utils/filter.ts</context>
-          <context context-type="linenumber">55</context>
+          <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
       <trans-unit id="route.login" datatype="html">
@@ -265,34 +265,41 @@
           <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="route.admin.items" datatype="html">
+        <source>Items</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.routes.ts</context>
+          <context context-type="linenumber">86</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="route.auctions" datatype="html">
         <source>Auctions</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.routes.ts</context>
-          <context context-type="linenumber">95</context>
+          <context context-type="linenumber">104</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.routes.ts</context>
-          <context context-type="linenumber">123</context>
+          <context context-type="linenumber">132</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">182</context>
+          <context context-type="linenumber">167</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">309</context>
+          <context context-type="linenumber">294</context>
         </context-group>
       </trans-unit>
       <trans-unit id="route.crafting" datatype="html">
         <source>Crafting</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.routes.ts</context>
-          <context context-type="linenumber">134</context>
+          <context context-type="linenumber">143</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.routes.ts</context>
-          <context context-type="linenumber">162</context>
+          <context context-type="linenumber">171</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/crafting/crafting-browser.page.ts</context>
@@ -300,7 +307,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">291,292</context>
+          <context context-type="linenumber">259,260</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.fallbackCharacter.name" datatype="html">
@@ -332,7 +339,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/admin/expansions/expansion-ranges-table.columns.ts</context>
-          <context context-type="linenumber">72</context>
+          <context context-type="linenumber">130</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/admin/user-administration/user-administration-table.columns.ts</context>
@@ -559,7 +566,7 @@
         <source>Has Recipe</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/utils/filter.ts</context>
-          <context context-type="linenumber">33</context>
+          <context context-type="linenumber">35</context>
         </context-group>
       </trans-unit>
       <trans-unit id="admin.expansions.jobs.apply.running" datatype="html">
@@ -591,7 +598,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="admin.expansions.jobs.generic" datatype="html">
-        <source>Admin item job</source>
+        <source>Admin job</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/admin/expansions/expansion-job-summary.ts</context>
           <context context-type="linenumber">18</context>
@@ -608,63 +615,71 @@
         <source>Name</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/admin/expansions/expansion-ranges-table.columns.ts</context>
-          <context context-type="linenumber">15</context>
+          <context context-type="linenumber">23</context>
         </context-group>
       </trans-unit>
       <trans-unit id="admin.expansions.catalog.slug" datatype="html">
         <source>Slug</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/admin/expansions/expansion-ranges-table.columns.ts</context>
-          <context context-type="linenumber">19</context>
+          <context context-type="linenumber">31</context>
         </context-group>
       </trans-unit>
       <trans-unit id="admin.expansions.catalog.majorVersion" datatype="html">
         <source>Major version</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/admin/expansions/expansion-ranges-table.columns.ts</context>
-          <context context-type="linenumber">23</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="admin.expansions.catalog.displayOrder" datatype="html">
         <source>Display order</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/admin/expansions/expansion-ranges-table.columns.ts</context>
-          <context context-type="linenumber">27</context>
+          <context context-type="linenumber">47</context>
         </context-group>
       </trans-unit>
       <trans-unit id="admin.expansions.ranges.expansion" datatype="html">
         <source>Expansion</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/admin/expansions/expansion-ranges-table.columns.ts</context>
-          <context context-type="linenumber">45</context>
+          <context context-type="linenumber">79</context>
         </context-group>
       </trans-unit>
       <trans-unit id="admin.expansions.ranges.startItemId" datatype="html">
         <source>Start item ID</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/admin/expansions/expansion-ranges-table.columns.ts</context>
-          <context context-type="linenumber">49</context>
+          <context context-type="linenumber">87</context>
         </context-group>
       </trans-unit>
       <trans-unit id="admin.expansions.ranges.endItemId" datatype="html">
         <source>End item ID</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/admin/expansions/expansion-ranges-table.columns.ts</context>
-          <context context-type="linenumber">53</context>
+          <context context-type="linenumber">95</context>
         </context-group>
       </trans-unit>
       <trans-unit id="admin.expansions.ranges.source" datatype="html">
         <source>Source</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/admin/expansions/expansion-ranges-table.columns.ts</context>
-          <context context-type="linenumber">57</context>
+          <context context-type="linenumber">103</context>
         </context-group>
       </trans-unit>
       <trans-unit id="common.yes" datatype="html">
         <source>Yes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/admin/expansions/expansion-ranges-table.columns.ts</context>
-          <context context-type="linenumber">64</context>
+          <context context-type="linenumber">118</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/admin-item-create-form.component.ts</context>
+          <context context-type="linenumber">206</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/admin-item-override-form.component.ts</context>
+          <context context-type="linenumber">385</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/admin/user-administration/user-administration-table.columns.ts</context>
@@ -675,7 +690,15 @@
         <source>No</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/admin/expansions/expansion-ranges-table.columns.ts</context>
-          <context context-type="linenumber">64</context>
+          <context context-type="linenumber">118</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/admin-item-create-form.component.ts</context>
+          <context context-type="linenumber">207</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/admin-item-override-form.component.ts</context>
+          <context context-type="linenumber">386</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/admin/user-administration/user-administration-table.columns.ts</context>
@@ -686,7 +709,222 @@
         <source>Note</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/admin/expansions/expansion-ranges-table.columns.ts</context>
-          <context context-type="linenumber">67</context>
+          <context context-type="linenumber">121</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.create.englishRequired" datatype="html">
+        <source>English (US) or English (GB) name is required.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/admin-item-create-form.component.ts</context>
+          <context context-type="linenumber">241</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.unnamed" datatype="html">
+        <source>Unnamed item</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/admin-item-override-form.component.ts</context>
+          <context context-type="linenumber">488</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/admin-items-table.columns.ts</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.form.classSubclassRequired" datatype="html">
+        <source>Class ID and subclass ID are required together.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/admin-item-override-form.component.ts</context>
+          <context context-type="linenumber">517</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.loadError" datatype="html">
+        <source>Unable to load items.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/admin-item.service.ts</context>
+          <context context-type="linenumber">73</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.detailError" datatype="html">
+        <source>Unable to load item details.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/admin-item.service.ts</context>
+          <context context-type="linenumber">95</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.recipeSearchError" datatype="html">
+        <source>Unable to search recipes.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/admin-item.service.ts</context>
+          <context context-type="linenumber">138</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.compareError" datatype="html">
+        <source>Unable to compare item with Blizzard API.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/admin-item.service.ts</context>
+          <context context-type="linenumber">169</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.mutationError" datatype="html">
+        <source>Item request failed.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/admin-item.service.ts</context>
+          <context context-type="linenumber">192</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.table.id" datatype="html">
+        <source>Item ID</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/admin-items-table.columns.ts</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/admin-items-table.columns.ts</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.table.name" datatype="html">
+        <source>Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/admin-items-table.columns.ts</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.table.quality" datatype="html">
+        <source>Quality</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/admin-items-table.columns.ts</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/admin-items-table.columns.ts</context>
+          <context context-type="linenumber">55</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.table.class" datatype="html">
+        <source>Class</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/admin-items-table.columns.ts</context>
+          <context context-type="linenumber">62</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.table.expansion" datatype="html">
+        <source>Expansion</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/admin-items-table.columns.ts</context>
+          <context context-type="linenumber">72</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.table.state" datatype="html">
+        <source>State</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/admin-items-table.columns.ts</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.table.actions" datatype="html">
+        <source>Actions</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/admin-items-table.columns.ts</context>
+          <context context-type="linenumber">93</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anyOverride" datatype="html">
+        <source>All override states</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/items.page.ts</context>
+          <context context-type="linenumber">97</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.hasOverride" datatype="html">
+        <source>Has override</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/items.page.ts</context>
+          <context context-type="linenumber">98</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.noOverride" datatype="html">
+        <source>No override</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/items.page.ts</context>
+          <context context-type="linenumber">99</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anyRecipe" datatype="html">
+        <source>All recipe states</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/items.page.ts</context>
+          <context context-type="linenumber">102</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.hasRecipe" datatype="html">
+        <source>Has recipe</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/items.page.ts</context>
+          <context context-type="linenumber">103</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.noRecipe" datatype="html">
+        <source>No recipe</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/items.page.ts</context>
+          <context context-type="linenumber">104</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anyClass" datatype="html">
+        <source>All classes</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/items.page.ts</context>
+          <context context-type="linenumber">113</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anySubclass" datatype="html">
+        <source>All subclasses</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/items.page.ts</context>
+          <context context-type="linenumber">117</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anyExpansion" datatype="html">
+        <source>All expansions</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/items.page.ts</context>
+          <context context-type="linenumber">121</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.create" datatype="html">
+        <source>Create manual item</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/items.page.ts</context>
+          <context context-type="linenumber">151</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.compare" datatype="html">
+        <source>Compare Blizzard API</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/items.page.ts</context>
+          <context context-type="linenumber">153</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.edit" datatype="html">
+        <source>Edit item override</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/items.page.ts</context>
+          <context context-type="linenumber">155</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.recipe" datatype="html">
+        <source>Associate recipe</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/items.page.ts</context>
+          <context context-type="linenumber">157</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="admin.items.deleteConfirm" datatype="html">
+        <source>Delete this item override? Base item data will be inherited again.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/admin/items/items.page.ts</context>
+          <context context-type="linenumber">321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="common.email" datatype="html">
@@ -818,7 +1056,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">394,395</context>
+          <context context-type="linenumber">362,363</context>
         </context-group>
       </trans-unit>
       <trans-unit id="crafting.column.roi" datatype="html">
@@ -837,7 +1075,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">398,399</context>
+          <context context-type="linenumber">366,367</context>
         </context-group>
       </trans-unit>
       <trans-unit id="crafting.column.trend" datatype="html">
@@ -1200,7 +1438,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">639</context>
+          <context context-type="linenumber">624</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.heatmapAvgPrice" datatype="html">
@@ -1210,437 +1448,437 @@
           <context context-type="linenumber">358</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="itemDetail.loadError" datatype="html">
+        <source> Could not load this item. Try again from the market browser. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
+          <context context-type="linenumber">10,12</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="itemDetail.breadcrumb" datatype="html">
         <source>Breadcrumb</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">17,18</context>
+          <context context-type="linenumber">16,17</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.chartDataScope" datatype="html">
         <source>Chart data scope</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">65,66</context>
+          <context context-type="linenumber">61,62</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.realmScope" datatype="html">
         <source>Realm</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">77,79</context>
+          <context context-type="linenumber">73,74</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">669</context>
+          <context context-type="linenumber">654</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.regionScope" datatype="html">
         <source>Region</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">88,90</context>
+          <context context-type="linenumber">84,85</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">668</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="itemDetail.loadError" datatype="html">
-        <source> Could not load this item. Try again from the market browser. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">134,136</context>
+          <context context-type="linenumber">653</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.noDayValues" datatype="html">
         <source>No values for this day</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">144,147</context>
+          <context context-type="linenumber">98,100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.noHourValues" datatype="html">
         <source>No values for this hour</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">154,157</context>
+          <context context-type="linenumber">110,112</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.dailyMarket" datatype="html">
         <source>Daily market</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">191,192</context>
+          <context context-type="linenumber">153,154</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.range14Days" datatype="html">
         <source>14 days</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">194</context>
+          <context context-type="linenumber">156</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">208</context>
+          <context context-type="linenumber">171</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">222</context>
+          <context context-type="linenumber">186</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">469</context>
+          <context context-type="linenumber">400</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">481</context>
+          <context context-type="linenumber">413</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.dailyMarketDescription" datatype="html">
         <source>Average quantity per hour as bars; buyout spread and average as lines.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">198,202</context>
+          <context context-type="linenumber">160,164</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.hourlyMarket" datatype="html">
         <source>Hourly market</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">205,206</context>
+          <context context-type="linenumber">168,169</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.hourlyMarketDescription" datatype="html">
         <source>Listed quantity per hour over 14 days as bars; buyout spread and average as lines.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">212,216</context>
+          <context context-type="linenumber">175,179</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.hourlyPriceHeatmap" datatype="html">
         <source>Hourly price heatmap</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">219,220</context>
+          <context context-type="linenumber">183,184</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.hourlyPriceHeatmapDescription" datatype="html">
         <source>Average market unit price by day and hour.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">223,225</context>
+          <context context-type="linenumber">187,189</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.currentListings" datatype="html">
         <source>Current listings</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">237,239</context>
+          <context context-type="linenumber">204,206</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.listingsCount" datatype="html">
         <source>listings</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">241,243</context>
+          <context context-type="linenumber">208,210</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">153</context>
+          <context context-type="linenumber">139</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.unitPrice" datatype="html">
         <source>Unit price</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">250,251</context>
+          <context context-type="linenumber">217,218</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">335,336</context>
+          <context context-type="linenumber">303,304</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.quantity" datatype="html">
         <source>Quantity</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">251,253</context>
+          <context context-type="linenumber">218,220</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.noCurrentListings" datatype="html">
         <source> No current listings for this item. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">280,283</context>
+          <context context-type="linenumber">247,250</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">140</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.loadingRecipeAnalytics" datatype="html">
         <source> Loading recipe analytics... </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">295,298</context>
+          <context context-type="linenumber">263,265</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.recipes" datatype="html">
         <source>Recipes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">305</context>
+          <context context-type="linenumber">273</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.reagent" datatype="html">
         <source>Reagent</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">333,334</context>
+          <context context-type="linenumber">301,302</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.quantityShort" datatype="html">
         <source>Qty</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">335</context>
+          <context context-type="linenumber">303</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.lineTotal" datatype="html">
         <source>Line total</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">336,338</context>
+          <context context-type="linenumber">304,306</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.missingPrice" datatype="html">
         <source>missing price</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">351,352</context>
+          <context context-type="linenumber">319,320</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.craftedQty" datatype="html">
         <source>Crafted qty</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">382,383</context>
+          <context context-type="linenumber">350,351</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.reagentCost" datatype="html">
         <source>Reagent cost</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">386,387</context>
+          <context context-type="linenumber">354,355</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.outputUnit" datatype="html">
         <source>Output unit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">390,391</context>
+          <context context-type="linenumber">358,359</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.profitHidden" datatype="html">
         <source> Profit hidden until all reagents have prices. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">405,406</context>
+          <context context-type="linenumber">373,374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.craftingProfitRoi" datatype="html">
         <source>Crafting profit / ROI</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">466,467</context>
+          <context context-type="linenumber">397,398</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.craftingProfitDescription" datatype="html">
         <source>Daily profit and ROI for selected recipe. Missing points mean incomplete pricing.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">472,475</context>
+          <context context-type="linenumber">403,406</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.craftingProfitHeatmap" datatype="html">
         <source>Crafting profit heatmap</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">478,479</context>
+          <context context-type="linenumber">410,411</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.craftingProfitHeatmapDescription" datatype="html">
         <source>Average profit by day and hour for selected recipe.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">482,484</context>
+          <context context-type="linenumber">414,416</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.craftingAnalyticsError" datatype="html">
         <source> Could not load crafting analytics. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.html</context>
-          <context context-type="linenumber">493,495</context>
+          <context context-type="linenumber">425,427</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.eyebrow" datatype="html">
         <source>Item Codex</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">157</context>
+          <context context-type="linenumber">143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.heatmapProfit" datatype="html">
         <source>profit <x id="PH" equiv-text="formatCopperCurrency(cell.profit)"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">244</context>
+          <context context-type="linenumber">229</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.heatmapPrice" datatype="html">
         <source>price <x id="PH" equiv-text="formatCopperCurrency(cell.outputUnitPrice)"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">245</context>
+          <context context-type="linenumber">230</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.heatmapRoi" datatype="html">
         <source>ROI <x id="PH" equiv-text="this.formatRoi(cell.roiPercent)"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">246</context>
+          <context context-type="linenumber">231</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.backToMarket" datatype="html">
         <source>Back to market</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">397</context>
+          <context context-type="linenumber">382</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.dayLabel" datatype="html">
         <source>Day <x id="PH" equiv-text="Math.round(x) + 1"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">555</context>
+          <context context-type="linenumber">540</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.tooltip.date" datatype="html">
         <source>date</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">562</context>
+          <context context-type="linenumber">547</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.tooltip.avgQuantity" datatype="html">
         <source>avg quantity</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">564</context>
+          <context context-type="linenumber">549</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.tooltip.minQuantity" datatype="html">
         <source>min quantity</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">568</context>
+          <context context-type="linenumber">553</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.tooltip.maxQuantity" datatype="html">
         <source>max quantity</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">572</context>
+          <context context-type="linenumber">557</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.tooltip.minPrice" datatype="html">
         <source>min price</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">576</context>
+          <context context-type="linenumber">561</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">622</context>
+          <context context-type="linenumber">607</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.tooltip.p25Price" datatype="html">
         <source>p25 price</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">580</context>
+          <context context-type="linenumber">565</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.tooltip.avgPrice" datatype="html">
         <source>avg price</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">584</context>
+          <context context-type="linenumber">569</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">626</context>
+          <context context-type="linenumber">611</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.tooltip.p75Price" datatype="html">
         <source>p75 price</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">588</context>
+          <context context-type="linenumber">573</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.tooltip.maxPrice" datatype="html">
         <source>max price</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">592</context>
+          <context context-type="linenumber">577</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">630</context>
+          <context context-type="linenumber">615</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.tooltip.hour" datatype="html">
         <source>hour</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">610</context>
+          <context context-type="linenumber">595</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.tooltip.timestamp" datatype="html">
         <source>timestamp</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">614</context>
+          <context context-type="linenumber">599</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.tooltip.quantityPerHour" datatype="html">
         <source>quantity / hour</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">618</context>
+          <context context-type="linenumber">603</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.vsCommodity" datatype="html">
         <source><x id="PH" equiv-text="sign"/><x id="PH_1" equiv-text="this.formatDecimal(pct, &apos;1.1-1&apos;)"/>% vs commodity</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">645</context>
+          <context context-type="linenumber">630</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.scopePrice" datatype="html">
         <source><x id="PH" equiv-text="scope"/> price</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">674</context>
+          <context context-type="linenumber">659</context>
         </context-group>
       </trans-unit>
       <trans-unit id="itemDetail.scopeQuantity" datatype="html">
         <source><x id="PH" equiv-text="scope"/> quantity</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/market-browser/market-item-detail.page.ts</context>
-          <context context-type="linenumber">679</context>
+          <context context-type="linenumber">664</context>
         </context-group>
       </trans-unit>
       <trans-unit id="profile.eyebrow" datatype="html">
@@ -1654,28 +1892,28 @@
         <source>Email</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/profile/profile.page.html</context>
-          <context context-type="linenumber">15,16</context>
+          <context context-type="linenumber">10,11</context>
         </context-group>
       </trans-unit>
       <trans-unit id="profile.changePassword" datatype="html">
         <source> Change password </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/profile/profile.page.html</context>
-          <context context-type="linenumber">30,32</context>
+          <context context-type="linenumber">25,27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="profile.updatePassword" datatype="html">
         <source>Update password</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/profile/profile.page.html</context>
-          <context context-type="linenumber">107,109</context>
+          <context context-type="linenumber">102,104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="profile.signOut" datatype="html">
         <source>Sign out</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/profile/profile.page.html</context>
-          <context context-type="linenumber">114,115</context>
+          <context context-type="linenumber">109,110</context>
         </context-group>
       </trans-unit>
       <trans-unit id="profile.currentPassword" datatype="html">
@@ -1752,120 +1990,47 @@
           <context context-type="linenumber">30,32</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="realmPicker.loading" datatype="html">
-        <source> Loading realms... </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/select-realm/select-realm.page.html</context>
-          <context context-type="linenumber">37,39</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="realmPicker.realms" datatype="html">
         <source>Realms</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/select-realm/select-realm.page.html</context>
-          <context context-type="linenumber">44,45</context>
+          <context context-type="linenumber">40,41</context>
         </context-group>
       </trans-unit>
       <trans-unit id="realmPicker.empty" datatype="html">
         <source> No realms match your search. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/select-realm/select-realm.page.html</context>
-          <context context-type="linenumber">50,52</context>
+          <context context-type="linenumber">46,48</context>
         </context-group>
       </trans-unit>
       <trans-unit id="realmPicker.availableRealms" datatype="html">
         <source>Available realms</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/select-realm/select-realm.page.html</context>
-          <context context-type="linenumber">55,56</context>
+          <context context-type="linenumber">51,52</context>
         </context-group>
       </trans-unit>
       <trans-unit id="realmPicker.resultsPartial" datatype="html">
         <source>Showing <x id="PH" equiv-text="shown"/> of <x id="PH_1" equiv-text="total"/> realms</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/select-realm/select-realm.page.ts</context>
-          <context context-type="linenumber">57</context>
+          <context context-type="linenumber">58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="realmPicker.resultsTotal" datatype="html">
         <source><x id="PH" equiv-text="total"/> realms</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/select-realm/select-realm.page.ts</context>
-          <context context-type="linenumber">58</context>
+          <context context-type="linenumber">59</context>
         </context-group>
       </trans-unit>
       <trans-unit id="realmPicker.loadError" datatype="html">
         <source>Could not load realm list. Please try again later.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/select-realm/select-realm.page.ts</context>
-          <context context-type="linenumber">78</context>
+          <context context-type="linenumber">79</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="route.admin.items" datatype="html">
-        <source>Items</source>
-      </trans-unit>
-      <trans-unit id="admin.items.loadError" datatype="html">
-        <source>Unable to load items.</source>
-      </trans-unit>
-      <trans-unit id="admin.items.detailError" datatype="html">
-        <source>Unable to load item details.</source>
-      </trans-unit>
-      <trans-unit id="admin.items.compareError" datatype="html">
-        <source>Unable to compare item with Blizzard API.</source>
-      </trans-unit>
-      <trans-unit id="admin.items.mutationError" datatype="html">
-        <source>Item request failed.</source>
-      </trans-unit>
-      <trans-unit id="admin.items.create.englishRequired" datatype="html">
-        <source>English (US) or English (GB) name is required.</source>
-      </trans-unit>
-      <trans-unit id="admin.items.table.id" datatype="html">
-        <source>Item ID</source>
-      </trans-unit>
-      <trans-unit id="admin.items.unnamed" datatype="html">
-        <source>Unnamed item</source>
-      </trans-unit>
-      <trans-unit id="admin.items.table.name" datatype="html">
-        <source>Name</source>
-      </trans-unit>
-      <trans-unit id="admin.items.table.quality" datatype="html">
-        <source>Quality</source>
-      </trans-unit>
-      <trans-unit id="admin.items.table.class" datatype="html">
-        <source>Class</source>
-      </trans-unit>
-      <trans-unit id="admin.items.table.expansion" datatype="html">
-        <source>Expansion</source>
-      </trans-unit>
-      <trans-unit id="admin.items.table.state" datatype="html">
-        <source>State</source>
-      </trans-unit>
-      <trans-unit id="admin.items.table.actions" datatype="html">
-        <source>Actions</source>
-      </trans-unit>
-      <trans-unit id="admin.items.filter.anyOverride" datatype="html">
-        <source>All override states</source>
-      </trans-unit>
-      <trans-unit id="admin.items.filter.hasOverride" datatype="html">
-        <source>Has override</source>
-      </trans-unit>
-      <trans-unit id="admin.items.filter.noOverride" datatype="html">
-        <source>No override</source>
-      </trans-unit>
-      <trans-unit id="admin.items.panel.create" datatype="html">
-        <source>Create manual item</source>
-      </trans-unit>
-      <trans-unit id="admin.items.panel.compare" datatype="html">
-        <source>Compare Blizzard API</source>
-      </trans-unit>
-      <trans-unit id="admin.items.panel.edit" datatype="html">
-        <source>Edit item override</source>
-      </trans-unit>
-      <trans-unit id="admin.items.deleteConfirm" datatype="html">
-        <source>Delete this item override? Base item data will be inherited again.</source>
-      </trans-unit>
-      <trans-unit id="admin.items.form.classSubclassRequired" datatype="html">
-        <source>Class ID and subclass ID are required together.</source>
       </trans-unit>
     </body>
   </file>

--- a/frontend/src/locale/messages.xlf
+++ b/frontend/src/locale/messages.xlf
@@ -1801,6 +1801,72 @@
           <context context-type="linenumber">78</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="route.admin.items" datatype="html">
+        <source>Items</source>
+      </trans-unit>
+      <trans-unit id="admin.items.loadError" datatype="html">
+        <source>Unable to load items.</source>
+      </trans-unit>
+      <trans-unit id="admin.items.detailError" datatype="html">
+        <source>Unable to load item details.</source>
+      </trans-unit>
+      <trans-unit id="admin.items.compareError" datatype="html">
+        <source>Unable to compare item with Blizzard API.</source>
+      </trans-unit>
+      <trans-unit id="admin.items.mutationError" datatype="html">
+        <source>Item request failed.</source>
+      </trans-unit>
+      <trans-unit id="admin.items.create.englishRequired" datatype="html">
+        <source>English (US) or English (GB) name is required.</source>
+      </trans-unit>
+      <trans-unit id="admin.items.table.id" datatype="html">
+        <source>Item ID</source>
+      </trans-unit>
+      <trans-unit id="admin.items.unnamed" datatype="html">
+        <source>Unnamed item</source>
+      </trans-unit>
+      <trans-unit id="admin.items.table.name" datatype="html">
+        <source>Name</source>
+      </trans-unit>
+      <trans-unit id="admin.items.table.quality" datatype="html">
+        <source>Quality</source>
+      </trans-unit>
+      <trans-unit id="admin.items.table.class" datatype="html">
+        <source>Class</source>
+      </trans-unit>
+      <trans-unit id="admin.items.table.expansion" datatype="html">
+        <source>Expansion</source>
+      </trans-unit>
+      <trans-unit id="admin.items.table.state" datatype="html">
+        <source>State</source>
+      </trans-unit>
+      <trans-unit id="admin.items.table.actions" datatype="html">
+        <source>Actions</source>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anyOverride" datatype="html">
+        <source>All override states</source>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.hasOverride" datatype="html">
+        <source>Has override</source>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.noOverride" datatype="html">
+        <source>No override</source>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.create" datatype="html">
+        <source>Create manual item</source>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.compare" datatype="html">
+        <source>Compare Blizzard API</source>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.edit" datatype="html">
+        <source>Edit item override</source>
+      </trans-unit>
+      <trans-unit id="admin.items.deleteConfirm" datatype="html">
+        <source>Delete this item override? Base item data will be inherited again.</source>
+      </trans-unit>
+      <trans-unit id="admin.items.form.classSubclassRequired" datatype="html">
+        <source>Class ID and subclass ID are required together.</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/frontend/src/locale/messages.zh.xlf
+++ b/frontend/src/locale/messages.zh.xlf
@@ -1770,6 +1770,23 @@
         <source>No override</source>
         <target>No override</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.filter.anyRecipe" datatype="html">
+        <source>All recipe states</source>
+        <target>All recipe states</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.hasRecipe" datatype="html">
+        <source>Has recipe</source>
+        <target>Has recipe</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.noRecipe" datatype="html">
+        <source>No recipe</source>
+        <target>No recipe</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anyExpansion" datatype="html">
+        <source>All expansions</source>
+        <target>All expansions</target>
+      </trans-unit>
       <trans-unit id="admin.items.panel.create" datatype="html">
         <source>Create manual item</source>
         <target>Create manual item</target>

--- a/frontend/src/locale/messages.zh.xlf
+++ b/frontend/src/locale/messages.zh.xlf
@@ -1702,6 +1702,94 @@
           <context context-type="linenumber">78</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="route.admin.items" datatype="html">
+        <source>Items</source>
+        <target>Items</target>
+      </trans-unit>
+      <trans-unit id="admin.items.loadError" datatype="html">
+        <source>Unable to load items.</source>
+        <target>Unable to load items.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.detailError" datatype="html">
+        <source>Unable to load item details.</source>
+        <target>Unable to load item details.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.compareError" datatype="html">
+        <source>Unable to compare item with Blizzard API.</source>
+        <target>Unable to compare item with Blizzard API.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.mutationError" datatype="html">
+        <source>Item request failed.</source>
+        <target>Item request failed.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.create.englishRequired" datatype="html">
+        <source>English (US) or English (GB) name is required.</source>
+        <target>English (US) or English (GB) name is required.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.id" datatype="html">
+        <source>Item ID</source>
+        <target>Item ID</target>
+      </trans-unit>
+      <trans-unit id="admin.items.unnamed" datatype="html">
+        <source>Unnamed item</source>
+        <target>Unnamed item</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.name" datatype="html">
+        <source>Name</source>
+        <target>Name</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.quality" datatype="html">
+        <source>Quality</source>
+        <target>Quality</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.class" datatype="html">
+        <source>Class</source>
+        <target>Class</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.expansion" datatype="html">
+        <source>Expansion</source>
+        <target>Expansion</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.state" datatype="html">
+        <source>State</source>
+        <target>State</target>
+      </trans-unit>
+      <trans-unit id="admin.items.table.actions" datatype="html">
+        <source>Actions</source>
+        <target>Actions</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anyOverride" datatype="html">
+        <source>All override states</source>
+        <target>All override states</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.hasOverride" datatype="html">
+        <source>Has override</source>
+        <target>Has override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.noOverride" datatype="html">
+        <source>No override</source>
+        <target>No override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.create" datatype="html">
+        <source>Create manual item</source>
+        <target>Create manual item</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.compare" datatype="html">
+        <source>Compare Blizzard API</source>
+        <target>Compare Blizzard API</target>
+      </trans-unit>
+      <trans-unit id="admin.items.panel.edit" datatype="html">
+        <source>Edit item override</source>
+        <target>Edit item override</target>
+      </trans-unit>
+      <trans-unit id="admin.items.deleteConfirm" datatype="html">
+        <source>Delete this item override? Base item data will be inherited again.</source>
+        <target>Delete this item override? Base item data will be inherited again.</target>
+      </trans-unit>
+      <trans-unit id="admin.items.form.classSubclassRequired" datatype="html">
+        <source>Class ID and subclass ID are required together.</source>
+        <target>Class ID and subclass ID are required together.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/frontend/src/locale/messages.zh.xlf
+++ b/frontend/src/locale/messages.zh.xlf
@@ -1722,6 +1722,11 @@
         <source>Item request failed.</source>
         <target>Item request failed.</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.recipeSearchError" datatype="html">
+        <source>Unable to search recipes.</source>
+        <target>Unable to search recipes.</target>
+      </trans-unit>
       <trans-unit id="admin.items.create.englishRequired" datatype="html">
         <source>English (US) or English (GB) name is required.</source>
         <target>English (US) or English (GB) name is required.</target>
@@ -1787,6 +1792,15 @@
         <source>All expansions</source>
         <target>All expansions</target>
       </trans-unit>
+
+      <trans-unit id="admin.items.filter.anyClass" datatype="html">
+        <source>All classes</source>
+        <target>All classes</target>
+      </trans-unit>
+      <trans-unit id="admin.items.filter.anySubclass" datatype="html">
+        <source>All subclasses</source>
+        <target>All subclasses</target>
+      </trans-unit>
       <trans-unit id="admin.items.panel.create" datatype="html">
         <source>Create manual item</source>
         <target>Create manual item</target>
@@ -1798,6 +1812,11 @@
       <trans-unit id="admin.items.panel.edit" datatype="html">
         <source>Edit item override</source>
         <target>Edit item override</target>
+      </trans-unit>
+
+      <trans-unit id="admin.items.panel.recipe" datatype="html">
+        <source>Associate recipe</source>
+        <target>Associate recipe</target>
       </trans-unit>
       <trans-unit id="admin.items.deleteConfirm" datatype="html">
         <source>Delete this item override? Base item data will be inherited again.</source>

--- a/openapi/components/schemas/admin/admin-item-bulk-override-request.yml
+++ b/openapi/components/schemas/admin/admin-item-bulk-override-request.yml
@@ -1,0 +1,9 @@
+type: object
+required: [overrides]
+properties:
+  overrides:
+    type: array
+    minItems: 1
+    maxItems: 100
+    items:
+      $ref: "../../../openapi.yml#/components/schemas/AdminItemBulkOverride"

--- a/openapi/components/schemas/admin/admin-item-bulk-override.yml
+++ b/openapi/components/schemas/admin/admin-item-bulk-override.yml
@@ -1,0 +1,7 @@
+type: object
+required: [id, override]
+properties:
+  id:
+    type: integer
+  override:
+    $ref: "../../../openapi.yml#/components/schemas/AdminItemOverrideRequest"

--- a/openapi/components/schemas/admin/admin-item-compare-field.yml
+++ b/openapi/components/schemas/admin/admin-item-compare-field.yml
@@ -1,0 +1,10 @@
+type: object
+properties:
+  base:
+    nullable: true
+  override:
+    nullable: true
+  api:
+    nullable: true
+  effective:
+    nullable: true

--- a/openapi/components/schemas/admin/admin-item-compare-response.yml
+++ b/openapi/components/schemas/admin/admin-item-compare-response.yml
@@ -1,0 +1,9 @@
+type: object
+required: [itemId, fields]
+properties:
+  itemId:
+    type: integer
+  fields:
+    type: object
+    additionalProperties:
+      $ref: "../../../openapi.yml#/components/schemas/AdminItemCompareField"

--- a/openapi/components/schemas/admin/admin-item-create-request.yml
+++ b/openapi/components/schemas/admin/admin-item-create-request.yml
@@ -1,0 +1,62 @@
+type: object
+required:
+  - id
+  - nameLocales
+  - qualityType
+  - level
+  - requiredLevel
+  - mediaUrl
+  - itemClassId
+  - itemSubclassId
+  - inventoryType
+  - purchasePrice
+  - sellPrice
+  - maxCount
+  - isEquippable
+  - isStackable
+  - purchaseQuantity
+properties:
+  id:
+    type: integer
+    minimum: 1
+  nameLocales:
+    $ref: "../../../openapi.yml#/components/schemas/GameLocale"
+  qualityType:
+    type: string
+  level:
+    type: integer
+  requiredLevel:
+    type: integer
+  mediaUrl:
+    type: string
+  mediaSourceUrl:
+    type: string
+    nullable: true
+  itemClassId:
+    type: integer
+  itemSubclassId:
+    type: integer
+  inventoryType:
+    type: string
+  bindingType:
+    type: string
+    nullable: true
+  purchasePrice:
+    type: integer
+  sellPrice:
+    type: integer
+  maxCount:
+    type: integer
+  isEquippable:
+    type: boolean
+  isStackable:
+    type: boolean
+  purchaseQuantity:
+    type: integer
+  expansionId:
+    type: integer
+    nullable: true
+  overrideNote:
+    type: string
+    nullable: true
+    maxLength: 512

--- a/openapi/components/schemas/admin/admin-item-fields.yml
+++ b/openapi/components/schemas/admin/admin-item-fields.yml
@@ -1,0 +1,62 @@
+type: object
+properties:
+  id:
+    type: integer
+  name:
+    type: string
+    nullable: true
+  nameLocales:
+    $ref: "../../../openapi.yml#/components/schemas/GameLocale"
+  quality:
+    $ref: "../../../openapi.yml#/components/schemas/AdminItemReference"
+  level:
+    type: integer
+    nullable: true
+  requiredLevel:
+    type: integer
+    nullable: true
+  mediaUrl:
+    type: string
+    nullable: true
+  mediaSourceUrl:
+    type: string
+    nullable: true
+  itemClass:
+    $ref: "../../../openapi.yml#/components/schemas/AdminItemReference"
+  itemSubclass:
+    $ref: "../../../openapi.yml#/components/schemas/AdminItemReference"
+  inventoryType:
+    $ref: "../../../openapi.yml#/components/schemas/AdminItemReference"
+  binding:
+    $ref: "../../../openapi.yml#/components/schemas/AdminItemReference"
+  purchasePrice:
+    type: integer
+    nullable: true
+  sellPrice:
+    type: integer
+    nullable: true
+  maxCount:
+    type: integer
+    nullable: true
+  isEquippable:
+    type: boolean
+    nullable: true
+  isStackable:
+    type: boolean
+    nullable: true
+  purchaseQuantity:
+    type: integer
+    nullable: true
+  expansion:
+    $ref: "../../../openapi.yml#/components/schemas/AdminExpansion"
+  overrideNote:
+    type: string
+    nullable: true
+  createdAt:
+    type: string
+    format: date-time
+    nullable: true
+  updatedAt:
+    type: string
+    format: date-time
+    nullable: true

--- a/openapi/components/schemas/admin/admin-item-fields.yml
+++ b/openapi/components/schemas/admin/admin-item-fields.yml
@@ -49,6 +49,11 @@ properties:
     nullable: true
   expansion:
     $ref: "../../../openapi.yml#/components/schemas/AdminExpansion"
+  recipes:
+    type: array
+    items:
+      $ref: "../../../openapi.yml#/components/schemas/AdminItemRecipe"
+    default: []
   overrideNote:
     type: string
     nullable: true

--- a/openapi/components/schemas/admin/admin-item-override-request.yml
+++ b/openapi/components/schemas/admin/admin-item-override-request.yml
@@ -1,0 +1,56 @@
+type: object
+properties:
+  nameLocales:
+    $ref: "../../../openapi.yml#/components/schemas/GameLocale"
+  qualityType:
+    type: string
+    nullable: true
+  level:
+    type: integer
+    nullable: true
+  requiredLevel:
+    type: integer
+    nullable: true
+  mediaUrl:
+    type: string
+    nullable: true
+  mediaSourceUrl:
+    type: string
+    nullable: true
+  itemClassId:
+    type: integer
+    nullable: true
+  itemSubclassId:
+    type: integer
+    nullable: true
+  inventoryType:
+    type: string
+    nullable: true
+  bindingType:
+    type: string
+    nullable: true
+  purchasePrice:
+    type: integer
+    nullable: true
+  sellPrice:
+    type: integer
+    nullable: true
+  maxCount:
+    type: integer
+    nullable: true
+  isEquippable:
+    type: boolean
+    nullable: true
+  isStackable:
+    type: boolean
+    nullable: true
+  purchaseQuantity:
+    type: integer
+    nullable: true
+  expansionId:
+    type: integer
+    nullable: true
+  overrideNote:
+    type: string
+    nullable: true
+    maxLength: 512

--- a/openapi/components/schemas/admin/admin-item-page.yml
+++ b/openapi/components/schemas/admin/admin-item-page.yml
@@ -1,0 +1,9 @@
+type: object
+required: [items, page]
+properties:
+  items:
+    type: array
+    items:
+      $ref: "../../../openapi.yml#/components/schemas/AdminItem"
+  page:
+    $ref: "../../../openapi.yml#/components/schemas/PageMetadata"

--- a/openapi/components/schemas/admin/admin-item-recipe.yml
+++ b/openapi/components/schemas/admin/admin-item-recipe.yml
@@ -1,0 +1,9 @@
+type: object
+required: [recipeId, name, professionName]
+properties:
+    recipeId:
+        type: integer
+    name:
+        type: string
+    professionName:
+        type: string

--- a/openapi/components/schemas/admin/admin-item-reference.yml
+++ b/openapi/components/schemas/admin/admin-item-reference.yml
@@ -1,0 +1,12 @@
+type: object
+required: [id, name]
+properties:
+  id:
+    type: integer
+    format: int64
+  type:
+    type: string
+    nullable: true
+  name:
+    type: string
+    nullable: true

--- a/openapi/components/schemas/admin/admin-item.yml
+++ b/openapi/components/schemas/admin/admin-item.yml
@@ -1,0 +1,15 @@
+type: object
+required: [id, hasBase, hasOverride, effective]
+properties:
+  id:
+    type: integer
+  hasBase:
+    type: boolean
+  hasOverride:
+    type: boolean
+  effective:
+    $ref: "../../../openapi.yml#/components/schemas/AdminItemFields"
+  base:
+    $ref: "../../../openapi.yml#/components/schemas/AdminItemFields"
+  override:
+    $ref: "../../../openapi.yml#/components/schemas/AdminItemFields"

--- a/openapi/components/schemas/admin/admin-recipe-association-request.yml
+++ b/openapi/components/schemas/admin/admin-recipe-association-request.yml
@@ -1,0 +1,11 @@
+type: object
+properties:
+    craftedItemId:
+        type: integer
+        nullable: true
+        description: Item id to set as recipe.crafted_item_id. Null clears the association.
+    craftedQuantity:
+        type: integer
+        minimum: 1
+        nullable: true
+        description: Quantity produced by the recipe. Required when craftedItemId is set.

--- a/openapi/components/schemas/admin/admin-recipe-search-result.yml
+++ b/openapi/components/schemas/admin/admin-recipe-search-result.yml
@@ -1,0 +1,27 @@
+type: object
+required:
+    - recipeId
+    - name
+    - professionName
+    - skillTierName
+    - professionCategoryName
+properties:
+    recipeId:
+        type: integer
+    name:
+        type: string
+    professionName:
+        type: string
+    skillTierName:
+        type: string
+    professionCategoryName:
+        type: string
+    craftedItemId:
+        type: integer
+        nullable: true
+    craftedItemName:
+        type: string
+        nullable: true
+    craftedQuantity:
+        type: integer
+        nullable: true

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -126,6 +126,8 @@ components:
       $ref: ./components/schemas/admin/admin-item-page.yml
     AdminItemReference:
       $ref: ./components/schemas/admin/admin-item-reference.yml
+    AdminItemRecipe:
+      $ref: ./components/schemas/admin/admin-item-recipe.yml
     AdminItemOverrideRequest:
       $ref: ./components/schemas/admin/admin-item-override-request.yml
     AuctionHouseStatus:

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -44,6 +44,16 @@ paths:
     $ref: ./paths/admin.yml#/fetchMissingExpansionRangeItems
   /admin/jobs/{id}:
     $ref: ./paths/admin.yml#/getAdminJob
+  /admin/items:
+    $ref: ./paths/admin.yml#/adminItems
+  /admin/items/{id}:
+    $ref: ./paths/admin.yml#/adminItemById
+  /admin/items/{id}/override:
+    $ref: ./paths/admin.yml#/adminItemOverride
+  /admin/items/{id}/compare-api:
+    $ref: ./paths/admin.yml#/adminItemCompareApi
+  /admin/items/bulk-overrides:
+    $ref: ./paths/admin.yml#/adminItemBulkOverrides
   /realms:
     $ref: ./paths/realm.yml#/listRealms
   /realms/{region}/{slug}:
@@ -98,6 +108,26 @@ components:
       $ref: ./components/schemas/admin/admin-expansion-item-range-request.yml
     AdminJob:
       $ref: ./components/schemas/admin/admin-job.yml
+    AdminItem:
+      $ref: ./components/schemas/admin/admin-item.yml
+    AdminItemBulkOverride:
+      $ref: ./components/schemas/admin/admin-item-bulk-override.yml
+    AdminItemBulkOverrideRequest:
+      $ref: ./components/schemas/admin/admin-item-bulk-override-request.yml
+    AdminItemCompareField:
+      $ref: ./components/schemas/admin/admin-item-compare-field.yml
+    AdminItemCompareResponse:
+      $ref: ./components/schemas/admin/admin-item-compare-response.yml
+    AdminItemCreateRequest:
+      $ref: ./components/schemas/admin/admin-item-create-request.yml
+    AdminItemFields:
+      $ref: ./components/schemas/admin/admin-item-fields.yml
+    AdminItemPage:
+      $ref: ./components/schemas/admin/admin-item-page.yml
+    AdminItemReference:
+      $ref: ./components/schemas/admin/admin-item-reference.yml
+    AdminItemOverrideRequest:
+      $ref: ./components/schemas/admin/admin-item-override-request.yml
     AuctionHouseStatus:
       $ref: ./components/schemas/auction-house-status.yml
     AuctionListingKey:

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -50,10 +50,14 @@ paths:
     $ref: ./paths/admin.yml#/adminItemById
   /admin/items/{id}/override:
     $ref: ./paths/admin.yml#/adminItemOverride
+  /admin/items/{id}/recipes/{recipeId}:
+    $ref: ./paths/admin.yml#/adminItemRecipeAssociation
   /admin/items/{id}/compare-api:
     $ref: ./paths/admin.yml#/adminItemCompareApi
   /admin/items/bulk-overrides:
     $ref: ./paths/admin.yml#/adminItemBulkOverrides
+  /admin/recipes:
+    $ref: ./paths/admin.yml#/adminRecipes
   /realms:
     $ref: ./paths/realm.yml#/listRealms
   /realms/{region}/{slug}:
@@ -128,6 +132,10 @@ components:
       $ref: ./components/schemas/admin/admin-item-reference.yml
     AdminItemRecipe:
       $ref: ./components/schemas/admin/admin-item-recipe.yml
+    AdminRecipeAssociationRequest:
+      $ref: ./components/schemas/admin/admin-recipe-association-request.yml
+    AdminRecipeSearchResult:
+      $ref: ./components/schemas/admin/admin-recipe-search-result.yml
     AdminItemOverrideRequest:
       $ref: ./components/schemas/admin/admin-item-override-request.yml
     AuctionHouseStatus:

--- a/openapi/paths/admin.yml
+++ b/openapi/paths/admin.yml
@@ -461,6 +461,40 @@ adminItemOverride:
                 description: Override deleted
             "404":
                 description: Override not found
+adminItemRecipeAssociation:
+    put:
+        tags:
+            - Admin
+        operationId: upsertAdminItemRecipeAssociation
+        summary: Associates a recipe with an item by updating recipe crafted output fields
+        parameters:
+            - name: id
+              in: path
+              required: true
+              schema:
+                  type: integer
+            - name: recipeId
+              in: path
+              required: true
+              schema:
+                  type: integer
+        requestBody:
+            required: true
+            content:
+                application/json:
+                    schema:
+                        $ref: "../openapi.yml#/components/schemas/AdminRecipeAssociationRequest"
+        responses:
+            "200":
+                description: Updated admin item
+                content:
+                    application/json:
+                        schema:
+                            $ref: "../openapi.yml#/components/schemas/AdminItem"
+            "400":
+                description: Invalid recipe association
+            "404":
+                description: Item or recipe not found
 adminItemCompareApi:
     post:
         tags:
@@ -507,3 +541,41 @@ adminItemBulkOverrides:
                 description: Invalid bulk override request
             "404":
                 description: One or more base items were not found
+adminRecipes:
+    get:
+        tags:
+            - Admin
+        operationId: searchAdminRecipes
+        summary: Searches recipes for admin item association
+        parameters:
+            - name: query
+              in: query
+              required: false
+              schema:
+                  type: string
+              description: Optional search text matched against recipe id and localized recipe names.
+            - name: locale
+              in: query
+              required: false
+              schema:
+                  type: string
+              description: Optional locale override for resolved labels.
+            - name: limit
+              in: query
+              required: false
+              schema:
+                  type: integer
+                  minimum: 1
+                  maximum: 50
+                  default: 20
+        responses:
+            "200":
+                description: Matching recipes
+                content:
+                    application/json:
+                        schema:
+                            type: array
+                            items:
+                                $ref: "../openapi.yml#/components/schemas/AdminRecipeSearchResult"
+            "400":
+                description: Invalid search request

--- a/openapi/paths/admin.yml
+++ b/openapi/paths/admin.yml
@@ -298,3 +298,212 @@ getAdminJob:
                             $ref: "../openapi.yml#/components/schemas/AdminJob"
             "404":
                 description: Job not found
+adminItems:
+    get:
+        tags:
+            - Admin
+        operationId: searchAdminItems
+        summary: Searches effective item rows for admin editing
+        parameters:
+            - name: query
+              in: query
+              required: false
+              schema:
+                  type: string
+              description: Optional search text matched against item id and localized names.
+            - name: locale
+              in: query
+              required: false
+              schema:
+                  type: string
+              description: Optional locale override for resolved labels.
+            - name: hasBase
+              in: query
+              required: false
+              schema:
+                  type: boolean
+              description: Filter to items with or without a Blizzard/base row.
+            - name: hasOverride
+              in: query
+              required: false
+              schema:
+                  type: boolean
+              description: Filter to items with or without an admin override row.
+            - name: page
+              in: query
+              required: false
+              schema:
+                  type: integer
+                  minimum: 1
+                  default: 1
+            - name: pageSize
+              in: query
+              required: false
+              schema:
+                  type: integer
+                  minimum: 1
+                  maximum: 100
+                  default: 25
+        responses:
+            "200":
+                description: Paginated admin items
+                content:
+                    application/json:
+                        schema:
+                            $ref: "../openapi.yml#/components/schemas/AdminItemPage"
+            "400":
+                description: Invalid search or pagination request
+    post:
+        tags:
+            - Admin
+        operationId: createAdminItem
+        summary: Creates an override-only manual item
+        requestBody:
+            required: true
+            content:
+                application/json:
+                    schema:
+                        $ref: "../openapi.yml#/components/schemas/AdminItemCreateRequest"
+        responses:
+            "200":
+                description: Created admin item
+                content:
+                    application/json:
+                        schema:
+                            $ref: "../openapi.yml#/components/schemas/AdminItem"
+            "400":
+                description: Invalid item
+            "409":
+                description: Item already has a base or override row
+adminItemById:
+    get:
+        tags:
+            - Admin
+        operationId: getAdminItem
+        summary: Gets an effective admin item row
+        parameters:
+            - name: id
+              in: path
+              required: true
+              schema:
+                  type: integer
+            - name: locale
+              in: query
+              required: false
+              schema:
+                  type: string
+              description: Optional locale override for resolved labels.
+            - name: includeBase
+              in: query
+              required: false
+              schema:
+                  type: boolean
+                  default: false
+              description: Include raw Blizzard/base row fields when present.
+            - name: includeOverride
+              in: query
+              required: false
+              schema:
+                  type: boolean
+                  default: false
+              description: Include raw sparse override row fields when present.
+        responses:
+            "200":
+                description: Admin item
+                content:
+                    application/json:
+                        schema:
+                            $ref: "../openapi.yml#/components/schemas/AdminItem"
+            "404":
+                description: Item not found
+adminItemOverride:
+    put:
+        tags:
+            - Admin
+        operationId: upsertAdminItemOverride
+        summary: Upserts a sparse admin override for an existing item
+        parameters:
+            - name: id
+              in: path
+              required: true
+              schema:
+                  type: integer
+        requestBody:
+            required: true
+            content:
+                application/json:
+                    schema:
+                        $ref: "../openapi.yml#/components/schemas/AdminItemOverrideRequest"
+        responses:
+            "200":
+                description: Updated admin item
+                content:
+                    application/json:
+                        schema:
+                            $ref: "../openapi.yml#/components/schemas/AdminItem"
+            "400":
+                description: Invalid override
+            "404":
+                description: Base item not found
+    delete:
+        tags:
+            - Admin
+        operationId: deleteAdminItemOverride
+        summary: Deletes the sparse admin override row
+        parameters:
+            - name: id
+              in: path
+              required: true
+              schema:
+                  type: integer
+        responses:
+            "204":
+                description: Override deleted
+            "404":
+                description: Override not found
+adminItemCompareApi:
+    post:
+        tags:
+            - Admin
+        operationId: compareAdminItemWithApi
+        summary: Fetches the Blizzard API item and compares it to base, override, and effective fields
+        parameters:
+            - name: id
+              in: path
+              required: true
+              schema:
+                  type: integer
+        responses:
+            "200":
+                description: Item API comparison
+                content:
+                    application/json:
+                        schema:
+                            $ref: "../openapi.yml#/components/schemas/AdminItemCompareResponse"
+            "404":
+                description: Item not found locally or in Blizzard API
+adminItemBulkOverrides:
+    put:
+        tags:
+            - Admin
+        operationId: bulkUpsertAdminItemOverrides
+        summary: Upserts sparse admin overrides in bulk
+        requestBody:
+            required: true
+            content:
+                application/json:
+                    schema:
+                        $ref: "../openapi.yml#/components/schemas/AdminItemBulkOverrideRequest"
+        responses:
+            "200":
+                description: Updated admin items
+                content:
+                    application/json:
+                        schema:
+                            type: array
+                            items:
+                                $ref: "../openapi.yml#/components/schemas/AdminItem"
+            "400":
+                description: Invalid bulk override request
+            "404":
+                description: One or more base items were not found

--- a/openapi/paths/admin.yml
+++ b/openapi/paths/admin.yml
@@ -341,6 +341,18 @@ adminItems:
               schema:
                   type: integer
               description: Filter to an item subclass id within the selected/effective class.
+            - name: expansionId
+              in: query
+              required: false
+              schema:
+                  type: integer
+              description: Filter to an expansion id.
+            - name: hasRecipe
+              in: query
+              required: false
+              schema:
+                  type: boolean
+              description: Filter to items with or without an associated crafting recipe.
             - name: page
               in: query
               required: false

--- a/openapi/paths/admin.yml
+++ b/openapi/paths/admin.yml
@@ -329,6 +329,18 @@ adminItems:
               schema:
                   type: boolean
               description: Filter to items with or without an admin override row.
+            - name: itemClassId
+              in: query
+              required: false
+              schema:
+                  type: integer
+              description: Filter to an item class id.
+            - name: itemSubclassId
+              in: query
+              required: false
+              schema:
+                  type: integer
+              description: Filter to an item subclass id within the selected/effective class.
             - name: page
               in: query
               required: false


### PR DESCRIPTION
## Summary

Delivers the admin item override system from #58: sparse overrides on the shared `item` table, effective reads through `v_item`, a full `/admin/items` management UI, Blizzard API compare, recipe association, and class/subclass search filters.

Closes #58

## Type
- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Docs

## Details

- **Database:** `V16__item_overrides.sql` adds `is_override`, audit columns, and composite PK `(id, is_override)`; `R__create_v_item.sql` merges base + override rows; market detail view reads from `v_item`.
- **Backend:** `AdminItemRepository`, `AdminItemService`, and OpenAPI admin endpoints for search, CRUD overrides, manual item create, Blizzard compare, bulk override, recipe search/association.
- **Read-path migration:** auction market search and item detail repositories use `v_item`; Blizzard sync always writes `is_override = FALSE`.
- **Frontend:** `/admin/items` page with server-side filters/pagination, sparse override/create forms, compare panel, recipe association slide-over, i18n strings, and class/subclass filter dropdowns.
- **Search fix:** class/subclass filters use game `subclass_id` values (matching market search); search no longer 400s when a subclass row is missing from the reference table.

## Checklist
- [x] Acceptance criteria met
- [x] Tests added/updated
- [ ] Docs updated (README/ADR/architecture)
- [x] Security/SEO implications considered

## Test plan
- [ ] Open `/en/admin/items` as admin; search, paginate, and filter by override state, class, and subclass (including Consumable class id `0`).
- [ ] Edit an item override with sparse fields; confirm effective values appear in market search/detail.
- [ ] Compare an item with Blizzard API and apply selected fields to the override.
- [ ] Associate a recipe with a crafted item from the item slide-over panel.
- [ ] Create a manual override-only item and verify it appears in search results.
- [ ] Run backend `AdminItemServiceTest` and frontend admin item filter/service specs.

## Links
- Related issue(s): #54 (parent admin UI epic — item correction slice)